### PR TITLE
Port changes of [#17170] to branch-2.8

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/policy/SpecificHostPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/SpecificHostPolicy.java
@@ -21,6 +21,13 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+<<<<<<< HEAD
+||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
+import java.util.Optional;
+=======
+import java.util.Optional;
+import javax.annotation.Nullable;
+>>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -30,6 +37,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class SpecificHostPolicy implements BlockLocationPolicy {
   private final String mHostname;
+  @Nullable
+  private final Integer mRpcPort;
 
   /**
    * Constructs a new {@link SpecificHostPolicy}.
@@ -37,7 +46,7 @@ public final class SpecificHostPolicy implements BlockLocationPolicy {
    * @param conf Alluxio configuration
    */
   public SpecificHostPolicy(AlluxioConfiguration conf) {
-    this(conf.getString(PropertyKey.WORKER_HOSTNAME));
+    this(conf.getString(PropertyKey.WORKER_HOSTNAME), conf.getInt(PropertyKey.WORKER_RPC_PORT));
   }
 
   /**
@@ -46,7 +55,18 @@ public final class SpecificHostPolicy implements BlockLocationPolicy {
    * @param hostname the name of the host
    */
   public SpecificHostPolicy(String hostname) {
+    this(hostname, null);
+  }
+
+  /**
+   * Constructs the policy with the hostname and port.
+   *
+   * @param hostname the name of the host
+   * @param rpcPort the rpc port
+   */
+  public SpecificHostPolicy(String hostname, @Nullable Integer rpcPort) {
     mHostname = Preconditions.checkNotNull(hostname, "hostname");
+    mRpcPort = rpcPort;
   }
 
   /**
@@ -57,8 +77,17 @@ public final class SpecificHostPolicy implements BlockLocationPolicy {
   public WorkerNetAddress getWorker(GetWorkerOptions options) {
     // find the first worker matching the host name
     for (BlockWorkerInfo info : options.getBlockWorkerInfos()) {
+<<<<<<< HEAD
       if (info.getNetAddress().getHost().equals(mHostname)) {
         return info.getNetAddress();
+||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
+      if (info.getNetAddress().getHost().equals(mHostname)) {
+        return Optional.of(info.getNetAddress());
+=======
+      if (info.getNetAddress().getHost().equals(mHostname)
+          && (mRpcPort == null || info.getNetAddress().getRpcPort() == mRpcPort)) {
+        return Optional.of(info.getNetAddress());
+>>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
       }
     }
     return null;

--- a/core/client/fs/src/main/java/alluxio/client/block/policy/SpecificHostPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/SpecificHostPolicy.java
@@ -21,13 +21,8 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
-<<<<<<< HEAD
-||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
-import java.util.Optional;
-=======
 import java.util.Optional;
 import javax.annotation.Nullable;
->>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -77,17 +72,9 @@ public final class SpecificHostPolicy implements BlockLocationPolicy {
   public WorkerNetAddress getWorker(GetWorkerOptions options) {
     // find the first worker matching the host name
     for (BlockWorkerInfo info : options.getBlockWorkerInfos()) {
-<<<<<<< HEAD
-      if (info.getNetAddress().getHost().equals(mHostname)) {
-        return info.getNetAddress();
-||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
-      if (info.getNetAddress().getHost().equals(mHostname)) {
-        return Optional.of(info.getNetAddress());
-=======
       if (info.getNetAddress().getHost().equals(mHostname)
           && (mRpcPort == null || info.getNetAddress().getRpcPort() == mRpcPort)) {
-        return Optional.of(info.getNetAddress());
->>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
+        return info.getNetAddress();
       }
     }
     return null;

--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -13,13 +13,7 @@ package alluxio.client.file.options;
 
 import alluxio.client.ReadType;
 import alluxio.client.block.policy.BlockLocationPolicy;
-<<<<<<< HEAD
-||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
-import alluxio.client.file.FileSystemContext;
-=======
 import alluxio.client.block.policy.SpecificHostPolicy;
-import alluxio.client.file.FileSystemContext;
->>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
@@ -80,20 +74,14 @@ public final class InStreamOptions {
 
     mStatus = status;
     mProtoOptions = openOptions;
-<<<<<<< HEAD
-    mUfsReadLocationPolicy = BlockLocationPolicy.Factory.create(
-        alluxioConf.getClass(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY), alluxioConf);
-||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
-    mUfsReadLocationPolicy = context.getReadBlockLocationPolicy(alluxioConf);
-=======
     if (options.hasUfsReadWorkerLocation()) {
       int port = options.getUfsReadWorkerLocation().getRpcPort();
       mUfsReadLocationPolicy = new SpecificHostPolicy(
           options.getUfsReadWorkerLocation().getHost(), port == 0 ? null : port);
     } else {
-      mUfsReadLocationPolicy = context.getReadBlockLocationPolicy(alluxioConf);
+      mUfsReadLocationPolicy = BlockLocationPolicy.Factory.create(
+          alluxioConf.getClass(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY), alluxioConf);
     }
->>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
     mPositionShort = false;
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -13,6 +13,13 @@ package alluxio.client.file.options;
 
 import alluxio.client.ReadType;
 import alluxio.client.block.policy.BlockLocationPolicy;
+<<<<<<< HEAD
+||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
+import alluxio.client.file.FileSystemContext;
+=======
+import alluxio.client.block.policy.SpecificHostPolicy;
+import alluxio.client.file.FileSystemContext;
+>>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
@@ -73,8 +80,20 @@ public final class InStreamOptions {
 
     mStatus = status;
     mProtoOptions = openOptions;
+<<<<<<< HEAD
     mUfsReadLocationPolicy = BlockLocationPolicy.Factory.create(
         alluxioConf.getClass(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY), alluxioConf);
+||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
+    mUfsReadLocationPolicy = context.getReadBlockLocationPolicy(alluxioConf);
+=======
+    if (options.hasUfsReadWorkerLocation()) {
+      int port = options.getUfsReadWorkerLocation().getRpcPort();
+      mUfsReadLocationPolicy = new SpecificHostPolicy(
+          options.getUfsReadWorkerLocation().getHost(), port == 0 ? null : port);
+    } else {
+      mUfsReadLocationPolicy = context.getReadBlockLocationPolicy(alluxioConf);
+    }
+>>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
     mPositionShort = false;
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/options/OutStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/OutStreamOptions.java
@@ -17,6 +17,13 @@ import alluxio.client.AlluxioStorageType;
 import alluxio.client.UnderStorageType;
 import alluxio.client.WriteType;
 import alluxio.client.block.policy.BlockLocationPolicy;
+<<<<<<< HEAD
+||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
+import alluxio.client.file.FileSystemContext;
+=======
+import alluxio.client.block.policy.SpecificHostPolicy;
+import alluxio.client.file.FileSystemContext;
+>>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.CreateFilePOptions;
@@ -112,12 +119,21 @@ public final class OutStreamOptions {
     if (options.hasWriteType()) {
       mWriteType = WriteType.fromProto(options.getWriteType());
     }
+<<<<<<< HEAD
     try {
       mLocationPolicy = BlockLocationPolicy.Factory.create(
           alluxioConf.getClass(PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY), alluxioConf);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
+=======
+    if (options.hasWorkerLocation()) {
+      int port = options.getWorkerLocation().getRpcPort();
+      mLocationPolicy = new SpecificHostPolicy(
+          options.getWorkerLocation().getHost(), port == 0 ? null : port);
+    }
+>>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
   }
 
   private OutStreamOptions(ClientContext context, AlluxioConfiguration alluxioConf) {

--- a/core/client/fs/src/main/java/alluxio/client/file/options/OutStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/OutStreamOptions.java
@@ -17,13 +17,7 @@ import alluxio.client.AlluxioStorageType;
 import alluxio.client.UnderStorageType;
 import alluxio.client.WriteType;
 import alluxio.client.block.policy.BlockLocationPolicy;
-<<<<<<< HEAD
-||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
-import alluxio.client.file.FileSystemContext;
-=======
 import alluxio.client.block.policy.SpecificHostPolicy;
-import alluxio.client.file.FileSystemContext;
->>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.CreateFilePOptions;
@@ -119,21 +113,18 @@ public final class OutStreamOptions {
     if (options.hasWriteType()) {
       mWriteType = WriteType.fromProto(options.getWriteType());
     }
-<<<<<<< HEAD
-    try {
-      mLocationPolicy = BlockLocationPolicy.Factory.create(
-          alluxioConf.getClass(PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY), alluxioConf);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
-=======
     if (options.hasWorkerLocation()) {
       int port = options.getWorkerLocation().getRpcPort();
       mLocationPolicy = new SpecificHostPolicy(
-          options.getWorkerLocation().getHost(), port == 0 ? null : port);
+              options.getWorkerLocation().getHost(), port == 0 ? null : port);
+    } else {
+      try {
+        mLocationPolicy = BlockLocationPolicy.Factory.create(
+                alluxioConf.getClass(PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY), alluxioConf);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
     }
->>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
   }
 
   private OutStreamOptions(ClientContext context, AlluxioConfiguration alluxioConf) {

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -94,6 +94,11 @@ message OpenFilePOptions {
   optional int32 maxUfsReadConcurrency = 2;
   optional FileSystemMasterCommonPOptions commonOptions = 3;
   optional bool updateLastAccessTime = 4 [default = true];
+  // If specified and the blocks are not cached in any worker,
+  // the data will be read and cached to the certain worker.
+  // If the blocks have been cached in some alluxio workers,
+  // this field will be ignored.
+  optional grpc.WorkerNetAddress ufsReadWorkerLocation = 15;
 }
 
 // XAttrPropagationStrategy controls the behaviour for assigning xAttr
@@ -137,6 +142,16 @@ message CreateFilePOptions {
   optional int64 persistenceWaitTime = 10;
   map<string, bytes> xattr = 11;
   optional XAttrPropagationStrategy xattrPropStrat = 12 [default = NEW_PATHS];
+<<<<<<< HEAD
+||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
+  optional bool overwrite = 13;
+  optional bool checkS3BucketPath = 14;
+=======
+  optional bool overwrite = 13;
+  optional bool checkS3BucketPath = 14;
+  // If specified, the data will be written to the certain worker
+  optional grpc.WorkerNetAddress workerLocation = 15;
+>>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 }
 message CreateFilePRequest {
   /** the path of the file */

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -142,16 +142,10 @@ message CreateFilePOptions {
   optional int64 persistenceWaitTime = 10;
   map<string, bytes> xattr = 11;
   optional XAttrPropagationStrategy xattrPropStrat = 12 [default = NEW_PATHS];
-<<<<<<< HEAD
-||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
-  optional bool overwrite = 13;
-  optional bool checkS3BucketPath = 14;
-=======
   optional bool overwrite = 13;
   optional bool checkS3BucketPath = 14;
   // If specified, the data will be written to the certain worker
   optional grpc.WorkerNetAddress workerLocation = 15;
->>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 }
 message CreateFilePRequest {
   /** the path of the file */

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -2071,6 +2071,11 @@
                     "value": "true"
                   }
                 ]
+              },
+              {
+                "id": 15,
+                "name": "ufsReadWorkerLocation",
+                "type": "grpc.WorkerNetAddress"
               }
             ]
           },
