### PR TITLE
Port changes of [#16618] to branch-2.8

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1127,26 +1127,10 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     worker.markAllBlocksToRemove();
     worker.updateUsage(mGlobalStorageTierAssoc, storageTiers,
         totalBytesOnTiers, usedBytesOnTiers);
-<<<<<<< HEAD
     processWorkerAddedBlocks(worker, currentBlocksOnLocation);
     processWorkerOrphanedBlocks(worker);
     worker.addLostStorage(lostStorage);
-    if (options.hasBuildVersion()) {
-      worker.setBuildVersion(options.getBuildVersion());
-    }
-||||||| parent of 952721773b (Fix stale buildVersion when downgrade workers)
-    processWorkerAddedBlocks(workerInfo, currentBlocksOnLocation);
-    processWorkerOrphanedBlocks(workerInfo);
-    workerInfo.addLostStorage(lostStorage);
-    if (options.hasBuildVersion()) {
-      workerInfo.setBuildVersion(options.getBuildVersion());
-    }
-=======
-    processWorkerAddedBlocks(workerInfo, currentBlocksOnLocation);
-    processWorkerOrphanedBlocks(workerInfo);
-    workerInfo.addLostStorage(lostStorage);
-    workerInfo.setBuildVersion(options.getBuildVersion());
->>>>>>> 952721773b (Fix stale buildVersion when downgrade workers)
+    worker.setBuildVersion(options.getBuildVersion());
 
     // TODO(jiacheng): This block can be moved to a non-locked section
     if (options.getConfigsCount() > 0) {

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1037,9 +1037,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       throw new NotFoundException(ExceptionMessage.NO_WORKER_FOUND.getMessage(workerId));
     }
 
-    if (options.hasBuildVersion()) {
-      worker.setBuildVersion(options.getBuildVersion());
-    }
+    worker.setBuildVersion(options.getBuildVersion());
 
     // Gather all blocks on this worker.
     int totalSize = currentBlocksOnLocation.values().stream().mapToInt(List::size).sum();
@@ -1129,12 +1127,26 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     worker.markAllBlocksToRemove();
     worker.updateUsage(mGlobalStorageTierAssoc, storageTiers,
         totalBytesOnTiers, usedBytesOnTiers);
+<<<<<<< HEAD
     processWorkerAddedBlocks(worker, currentBlocksOnLocation);
     processWorkerOrphanedBlocks(worker);
     worker.addLostStorage(lostStorage);
     if (options.hasBuildVersion()) {
       worker.setBuildVersion(options.getBuildVersion());
     }
+||||||| parent of 952721773b (Fix stale buildVersion when downgrade workers)
+    processWorkerAddedBlocks(workerInfo, currentBlocksOnLocation);
+    processWorkerOrphanedBlocks(workerInfo);
+    workerInfo.addLostStorage(lostStorage);
+    if (options.hasBuildVersion()) {
+      workerInfo.setBuildVersion(options.getBuildVersion());
+    }
+=======
+    processWorkerAddedBlocks(workerInfo, currentBlocksOnLocation);
+    processWorkerOrphanedBlocks(workerInfo);
+    workerInfo.addLostStorage(lostStorage);
+    workerInfo.setBuildVersion(options.getBuildVersion());
+>>>>>>> 952721773b (Fix stale buildVersion when downgrade workers)
 
     // TODO(jiacheng): This block can be moved to a non-locked section
     if (options.getConfigsCount() > 0) {

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -16,17 +16,7 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
 import alluxio.clock.ManualClock;
-<<<<<<< HEAD
-||||||| parent of 952721773b (Fix stale buildVersion when downgrade workers)
-import alluxio.conf.Configuration;
-import alluxio.conf.PropertyKey;
-import alluxio.exception.status.NotFoundException;
-=======
-import alluxio.conf.Configuration;
-import alluxio.conf.PropertyKey;
-import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.BuildVersion;
->>>>>>> 952721773b (Fix stale buildVersion when downgrade workers)
 import alluxio.grpc.Command;
 import alluxio.grpc.CommandType;
 import alluxio.grpc.RegisterWorkerPOptions;

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -16,6 +16,17 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
 import alluxio.clock.ManualClock;
+<<<<<<< HEAD
+||||||| parent of 952721773b (Fix stale buildVersion when downgrade workers)
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.status.NotFoundException;
+=======
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.status.NotFoundException;
+import alluxio.grpc.BuildVersion;
+>>>>>>> 952721773b (Fix stale buildVersion when downgrade workers)
 import alluxio.grpc.Command;
 import alluxio.grpc.CommandType;
 import alluxio.grpc.RegisterWorkerPOptions;
@@ -118,6 +129,40 @@ public class BlockMasterTest {
   @After
   public void after() throws Exception {
     mRegistry.stop();
+  }
+
+  @Test
+  public void buildVersion() throws Exception {
+    long worker1 = mBlockMaster.getWorkerId(NET_ADDRESS_1);
+
+    // Sequence to simulate worker upgrade and downgrade,
+    // with or without buildVersion in registerWorkerPOptions
+    BuildVersion[] buildVersions = new BuildVersion[]{
+        null,
+        BuildVersion.newBuilder().setVersion("1.0.0")
+            .setRevision("foobar").build(),
+        BuildVersion.newBuilder().setVersion("1.1.0")
+            .setRevision("fizzbuzz").build(),
+        null,
+    };
+
+    for (BuildVersion bv : buildVersions) {
+      RegisterWorkerPOptions options = (bv == null)
+          ? RegisterWorkerPOptions.getDefaultInstance()
+          : RegisterWorkerPOptions.newBuilder().setBuildVersion(bv).build();
+
+      mBlockMaster.workerRegister(worker1,
+          ImmutableList.of(Constants.MEDIUM_MEM),
+          ImmutableMap.of(Constants.MEDIUM_MEM, 100L),
+          ImmutableMap.of(Constants.MEDIUM_MEM, 10L),
+          NO_BLOCKS_ON_LOCATION,
+          NO_LOST_STORAGE,
+          options);
+
+      BuildVersion actual = mBlockMaster.getWorker(worker1).getBuildVersion();
+      assertEquals(bv == null ? "" : bv.getVersion(), actual.getVersion());
+      assertEquals(bv == null ? "" : bv.getRevision(), actual.getRevision());
+    }
   }
 
   @Test


### PR DESCRIPTION
Manual cherry pick of https://github.com/Alluxio/alluxio/pull/16618

What changes are proposed in this pull request?
Clear worker.buildVersion when it's not set in proto.

Note: Since we are using protobuf3 to compile proto2, it's OK to omit hasField check.
If the field is not set, the default instance will be returned.

Steps to reproduce:

Start a new cluster (master and worker).
Stop the new worker.
Start a old worker (prior to https://github.com/Alluxio/alluxio/commit/7d8ad9b12ab366ef85c05a7cedfa3a60a562de12) using the same config.
Check workers in web UI.
Why are the changes needed?
Previously, if we downgrade a worker to a versions prior to https://github.com/Alluxio/alluxio/commit/7d8ad9b12ab366ef85c05a7cedfa3a60a562de12,
the buildVersion is stale.

Does this PR introduce any user facing changes?
It fixes a bug in which the buildVersion could be stale.