### PR TITLE
Avoid null when using BlockMasterClientPool

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -719,11 +719,9 @@ public class FileSystemContext implements Closeable {
    */
   private List<WorkerNetAddress> getWorkerAddresses() throws IOException {
     List<WorkerInfo> infos;
-    BlockMasterClient blockMasterClient = mBlockMasterClientPool.acquire();
-    try {
-      infos = blockMasterClient.getWorkerInfoList();
-    } finally {
-      mBlockMasterClientPool.release(blockMasterClient);
+    try (CloseableResource<BlockMasterClient> masterClientResource =
+        acquireBlockMasterClientResource()) {
+      infos = masterClientResource.get().getWorkerInfoList();
     }
     if (infos.isEmpty()) {
       throw new UnavailableException(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());


### PR DESCRIPTION
### What changes are proposed in this pull request?
Avoid using mBlockMasterClientPool directly.

### Why are the changes needed?
Using mBlockMasterClientPool during reinit may throw an exception.

