### PR TITLE
Make capacity command show worker state

### DIFF
--- a/core/common/src/main/java/alluxio/master/WorkerState.java
+++ b/core/common/src/main/java/alluxio/master/WorkerState.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.master.block.meta;
+package alluxio.master;
 
 /***
  * The worker state maintained by master.

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -51,7 +51,7 @@ import alluxio.master.CoreMaster;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.block.meta.MasterWorkerInfo;
 import alluxio.master.block.meta.WorkerMetaLockSection;
-import alluxio.master.block.meta.WorkerState;
+import alluxio.master.WorkerState;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.SingleEntryJournaled;
 import alluxio.master.journal.checkpoint.CheckpointName;

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -49,9 +49,9 @@ import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.heartbeat.HeartbeatThread;
 import alluxio.master.CoreMaster;
 import alluxio.master.CoreMasterContext;
+import alluxio.master.WorkerState;
 import alluxio.master.block.meta.MasterWorkerInfo;
 import alluxio.master.block.meta.WorkerMetaLockSection;
-import alluxio.master.WorkerState;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.SingleEntryJournaled;
 import alluxio.master.journal.checkpoint.CheckpointName;
@@ -794,7 +794,8 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     for (MasterWorkerInfo worker : selectedLiveWorkers) {
       // extractWorkerInfo handles the locking internally
       if (mRejectWorkers.contains(worker.getWorkerAddress())) {
-        workerInfoList.add(extractWorkerInfo(worker, options.getFieldRange(), WorkerState.DISABLED));
+        workerInfoList.add(extractWorkerInfo(worker, options.getFieldRange(),
+            WorkerState.DISABLED));
       } else {
         workerInfoList.add(extractWorkerInfo(worker, options.getFieldRange(), WorkerState.LIVE));
       }
@@ -802,7 +803,8 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     for (MasterWorkerInfo worker : selectedLostWorkers) {
       // extractWorkerInfo handles the locking internally
       if (mRejectWorkers.contains(worker.getWorkerAddress())) {
-        workerInfoList.add(extractWorkerInfo(worker, options.getFieldRange(), WorkerState.DISABLED));
+        workerInfoList.add(extractWorkerInfo(worker, options.getFieldRange(),
+            WorkerState.DISABLED));
       } else {
         workerInfoList.add(extractWorkerInfo(worker, options.getFieldRange(), WorkerState.LOST));
       }

--- a/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -17,6 +17,7 @@ import alluxio.client.block.options.GetWorkerReportOptions;
 import alluxio.client.block.options.GetWorkerReportOptions.WorkerInfoField;
 import alluxio.grpc.BuildVersion;
 import alluxio.grpc.StorageList;
+import alluxio.master.WorkerState;
 import alluxio.master.block.DefaultBlockMaster;
 import alluxio.resource.LockResource;
 import alluxio.util.CommonUtils;

--- a/core/server/master/src/main/java/alluxio/master/block/meta/WorkerState.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/WorkerState.java
@@ -15,9 +15,10 @@ package alluxio.master.block.meta;
  * The worker state maintained by master.
  */
 public enum WorkerState {
-  LIVE("In Service"),
-  LOST("Out of Service"),
-  DECOMMISSIONED("Decommissioned");
+  LIVE("ACTIVE"),
+  LOST("LOST"),
+  DECOMMISSIONED("Decommissioned"),
+  DISABLED("Disabled");
   private final String mState;
 
   WorkerState(String s) {

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -42,8 +42,8 @@ import alluxio.master.AlwaysPrimaryPrimarySelector;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
+import alluxio.master.WorkerState;
 import alluxio.master.block.meta.MasterWorkerInfo;
-import alluxio.master.block.meta.WorkerState;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.noop.NoopJournalSystem;
 import alluxio.master.metrics.MetricsMaster;
@@ -113,7 +113,6 @@ public class BlockMasterTest {
   private MasterRegistry mRegistry;
   private ManualClock mClock;
   private ExecutorService mExecutorService;
-  private ExecutorService mClientExecutorService;
   private MetricsMaster mMetricsMaster;
   private List<Metric> mMetrics;
 

--- a/core/server/master/src/test/java/alluxio/master/block/meta/MasterWorkerInfoTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/meta/MasterWorkerInfoTest.java
@@ -19,6 +19,7 @@ import alluxio.Constants;
 import alluxio.DefaultStorageTierAssoc;
 import alluxio.StorageTierAssoc;
 import alluxio.client.block.options.GetWorkerReportOptions;
+import alluxio.master.WorkerState;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
@@ -142,7 +143,7 @@ public final class MasterWorkerInfoTest {
         WorkerState.LIVE);
     assertEquals(mInfo.getId(), workerInfo.getId());
     assertEquals(mInfo.getWorkerAddress(), workerInfo.getAddress());
-    assertEquals("In Service", workerInfo.getState());
+    assertEquals(WorkerState.LIVE.toString(), workerInfo.getState());
     assertEquals(mInfo.getCapacityBytes(), workerInfo.getCapacityBytes());
     assertEquals(mInfo.getUsedBytes(), workerInfo.getUsedBytes());
     assertEquals(mInfo.getStartTime(), workerInfo.getStartTimeMs());

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/CapacityCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/CapacityCommand.java
@@ -301,6 +301,7 @@ public class CapacityCommand {
     if (mCapacityTierInfoMap.size() == 0) {
       return;
     } else if (mCapacityTierInfoMap.size() == 1) {
+      // TODO(jiacheng): test BOTH long and short output
       // Do not print Total value when only one tier exists
       printShortWorkerInfo(workerInfoList);
       return;
@@ -309,7 +310,7 @@ public class CapacityCommand {
     String tiersInfo = String.format(Strings.repeat("%-14s", tiers.size()), tiers.toArray());
     String longInfoFormat = getInfoFormat(workerInfoList, false);
     print(String.format("%n" + longInfoFormat,
-        "Worker Name", "Last Heartbeat", "Storage", "Total", tiersInfo, "Version", "Revision"));
+        "Worker Name", "State", "Last Heartbeat", "Storage", "Total", tiersInfo, "Version", "Revision"));
 
     for (WorkerInfo info : workerInfoList) {
       String workerName = info.getAddress().getHost();
@@ -326,10 +327,11 @@ public class CapacityCommand {
       String capacityTierInfo = getWorkerFormattedTierValues(mCapacityTierInfoMap, workerName);
       String usedTierInfo = getWorkerFormattedTierValues(mUsedTierInfoMap, workerName);
 
-      print(String.format(longInfoFormat, workerName, info.getLastContactSec(), "capacity",
+      print(String.format(longInfoFormat, workerName, info.getState(),
+          info.getLastContactSec(), "capacity",
           FormatUtils.getSizeFromBytes(capacityBytes), capacityTierInfo,
           info.getVersion(), info.getRevision()));
-      print(String.format(longInfoFormat, "", "", "used",
+      print(String.format(longInfoFormat, "", "", "", "used",
           FormatUtils.getSizeFromBytes(usedBytes) + usedPercentageInfo, usedTierInfo,
           "", ""));
     }
@@ -344,7 +346,7 @@ public class CapacityCommand {
     String tier = String.format("%-16s", mCapacityTierInfoMap.firstKey());
     String shortInfoFormat = getInfoFormat(workerInfoList, true);
     print(String.format("%n" + shortInfoFormat,
-        "Worker Name", "Last Heartbeat", "Storage", tier, "Version", "Revision"));
+        "Worker Name", "State", "Last Heartbeat", "Storage", tier, "Version", "Revision"));
 
     for (WorkerInfo info : workerInfoList) {
       long capacityBytes = info.getCapacityBytes();
@@ -355,11 +357,11 @@ public class CapacityCommand {
         int usedPercentage = (int) (100L * usedBytes / capacityBytes);
         usedPercentageInfo = String.format(" (%s%%)", usedPercentage);
       }
-      print(String.format(shortInfoFormat, info.getAddress().getHost(),
+      print(String.format(shortInfoFormat, info.getAddress().getHost(), info.getState(),
           info.getLastContactSec(), "capacity",
           String.format("%-16s", FormatUtils.getSizeFromBytes(capacityBytes)),
           info.getVersion(), info.getRevision()));
-      print(String.format(shortInfoFormat, "", "", "used",
+      print(String.format(shortInfoFormat, "", "", "", "used",
           String.format("%-16s", FormatUtils.getSizeFromBytes(usedBytes) + usedPercentageInfo),
           "", ""));
     }
@@ -380,9 +382,9 @@ public class CapacityCommand {
       firstIndent = maxWorkerNameLength + 5;
     }
     if (isShort) {
-      return "%-" + firstIndent + "s %-16s %-13s %s %-16s %-40s";
+      return "%-" + firstIndent + "s %-15s %-16s %-13s %s %-16s %-40s";
     }
-    return "%-" + firstIndent + "s %-16s %-13s %-16s %s %-16s %-40s";
+    return "%-" + firstIndent + "s %-15s %-16s %-13s %-16s %s %-16s %-40s";
   }
 
   /**

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/CapacityCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/CapacityCommand.java
@@ -310,7 +310,8 @@ public class CapacityCommand {
     String tiersInfo = String.format(Strings.repeat("%-14s", tiers.size()), tiers.toArray());
     String longInfoFormat = getInfoFormat(workerInfoList, false);
     print(String.format("%n" + longInfoFormat,
-        "Worker Name", "State", "Last Heartbeat", "Storage", "Total", tiersInfo, "Version", "Revision"));
+        "Worker Name", "State", "Last Heartbeat", "Storage", "Total", tiersInfo,
+        "Version", "Revision"));
 
     for (WorkerInfo info : workerInfoList) {
       String workerName = info.getAddress().getHost();

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/CapacityCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/CapacityCommandTest.java
@@ -73,11 +73,11 @@ public class CapacityCommandTest {
           "    Used Percentage: 34%",
           "    Free Percentage: 66%",
           "",
-          "Worker Name      Last Heartbeat   Storage       Total            MEM           SSD           HDD           DOM           RAM            Version          Revision                                ",
-          "216.239.33.96    542              capacity      18.63GB          4768.37MB     4768.37MB     -             9.31GB        -              2.10.0-SNAPSHOT  0123456789abcdef0123456789abcdef01234567",
-          "                                  used          953.67MB (5%)    190.73MB      286.10MB      -             476.84MB      -                                                                       ",
-          "64.68.90.1       3123             capacity      11.18GB          3814.70MB     -             1907.35MB     -             5.59GB         2.9.3            0123456789012345678901234567890123456789",
-          "                                  used          9.31GB (83%)     2861.02MB     -             1907.35MB     -             4768.37MB                                                               ");
+          "Worker Name      State           Last Heartbeat   Storage       Total            MEM           SSD           HDD           DOM           RAM            Version          Revision                                ",
+          "216.239.33.96    ACTIVE          542              capacity      18.63GB          4768.37MB     4768.37MB     -             9.31GB        -              2.10.0-SNAPSHOT  0123456789abcdef0123456789abcdef01234567",
+          "                                                  used          953.67MB (5%)    190.73MB      286.10MB      -             476.84MB      -                                                                       ",
+          "64.68.90.1       ACTIVE          3123             capacity      11.18GB          3814.70MB     -             1907.35MB     -             5.59GB         2.9.3            0123456789012345678901234567890123456789",
+          "                                                  used          9.31GB (83%)     2861.02MB     -             1907.35MB     -             4768.37MB                                                               ");
       // CHECKSTYLE.ON: LineLengthExceed
       List<String> testOutput = Arrays.asList(output.split("\n"));
       Assert.assertThat(testOutput,
@@ -107,11 +107,11 @@ public class CapacityCommandTest {
           "    Used Percentage: 34%",
           "    Free Percentage: 66%",
           "",
-          "Worker Name      Last Heartbeat   Storage       RAM              Version          Revision                                ",
-          "215.42.95.24     953              capacity      9.31GB           2.2.4            000111222333444555666777888999aaabbbcccd",
-          "                                  used          476.84MB (5%)                                                             ",
-          "29.53.5.124      6424122          capacity      5.59GB           2.2.3            00112233445566778899aabbccddeeff00112233",
-          "                                  used          4768.37MB (83%)                                                           ");
+          "Worker Name      State           Last Heartbeat   Storage       RAM              Version          Revision                                ",
+          "215.42.95.24     ACTIVE          953              capacity      9.31GB           2.2.4            000111222333444555666777888999aaabbbcccd",
+          "                                                  used          476.84MB (5%)                                                             ",
+          "29.53.5.124      LOST            6424122          capacity      5.59GB           2.2.3            00112233445566778899aabbccddeeff00112233",
+          "                                                  used          4768.37MB (83%)                                                           ");
       List<String> testOutput = Arrays.asList(output.split("\n"));
       Assert.assertThat(testOutput,
           IsIterableContainingInOrder.contains(expectedOutput.toArray()));
@@ -145,11 +145,11 @@ public class CapacityCommandTest {
           "    Used Percentage: 34%",
           "    Free Percentage: 66%",
           "",
-          "Worker Name                 Last Heartbeat   Storage       Total            MEM           SSD           HDD            Version          Revision                                ",
-          "org.apache.hdp1             681              capacity      1907.35MB        572.20MB      572.20MB      -              2.10.0-rc1       abababababababababababababababababababab",
-          "                                             used          95.37MB (5%)     19.07MB       28.61MB       -                                                                       ",
-          "org.alluxio.long.host1      6211             capacity      1144.41MB        572.20MB      -             190.73MB       2.10.0-rc2       0101010101010101010101010101010101010101",
-          "                                             used          953.67MB (83%)   286.10MB      -             190.73MB                                                                ");
+          "Worker Name                 State           Last Heartbeat   Storage       Total            MEM           SSD           HDD            Version          Revision                                ",
+          "org.apache.hdp1             ACTIVE          681              capacity      1907.35MB        572.20MB      572.20MB      -              2.10.0-rc1       abababababababababababababababababababab",
+          "                                                             used          95.37MB (5%)     19.07MB       28.61MB       -                                                                       ",
+          "org.alluxio.long.host1      ACTIVE          6211             capacity      1144.41MB        572.20MB      -             190.73MB       2.10.0-rc2       0101010101010101010101010101010101010101",
+          "                                                             used          953.67MB (83%)   286.10MB      -             190.73MB                                                                ");
       // CHECKSTYLE.ON: LineLengthExceed
       List<String> testOutput = Arrays.asList(output.split("\n"));
 
@@ -178,7 +178,7 @@ public class CapacityCommandTest {
         .setId(1)
         .setLastContactSec(3123)
         .setStartTimeMs(1331231121212L)
-        .setState("In Service")
+        .setState("ACTIVE")
         .setUsedBytes(10000000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersOne)
         .setVersion("2.9.3")
@@ -199,7 +199,7 @@ public class CapacityCommandTest {
         .setId(2)
         .setLastContactSec(542)
         .setStartTimeMs(1131231121212L)
-        .setState("In Service")
+        .setState("ACTIVE")
         .setUsedBytes(1000000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersSec)
         .setVersion("2.10.0-SNAPSHOT")
@@ -226,7 +226,7 @@ public class CapacityCommandTest {
         .setId(1)
         .setLastContactSec(6424122)
         .setStartTimeMs(19365332L)
-        .setState("Out of Service")
+        .setState("LOST")
         .setUsedBytes(5000000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersOne)
         .setVersion("2.2.3")
@@ -243,7 +243,7 @@ public class CapacityCommandTest {
         .setId(2)
         .setLastContactSec(953)
         .setStartTimeMs(112495222L)
-        .setState("In Service")
+        .setState("ACTIVE")
         .setUsedBytes(500000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersSec)
         .setVersion("2.2.4")
@@ -272,7 +272,7 @@ public class CapacityCommandTest {
         .setId(1)
         .setLastContactSec(6211)
         .setStartTimeMs(1529222699127L)
-        .setState("In Service")
+        .setState("ACTIVE")
         .setUsedBytes(1000000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersOne)
         .setVersion("2.10.0-rc2")
@@ -291,7 +291,7 @@ public class CapacityCommandTest {
         .setId(2)
         .setLastContactSec(681)
         .setStartTimeMs(1529222699127L)
-        .setState("In Service")
+        .setState("ACTIVE")
         .setUsedBytes(100000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersSec)
         .setVersion("2.10.0-rc1")

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/CapacityCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/CapacityCommandTest.java
@@ -15,6 +15,7 @@ import alluxio.Constants;
 import alluxio.client.block.BlockMasterClient;
 import alluxio.client.block.options.GetWorkerReportOptions;
 import alluxio.conf.Configuration;
+import alluxio.master.WorkerState;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
@@ -178,7 +179,7 @@ public class CapacityCommandTest {
         .setId(1)
         .setLastContactSec(3123)
         .setStartTimeMs(1331231121212L)
-        .setState("ACTIVE")
+        .setState(WorkerState.LIVE.toString())
         .setUsedBytes(10000000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersOne)
         .setVersion("2.9.3")
@@ -199,7 +200,7 @@ public class CapacityCommandTest {
         .setId(2)
         .setLastContactSec(542)
         .setStartTimeMs(1131231121212L)
-        .setState("ACTIVE")
+        .setState(WorkerState.LIVE.toString())
         .setUsedBytes(1000000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersSec)
         .setVersion("2.10.0-SNAPSHOT")
@@ -226,7 +227,7 @@ public class CapacityCommandTest {
         .setId(1)
         .setLastContactSec(6424122)
         .setStartTimeMs(19365332L)
-        .setState("LOST")
+        .setState(WorkerState.LOST.toString())
         .setUsedBytes(5000000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersOne)
         .setVersion("2.2.3")
@@ -243,7 +244,7 @@ public class CapacityCommandTest {
         .setId(2)
         .setLastContactSec(953)
         .setStartTimeMs(112495222L)
-        .setState("ACTIVE")
+        .setState(WorkerState.LIVE.toString())
         .setUsedBytes(500000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersSec)
         .setVersion("2.2.4")
@@ -272,7 +273,7 @@ public class CapacityCommandTest {
         .setId(1)
         .setLastContactSec(6211)
         .setStartTimeMs(1529222699127L)
-        .setState("ACTIVE")
+        .setState(WorkerState.LIVE.toString())
         .setUsedBytes(1000000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersOne)
         .setVersion("2.10.0-rc2")
@@ -291,7 +292,7 @@ public class CapacityCommandTest {
         .setId(2)
         .setLastContactSec(681)
         .setStartTimeMs(1529222699127L)
-        .setState("ACTIVE")
+        .setState(WorkerState.LIVE.toString())
         .setUsedBytes(100000000L)
         .setUsedBytesOnTiers(usedBytesOnTiersSec)
         .setVersion("2.10.0-rc1")

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/CapacityCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/CapacityCommandIntegrationTest.java
@@ -39,7 +39,8 @@ public final class CapacityCommandIntegrationTest extends AbstractFsAdminShellTe
     Assert.assertEquals("    Free Percentage: 100%", lines[6]);
     Assert.assertEquals("", lines[7]);
     Assert.assertTrue(lines[8].matches(
-        "Worker Name {6,}Last Heartbeat {3}Storage {7}MEM {14}Version {10}Revision *"));
+        "Worker Name {6,}State {11,}Last Heartbeat {3}Storage {7}MEM {14}Version {10}Revision *"));
+    Assert.assertTrue(lines[9].contains("ACTIVE"));
     Assert.assertTrue(lines[9].contains("capacity      " + size));
     Assert.assertTrue(lines[10].contains("used          0B (0%)"));
   }
@@ -68,7 +69,8 @@ public final class CapacityCommandIntegrationTest extends AbstractFsAdminShellTe
     Assert.assertEquals("    Free Percentage: 100%", lines[6]);
     Assert.assertEquals("", lines[7]);
     Assert.assertTrue(lines[8].matches(
-        "Worker Name {6,}Last Heartbeat {3}Storage {7}MEM {14}Version {10}Revision *"));
+        "Worker Name {6,}State {11,}Last Heartbeat {3}Storage {7}MEM {14}Version {10}Revision *"));
+    Assert.assertTrue(lines[9].contains("ACTIVE"));
     Assert.assertTrue(lines[9].contains("capacity      " + size));
     Assert.assertTrue(lines[10].contains("used          0B (0%)"));
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

```
bin/alluxio fsadmin report capacity
Capacity information for all workers:
    Total Capacity: 10.67GB
        Tier: MEM  Size: 10.67GB
    Used Capacity: 0B
        Tier: MEM  Size: 0B
    Used Percentage: 0%
    Free Percentage: 100%
Format is short: true
Format is %-16s %-15s %-16s %-13s %s %-16s %-40s

Worker Name      State           Last Heartbeat   Storage       MEM              Version          Revision
192.168.3.8      ACTIVE           166              capacity      10.67GB          2.10.0-SNAPSHOT  ffcb706497bf47e43d5b2efc90f664c7a3e7014e
                                                  used          0B (0%)
```


### What changes are proposed in this pull request?

Please outline the changes and how this PR fixes the issue.

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
