### PR TITLE
Add more infomation for skip SudoMount

### DIFF
--- a/bin/alluxio-mount.sh
+++ b/bin/alluxio-mount.sh
@@ -212,7 +212,7 @@ function run_local() {
   init_env
 
   if [[ ${TIER_ALIAS} != "MEM" ]]; then
-    # the top tier is not MEM, skip
+    echo 'The top tier is not MEM, skip'
     exit 1
   fi
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Our `alluxio-site.properties` is:
```
alluxio.worker.tieredstore.levels=1
alluxio.worker.tieredstore.level0.alias=SSD
alluxio.worker.tieredstore.level0.dirs.path=/data2/alluxio,/data3/alluxio,/data4/alluxio
alluxio.worker.tieredstore.level0.dirs.mediumtype=SSD,SSD,SSD
alluxio.worker.tieredstore.level0.dirs.quota=2.5TB,2.5TB,2.5TB
```

![image](https://user-images.githubusercontent.com/45056332/234498861-1cb00bec-72ac-49b0-b273-39945cedbf51.png)


### Why are the changes needed?

When we need to scale up workers, we use the `bin/alluxio-mount.sh SudoMount` command. However, this command returns a status code of 1 without any prompt. Because the installation logic of our worker depends on the status code of each command, this will cause us to not know what happened.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs NO
  2. addition or removal of property keys NO
  3. webui NO