@@ -2216,6 +2221,35 @@
                     "value": "NEW_PATHS"
                   }
                 ]
+<<<<<<< HEAD
+||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
+              },
+              {
+                "id": 13,
+                "name": "overwrite",
+                "type": "bool"
+              },
+              {
+                "id": 14,
+                "name": "checkS3BucketPath",
+                "type": "bool"
+=======
+              },
+              {
+                "id": 13,
+                "name": "overwrite",
+                "type": "bool"
+              },
+              {
+                "id": 14,
+                "name": "checkS3BucketPath",
+                "type": "bool"
+              },
+              {
+                "id": 15,
+                "name": "workerLocation",
+                "type": "grpc.WorkerNetAddress"
+>>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
               }
             ],
             "maps": [

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -2221,19 +2221,6 @@
                     "value": "NEW_PATHS"
                   }
                 ]
-<<<<<<< HEAD
-||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
-              },
-              {
-                "id": 13,
-                "name": "overwrite",
-                "type": "bool"
-              },
-              {
-                "id": 14,
-                "name": "checkS3BucketPath",
-                "type": "bool"
-=======
               },
               {
                 "id": 13,
@@ -2249,7 +2236,6 @@
                 "id": 15,
                 "name": "workerLocation",
                 "type": "grpc.WorkerNetAddress"
->>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
               }
             ],
             "maps": [

--- a/shell/src/main/java/alluxio/cli/TestRunner.java
+++ b/shell/src/main/java/alluxio/cli/TestRunner.java
@@ -12,21 +12,38 @@
 package alluxio.cli;
 
 import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.annotation.SuppressFBWarnings;
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
+<<<<<<< HEAD
 import alluxio.conf.InstancedConfiguration;
+||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
+=======
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+>>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 import alluxio.grpc.DeletePOptions;
+<<<<<<< HEAD
 import alluxio.util.ConfigurationUtils;
+||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
+=======
+import alluxio.grpc.WorkerNetAddress;
+>>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 import alluxio.util.io.PathUtils;
 
+import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.internal.Lists;
+import com.google.common.base.Preconditions;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -63,6 +80,14 @@ public final class TestRunner {
       + "THROUGH, ASYNC_THROUGH. By default all writeTypes are tested.")
   private String mWriteType;
 
+  @Parameter(names = {"--workers", "--worker"},
+      description = "Alluxio worker addresses to run tests on. "
+          + "If not specified, random ones will be used.",
+      converter = WorkerAddressConverter.class)
+  @Nullable
+  @SuppressFBWarnings(value = "UWF_NULL_FIELD", justification = "Injected field")
+  private List<WorkerNetAddress> mWorkerAddresses = null;
+
   /**
    * The operation types to test.
    */
@@ -91,6 +116,7 @@ public final class TestRunner {
     TestRunner runner = new TestRunner();
     JCommander jCommander = new JCommander(runner, args);
     jCommander.setProgramName("TestRunner");
+    jCommander.parse(args);
     if (runner.mHelp) {
       jCommander.usage();
       return;
@@ -106,6 +132,10 @@ public final class TestRunner {
    * @return the number of failed tests
    */
   private int runTests() throws Exception {
+    if (mWorkerAddresses != null) {
+      Configuration.set(PropertyKey.USER_FILE_PASSIVE_CACHE_ENABLED, false);
+    }
+
     mDirectory = PathUtils.concatPath(mDirectory, TEST_DIRECTORY_NAME);
 
     AlluxioURI testDir = new AlluxioURI(mDirectory);
@@ -126,47 +156,126 @@ public final class TestRunner {
     List<OperationType> operations = mOperation == null ? Lists.newArrayList(OperationType.values())
         : Lists.newArrayList(OperationType.valueOf(mOperation));
 
-    for (ReadType readType : readTypes) {
-      for (WriteType writeType : writeTypes) {
-        for (OperationType opType : operations) {
-          System.out.println(String.format("runTest --operation %s --readType %s --writeType %s",
-                  opType, readType, writeType));
-          failed += runTest(opType, readType, writeType, fsContext);
+    if (mWorkerAddresses == null) {
+      for (ReadType readType : readTypes) {
+        for (WriteType writeType : writeTypes) {
+          for (OperationType opType : operations) {
+            System.out.println(String.format("runTest --operation %s --readType %s --writeType %s",
+                opType, readType, writeType));
+            failed += runTest(opType, readType, writeType, fsContext, null);
+          }
         }
       }
-    }
-    if (failed > 0) {
-      System.out.println("Number of failed tests: " + failed);
+      if (failed > 0) {
+        System.out.println("Number of failed tests: " + failed);
+      }
+    } else {
+      // If workers are specified, the test will iterate through all workers and
+      // for each worker:
+      // 1. Create a file
+      // 2. Write the blocks of test files into a specific worker using SpecificHostPolicy
+      // 3. Open the file to read
+      // 4. If blocks are cached on the worker (MUST_CACHE/CACHE_THROUGH/ASYNC_THROUGH),
+      //    then data will be read from that specific worker as there is only one copy of data.
+      //    If blocks are not cached on the worker (THROUGH),
+      //    then data will be loaded from UFS into that specific worker, by setting the
+      //    ufsReadWorkerLocation field InStreamOptions.
+      // In this way, we made sure that a worker works normally on both reads and writes.
+      HashMap<WorkerNetAddress, Integer> failedTestWorkers = new HashMap<>();
+      boolean hasFailedWorkers = false;
+      for (WorkerNetAddress workerNetAddress : mWorkerAddresses) {
+        System.out.println("Running test for worker:" + getWorkerAddressString(workerNetAddress));
+        for (ReadType readType : readTypes) {
+          for (WriteType writeType : writeTypes) {
+            for (OperationType opType : operations) {
+              System.out.printf("[%s] runTest --operation %s --readType %s --writeType %s%n",
+                  getWorkerAddressString(workerNetAddress), opType, readType, writeType);
+              failed += runTest(opType, readType, writeType, fsContext, workerNetAddress);
+              failedTestWorkers.put(
+                  workerNetAddress, failedTestWorkers.getOrDefault(workerNetAddress, 0) + failed);
+              if (failed != 0) {
+                hasFailedWorkers = true;
+              }
+            }
+          }
+        }
+      }
+      if (!hasFailedWorkers) {
+        System.out.println(
+            Constants.ANSI_GREEN + "All workers passed tests!" + Constants.ANSI_RESET);
+      } else {
+        System.out.println(
+            Constants.ANSI_RED + "Some workers failed tests!" + Constants.ANSI_RESET);
+        failedTestWorkers.forEach((k, v) -> {
+          if (v > 0) {
+            System.out.printf(
+                "%sWorker %s failed %s tests %s%n",
+                Constants.ANSI_RED, getWorkerAddressString(k), 4, Constants.ANSI_RESET);
+          }
+        });
+      }
     }
     return failed;
   }
 
-  /**
-   * Runs a single test given operation, read and write type.
-   *
-   * @param opType operation type
-   * @param readType read type
-   * @param writeType write type
-   * @return 0 on success, 1 on failure
-   */
-  private int runTest(OperationType opType, ReadType readType, WriteType writeType,
-      FileSystemContext fsContext) {
-    AlluxioURI filePath =
-        new AlluxioURI(String.format("%s/%s_%s_%s", mDirectory, opType, readType, writeType));
+    /**
+     * Runs a single test given operation, read and write type.
+     *
+     * @param opType operation type
+     * @param readType read type
+     * @param writeType write type
+     * @return 0 on success, 1 on failure
+     */
+  private int runTest(
+      OperationType opType, ReadType readType, WriteType writeType,
+      FileSystemContext fsContext, @Nullable WorkerNetAddress workerAddress) {
+    final AlluxioURI filePath;
+    if (workerAddress == null) {
+      filePath = new AlluxioURI(
+          String.format("%s/%s_%s_%s", mDirectory, opType, readType, writeType));
+    } else {
+      String workerAddressString = getWorkerAddressString(workerAddress);
+      filePath = new AlluxioURI(
+          String.format("%s/%s/%s_%s_%s", mDirectory, workerAddressString, opType, readType,
+              writeType));
+    }
 
     boolean result = true;
     switch (opType) {
       case BASIC:
         result = RunTestUtils.runExample(
-          new BasicOperations(filePath, readType, writeType, fsContext));
+          new BasicOperations(filePath, readType, writeType, fsContext, workerAddress));
         break;
       case BASIC_NON_BYTE_BUFFER:
         result = RunTestUtils.runExample(
-          new BasicNonByteBufferOperations(filePath, readType, writeType, true, 20, fsContext));
+          new BasicNonByteBufferOperations(
+              filePath, readType, writeType, true, 20, fsContext, workerAddress));
         break;
       default:
         System.out.println("Unrecognized operation type " + opType);
     }
     return result ? 0 : 1;
+  }
+
+  /**
+   * Parses worker address param.
+   */
+  public static class WorkerAddressConverter implements IStringConverter<WorkerNetAddress> {
+    @Override
+    public WorkerNetAddress convert(String s) {
+      if (s.contains(":")) {
+        String[] components = s.split(":");
+        Preconditions.checkState(components.length == 2);
+        return WorkerNetAddress.newBuilder().setHost(components[0])
+            .setRpcPort(Integer.parseInt(components[1])).build();
+      } else {
+        return WorkerNetAddress.newBuilder().setHost(s).build();
+      }
+    }
+  }
+
+  private String getWorkerAddressString(WorkerNetAddress workerAddress) {
+    return workerAddress.getRpcPort() == 0 ? workerAddress.getHost() :
+        workerAddress.getHost() + "_" + workerAddress.getRpcPort();
   }
 }

--- a/shell/src/main/java/alluxio/cli/TestRunner.java
+++ b/shell/src/main/java/alluxio/cli/TestRunner.java
@@ -18,20 +18,11 @@ import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
-<<<<<<< HEAD
 import alluxio.conf.InstancedConfiguration;
-||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
-=======
-import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
->>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 import alluxio.grpc.DeletePOptions;
-<<<<<<< HEAD
 import alluxio.util.ConfigurationUtils;
-||||||| parent of aee3c5cb96 (Support executing runTests on specific workers)
-=======
 import alluxio.grpc.WorkerNetAddress;
->>>>>>> aee3c5cb96 (Support executing runTests on specific workers)
 import alluxio.util.io.PathUtils;
 
 import com.beust.jcommander.IStringConverter;
@@ -116,7 +107,6 @@ public final class TestRunner {
     TestRunner runner = new TestRunner();
     JCommander jCommander = new JCommander(runner, args);
     jCommander.setProgramName("TestRunner");
-    jCommander.parse(args);
     if (runner.mHelp) {
       jCommander.usage();
       return;
@@ -132,15 +122,15 @@ public final class TestRunner {
    * @return the number of failed tests
    */
   private int runTests() throws Exception {
+    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
     if (mWorkerAddresses != null) {
-      Configuration.set(PropertyKey.USER_FILE_PASSIVE_CACHE_ENABLED, false);
+      conf.set(PropertyKey.USER_FILE_PASSIVE_CACHE_ENABLED, false);
     }
 
     mDirectory = PathUtils.concatPath(mDirectory, TEST_DIRECTORY_NAME);
 
     AlluxioURI testDir = new AlluxioURI(mDirectory);
-    FileSystemContext fsContext =
-        FileSystemContext.create(new InstancedConfiguration(ConfigurationUtils.defaults()));
+    FileSystemContext fsContext = FileSystemContext.create(conf);
     FileSystem fs =
         FileSystem.Factory.create(fsContext);
     if (fs.exists(testDir)) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support executing the runTests command on specific workers.
e.g. 

./alluxio runTests --workers worker1:29998,worker2:29998

If the workers are specified, runTests will be executed for each worker with writes and reads to go a dedicated worker.

<img width="1048" alt="Screen Shot 2023-03-30 at 3 45 20 PM" src="https://user-images.githubusercontent.com/6771554/228784580-99a066db-b325-4750-8e84-0a052c9eeb6c.png">
<img width="879" alt="Screen Shot 2023-03-30 at 3 46 44 PM" src="https://user-images.githubusercontent.com/6771554/228784598-680f076c-bdcc-4de3-b42b-47fa95d34add.png">


### Why are the changes needed?

So that we can verify if workers are up 

### Does this PR introduce any user facing changes?

N/A