### PR TITLE
Fix listStatus from ufs

### DIFF
--- a/core/common/src/main/java/alluxio/job/CopyJobRequest.java
+++ b/core/common/src/main/java/alluxio/job/CopyJobRequest.java
@@ -29,27 +29,17 @@ public class CopyJobRequest implements JobRequest {
   private final String mDst;
   private final CopyJobPOptions mOptions;
   private final String mSrc;
-  private final String mSrcUfsAddress;
-  private final String mDstUfsAddress;
 
   /**
    * @param src the source file path
    * @param dst the destination file path
-   * @param srcUfsAddress the source ufs path
-   * @param dstUfsAddress the destination ufs path
    * @param options copy job options
    **/
   public CopyJobRequest(@JsonProperty("src") String src,
       @JsonProperty("dst") String dst,
-      @JsonProperty("srcUfsAddress") String srcUfsAddress,
-      @JsonProperty("dstUfsAddress") String dstUfsAddress,
       @JsonProperty("copyJobPOptions") CopyJobPOptions options) {
     mSrc = Preconditions.checkNotNull(src, "The source path cannot be null");
     mDst = Preconditions.checkNotNull(dst, "The destination path cannot be null");
-    mSrcUfsAddress =
-        Preconditions.checkNotNull(srcUfsAddress, "The source ufs path cannot be null");
-    mDstUfsAddress =
-        Preconditions.checkNotNull(dstUfsAddress, "The source ufs path cannot be null");
     mOptions = Preconditions.checkNotNull(options, "The job options cannot be null");
   }
 
@@ -68,20 +58,6 @@ public class CopyJobRequest implements JobRequest {
   }
 
   /**
-   * @return the source ufs path
-   */
-  public String getSrcUfsAddress() {
-    return mSrcUfsAddress;
-  }
-
-  /**
-   * @return the destination ufs path
-   */
-  public String getDstUfsAddress() {
-    return mDstUfsAddress;
-  }
-
-  /**
    * @return job options
    */
   public CopyJobPOptions getOptions() {
@@ -94,8 +70,6 @@ public class CopyJobRequest implements JobRequest {
         .toStringHelper(this)
         .add("Src", mSrc)
         .add("Dst", mDst)
-        .add("SrcUfsAddress", mSrcUfsAddress)
-        .add("DstUfsAddress", mDstUfsAddress)
         .add("Options", mOptions)
         .toString();
   }

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -620,9 +620,9 @@ public interface UnderFileSystem extends Closeable {
    * abstract pathname, with options.
    *
    * <p>
-   * If this abstract pathname does not denote a directory, meaning it's a file, then this method
-   * would try to call getStatus on the path.
-   * Otherwise an array of statuses is returned, one for each file or directory. Names denoting the
+   * If this abstract pathname does not denote a directory, meaning it might be a file,
+   * then this method would try to call getStatus on the path.
+   * An array of statuses is returned, one for each file or directory. Names denoting the
    * directory itself and the directory's parent directory are not included in the result. Each
    * string is a path relative to the given directory.
    *
@@ -633,8 +633,10 @@ public interface UnderFileSystem extends Closeable {
    * @param path the abstract pathname to list
    * @param options for list directory
    * @return An array of statuses naming the files and directories in the directory denoted by this
-   *         abstract pathname. The array will be empty if the directory is empty. Returns
-   *         {@code Optional.empty()} if this abstract pathname does not denote a directory.
+   *         abstract pathname. The array will be empty if the directory is empty.
+   *         Or And array of single file if given path is a file.
+   *         Returns {@code Optional.empty()} if this abstract pathname does not denote a valid
+   *         directory or file not found.
    */
   default Optional<UfsStatus[]> listStatuses(String path, ListOptions options) throws IOException {
     UfsStatus[] statuses;
@@ -643,12 +645,11 @@ public interface UnderFileSystem extends Closeable {
       // If empty, the request path might be a regular file/object. Let's retry getStatus().
       try {
         UfsStatus status = getStatus(path);
-        // listStatus() expects relative name to the @path.
         status.setName("");
         statuses = new UfsStatus[1];
         statuses[0] = status;
       } catch (FileNotFoundException e) {
-        // statuses already bull
+        // statuses already null
       }
     }
     if (statuses == null) {

--- a/core/server/master/src/main/java/alluxio/master/job/CopyJob.java
+++ b/core/server/master/src/main/java/alluxio/master/job/CopyJob.java
@@ -264,8 +264,8 @@ public class CopyJob extends AbstractJob<CopyJob.CopyTask> {
   public boolean isHealthy() {
     long currentFailureCount = mCurrentFailureCount.get();
     return mState != JobState.FAILED
-        && currentFailureCount <= FAILURE_COUNT_THRESHOLD
-        || (double) currentFailureCount / mProcessedFileCount.get() <= FAILURE_RATIO_THRESHOLD;
+        && (currentFailureCount <= FAILURE_COUNT_THRESHOLD
+        || (double) currentFailureCount / mProcessedFileCount.get() <= FAILURE_RATIO_THRESHOLD);
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/job/CopyJob.java
+++ b/core/server/master/src/main/java/alluxio/master/job/CopyJob.java
@@ -14,7 +14,6 @@ package alluxio.master.job;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-import alluxio.client.WriteType;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
@@ -90,10 +89,6 @@ public class CopyJob extends AbstractJob<CopyJob.CopyTask> {
   private final String mSrc;
   private final String mDst;
   private final boolean mOverwrite;
-  private final WriteType mWriteType;
-  private final String mSrcUfsAddress;
-  private final String mDstUfsAddress;
-
   private OptionalLong mBandwidth;
   private boolean mUsePartialListing;
   private boolean mVerificationEnabled;
@@ -117,10 +112,7 @@ public class CopyJob extends AbstractJob<CopyJob.CopyTask> {
    *
    * @param src                 file source
    * @param dst                 file destination
-   * @param srcUfsAddress       source ufs address
-   * @param dstUfsAddress       destination ufs address
    * @param overwrite           whether to overwrite the file
-   * @param writeType           write type
    * @param user                user for authentication
    * @param jobId               job identifier
    * @param bandwidth           bandwidth
@@ -128,8 +120,7 @@ public class CopyJob extends AbstractJob<CopyJob.CopyTask> {
    * @param verificationEnabled whether to verify the job after loaded
    * @param fileIterable        file iterable
    */
-  public CopyJob(String src, String dst, String srcUfsAddress, String dstUfsAddress,
-      boolean overwrite, WriteType writeType, Optional<String> user, String jobId,
+  public CopyJob(String src, String dst, boolean overwrite, Optional<String> user, String jobId,
       OptionalLong bandwidth, boolean usePartialListing, boolean verificationEnabled,
       Iterable<FileInfo> fileIterable) {
     super(user, jobId);
@@ -145,9 +136,6 @@ public class CopyJob extends AbstractJob<CopyJob.CopyTask> {
     mState = JobState.RUNNING;
     mFileIterable = fileIterable;
     mOverwrite = overwrite;
-    mWriteType = writeType;
-    mSrcUfsAddress = srcUfsAddress;
-    mDstUfsAddress = dstUfsAddress;
   }
 
   /**
@@ -379,8 +367,7 @@ public class CopyJob extends AbstractJob<CopyJob.CopyTask> {
     }
     String dst = PathUtils.concatPath(mDst, relativePath);
     return Route.newBuilder().setSrc(sourceFile.getPath())
-                .setDst(dst).setSrcUfsAddress(mSrcUfsAddress)
-                .setDstUfsAddress(mDstUfsAddress).setLength(sourceFile.getLength()).build();
+                .setDst(dst).setLength(sourceFile.getLength()).build();
   }
 
   @Override
@@ -388,8 +375,6 @@ public class CopyJob extends AbstractJob<CopyJob.CopyTask> {
     return MoreObjects.toStringHelper(this)
         .add("Src", mSrc)
         .add("Dst", mDst)
-        .add("SrcUfsAddress", mSrcUfsAddress)
-        .add("DstUfsAddress", mDstUfsAddress)
         .add("User", mUser)
         .add("Bandwidth", mBandwidth)
         .add("UsePartialListing", mUsePartialListing)
@@ -412,8 +397,7 @@ public class CopyJob extends AbstractJob<CopyJob.CopyTask> {
   @Override
   public Journal.JournalEntry toJournalEntry() {
     alluxio.proto.journal.Job.CopyJobEntry.Builder jobEntry = alluxio.proto.journal.Job.CopyJobEntry
-        .newBuilder().setSrc(mSrc).setDst(mDst).setSrcUfsAddress(mSrcUfsAddress)
-                 .setDstUfsAddress(mDstUfsAddress).setState(JobState.toProto(mState))
+        .newBuilder().setSrc(mSrc).setDst(mDst).setState(JobState.toProto(mState))
         .setPartialListing(mUsePartialListing)
         .setVerify(mVerificationEnabled)
         .setJobId(mJobId);
@@ -537,7 +521,6 @@ public class CopyJob extends AbstractJob<CopyJob.CopyTask> {
       WriteOptions writeOptions = WriteOptions
           .newBuilder()
           .setOverwrite(mOverwrite)
-          .setWriteType(mWriteType.toProto())
           .build();
       return workerClient.copy(request
           .setUfsReadOptions(ufsReadOptions.build())

--- a/core/server/master/src/main/java/alluxio/master/job/CopyJobFactory.java
+++ b/core/server/master/src/main/java/alluxio/master/job/CopyJobFactory.java
@@ -11,6 +11,7 @@
 
 package alluxio.master.job;
 
+import alluxio.AlluxioURI;
 import alluxio.client.WriteType;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
@@ -49,6 +50,8 @@ public class CopyJobFactory implements JobFactory {
   public Job<?> create() {
     CopyJobPOptions options = mRequest.getOptions();
     String src = mRequest.getSrc();
+    String srcRoot = new AlluxioURI(src).getRootPath();
+    String dstRoot = new AlluxioURI(mRequest.getDst()).getRootPath();
     OptionalLong bandwidth =
         options.hasBandwidth() ? OptionalLong.of(options.getBandwidth()) : OptionalLong.empty();
     boolean partialListing = options.hasPartialListing() && options.getPartialListing();
@@ -58,12 +61,12 @@ public class CopyJobFactory implements JobFactory {
         Configuration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class);
     Iterable<FileInfo> fileIterator = new UfsFileIterable(mFs, src, Optional
         .ofNullable(AuthenticatedClientUser.getOrNull())
-        .map(User::getName), partialListing, FileInfo::isCompleted, mRequest.getSrcUfsAddress());
+        .map(User::getName), partialListing, FileInfo::isCompleted, srcRoot);
     Optional<String> user = Optional
         .ofNullable(AuthenticatedClientUser.getOrNull())
         .map(User::getName);
-    return new CopyJob(src, mRequest.getDst(), mRequest.getSrcUfsAddress(),
-        mRequest.getDstUfsAddress(), overwrite, writeType, user, UUID.randomUUID().toString(),
+    return new CopyJob(src, mRequest.getDst(), srcRoot,
+        dstRoot, overwrite, writeType, user, UUID.randomUUID().toString(),
         bandwidth, partialListing, verificationEnabled, fileIterator);
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/job/CopyJobFactory.java
+++ b/core/server/master/src/main/java/alluxio/master/job/CopyJobFactory.java
@@ -61,12 +61,11 @@ public class CopyJobFactory implements JobFactory {
         Configuration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class);
     Iterable<FileInfo> fileIterator = new UfsFileIterable(mFs, src, Optional
         .ofNullable(AuthenticatedClientUser.getOrNull())
-        .map(User::getName), partialListing, FileInfo::isCompleted, srcRoot);
+        .map(User::getName), partialListing, FileInfo::isCompleted);
     Optional<String> user = Optional
         .ofNullable(AuthenticatedClientUser.getOrNull())
         .map(User::getName);
-    return new CopyJob(src, mRequest.getDst(), srcRoot,
-        dstRoot, overwrite, writeType, user, UUID.randomUUID().toString(),
+    return new CopyJob(src, mRequest.getDst(), overwrite, user, UUID.randomUUID().toString(),
         bandwidth, partialListing, verificationEnabled, fileIterator);
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/job/JobFactoryProducer.java
+++ b/core/server/master/src/main/java/alluxio/master/job/JobFactoryProducer.java
@@ -11,6 +11,7 @@
 
 package alluxio.master.job;
 
+import alluxio.conf.Configuration;
 import alluxio.exception.runtime.AlluxioRuntimeException;
 import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
@@ -22,6 +23,7 @@ import alluxio.master.file.FileSystemMaster;
 import alluxio.proto.journal.Journal;
 import alluxio.scheduler.job.JobFactory;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.wire.MountPointInfo;
 
 import java.util.Map;
@@ -44,18 +46,9 @@ public class JobFactoryProducer {
     }
     if (request instanceof CopyJobRequest) {
       CopyJobRequest copyRequest = (CopyJobRequest) request;
-      Map<String, MountPointInfo> mountPointInfoSummary =
-          fsMaster.getMountPointInfoSummary(false);
-      UnderFileSystem ufsClient;
-      // no need to close under file system cause most close methods are noop
-      try {
-        ufsClient = fsMaster.getUfsManager()
-            .get(mountPointInfoSummary.get(copyRequest.getSrcUfsAddress()).getMountId())
-            .acquireUfsResource().get();
-      } catch (NotFoundException | UnavailableException e) {
-        throw AlluxioRuntimeException.from(e);
-      }
-      return new CopyJobFactory((CopyJobRequest) request, ufsClient);
+      UnderFileSystem ufs = UnderFileSystem.Factory.create(copyRequest.getSrc(),
+          UnderFileSystemConfiguration.defaults(Configuration.global()));
+      return new CopyJobFactory((CopyJobRequest) request, ufs);
     }
     throw new IllegalArgumentException("Unknown job type: " + request.getType());
   }

--- a/core/server/master/src/main/java/alluxio/master/job/JobFactoryProducer.java
+++ b/core/server/master/src/main/java/alluxio/master/job/JobFactoryProducer.java
@@ -12,9 +12,6 @@
 package alluxio.master.job;
 
 import alluxio.conf.Configuration;
-import alluxio.exception.runtime.AlluxioRuntimeException;
-import alluxio.exception.status.NotFoundException;
-import alluxio.exception.status.UnavailableException;
 import alluxio.job.CopyJobRequest;
 import alluxio.job.JobRequest;
 import alluxio.job.LoadJobRequest;
@@ -24,9 +21,6 @@ import alluxio.proto.journal.Journal;
 import alluxio.scheduler.job.JobFactory;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
-import alluxio.wire.MountPointInfo;
-
-import java.util.Map;
 
 /**
  * Producer for {@link JobFactory}.

--- a/core/server/master/src/main/java/alluxio/master/job/JournalCopyJobFactory.java
+++ b/core/server/master/src/main/java/alluxio/master/job/JournalCopyJobFactory.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.job;
 
-import alluxio.client.WriteType;
 import alluxio.scheduler.job.Job;
 import alluxio.scheduler.job.JobFactory;
 import alluxio.scheduler.job.JobState;
@@ -47,7 +46,7 @@ public class JournalCopyJobFactory implements JobFactory {
         mJobEntry.hasUser() ? Optional.of(mJobEntry.getUser()) : Optional.empty();
     Iterable<FileInfo> fileIterator =
         new UfsFileIterable(mFs, mJobEntry.getSrc(), user, mJobEntry.getPartialListing(),
-            FileInfo::isCompleted, mJobEntry.getSrcUfsAddress());
+            FileInfo::isCompleted);
     AbstractJob<?> job = getCopyJob(user, fileIterator);
     job.setJobState(JobState.fromProto(mJobEntry.getState()));
     if (mJobEntry.hasEndTime()) {
@@ -57,12 +56,12 @@ public class JournalCopyJobFactory implements JobFactory {
   }
 
   private CopyJob getCopyJob(Optional<String> user, Iterable<FileInfo> fileIterator) {
-    CopyJob job = new CopyJob(mJobEntry.getSrc(), mJobEntry.getDst(),
-        mJobEntry.getSrcUfsAddress(), mJobEntry.getDstUfsAddress(),
-        mJobEntry.getOverwrite(), WriteType.fromProto(mJobEntry.getWriteType()), user,
-        mJobEntry.getJobId(),
-        mJobEntry.hasBandwidth() ? OptionalLong.of(mJobEntry.getBandwidth()) : OptionalLong.empty(),
-        mJobEntry.getPartialListing(), mJobEntry.getVerify(), fileIterator);
+    CopyJob job =
+        new CopyJob(mJobEntry.getSrc(), mJobEntry.getDst(), mJobEntry.getOverwrite(), user,
+            mJobEntry.getJobId(),
+            mJobEntry.hasBandwidth() ? OptionalLong.of(mJobEntry.getBandwidth()) :
+                OptionalLong.empty(), mJobEntry.getPartialListing(), mJobEntry.getVerify(),
+            fileIterator);
     return job;
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/job/LoadJob.java
+++ b/core/server/master/src/main/java/alluxio/master/job/LoadJob.java
@@ -257,8 +257,8 @@ public class LoadJob extends AbstractJob<LoadJob.LoadTask> {
   public boolean isHealthy() {
     long currentFailureCount = mCurrentFailureCount.get();
     return mState != JobState.FAILED
-        && currentFailureCount <= FAILURE_COUNT_THRESHOLD
-        || (double) currentFailureCount / mCurrentBlockCount.get() <= FAILURE_RATIO_THRESHOLD;
+        && (currentFailureCount <= FAILURE_COUNT_THRESHOLD
+        || (double) currentFailureCount / mCurrentBlockCount.get() <= FAILURE_RATIO_THRESHOLD);
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/job/UfsFileIterable.java
+++ b/core/server/master/src/main/java/alluxio/master/job/UfsFileIterable.java
@@ -43,7 +43,6 @@ public class UfsFileIterable implements Iterable<FileInfo> {
   private final boolean mUsePartialListing;
   private final Predicate<FileInfo> mFilter;
   private final UnderFileSystem mFs;
-  private final String mRoot;
 
   /**
    * Creates a new instance of {@link FileIterable}.
@@ -53,16 +52,14 @@ public class UfsFileIterable implements Iterable<FileInfo> {
    * @param user              user to list as
    * @param usePartialListing whether to use partial listing
    * @param filter            filter to apply to the file infos
-   * @param root              ufs root path
    */
   public UfsFileIterable(UnderFileSystem fs, String path, Optional<String> user,
-      boolean usePartialListing, Predicate<FileInfo> filter, String root) {
+      boolean usePartialListing, Predicate<FileInfo> filter) {
     mFs = requireNonNull(fs, "fileSystem is null");
     mPath = requireNonNull(path, "path is null");
     mUser = requireNonNull(user, "user is null");
     mUsePartialListing = usePartialListing;
     mFilter = filter;
-    mRoot = root;
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/scheduler/JournaledJobMetaStore.java
+++ b/core/server/master/src/main/java/alluxio/master/scheduler/JournaledJobMetaStore.java
@@ -12,8 +12,8 @@
 package alluxio.master.scheduler;
 
 import alluxio.collections.ConcurrentHashSet;
+import alluxio.conf.Configuration;
 import alluxio.exception.runtime.UnavailableRuntimeException;
-import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.job.JobFactoryProducer;
@@ -26,13 +26,12 @@ import alluxio.scheduler.job.Job;
 import alluxio.scheduler.job.JobMetaStore;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystem;
-import alluxio.wire.MountPointInfo;
+import alluxio.underfs.UnderFileSystemConfiguration;
 
 import com.google.common.collect.Iterators;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -71,21 +70,9 @@ public class JournaledJobMetaStore implements JobMetaStore, Journaled {
       mExistingJobs.add(job);
     }
     if (entry.hasCopyJob()) {
-      Map<String, MountPointInfo> mountPointInfoSummary =
-          mFileSystemMaster.getMountPointInfoSummary(false);
-      UnderFileSystem ufsClient = null;
-      // no need to close under file system cause most close methods are noop
-      try {
-        ufsClient = mUfsManager
-            .get(mountPointInfoSummary.get(entry.getCopyJob().getSrcUfsAddress()).getMountId())
-            .acquireUfsResource().get();
-      } catch (NotFoundException | UnavailableException e) {
-        // should not happen in normal case, only happens when there's change in mount table during
-        // journal processing, but we should not fail the journal processing
-        LOG.warn("Failed to get ufs client for ufs address {}",
-            entry.getCopyJob().getSrcUfsAddress(), e);
-      }
-      Job<?> job = JobFactoryProducer.create(entry, ufsClient).create();
+      UnderFileSystem ufs = UnderFileSystem.Factory.create(entry.getCopyJob().getSrc(),
+          UnderFileSystemConfiguration.defaults(Configuration.global()));
+      Job<?> job = JobFactoryProducer.create(entry, ufs).create();
       mExistingJobs.add(job);
     }
     return true;

--- a/core/server/master/src/test/java/alluxio/master/file/scheduler/CopyJobTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/scheduler/CopyJobTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import alluxio.Constants;
-import alluxio.client.WriteType;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
@@ -55,7 +54,7 @@ public class CopyJobTest {
     Optional<String> user = Optional.of("user");
     FileIterable files =
         new FileIterable(fileSystemMaster, srcPath, user, false, CopyJob.QUALIFIED_FILE_FILTER);
-    CopyJob copy = new CopyJob(srcPath, dstPath, "/", "/", false, WriteType.NONE, user, "1",
+    CopyJob copy = new CopyJob(srcPath, dstPath, false, user, "1",
         OptionalLong.empty(), false, false, files);
     Optional<CopyJob.CopyTask> nextTask = copy.getNextTask(null);
     Assert.assertEquals(5, nextTask.get().getRoutes().size());
@@ -72,7 +71,7 @@ public class CopyJobTest {
     Optional<String> user = Optional.of("user");
     FileIterable files =
         new FileIterable(fileSystemMaster, srcPath, user, false, CopyJob.QUALIFIED_FILE_FILTER);
-    CopyJob copy = new CopyJob(srcPath, dstPath, "/", "/", false, WriteType.NONE, user, "1",
+    CopyJob copy = new CopyJob(srcPath, dstPath, false, user, "1",
         OptionalLong.empty(), false, false, files);
     List<Route> routes = copy.getNextRoutes(100);
     assertTrue(copy.isHealthy());
@@ -94,7 +93,7 @@ public class CopyJobTest {
     Optional<String> user = Optional.of("user");
     FileIterable files =
         new FileIterable(fileSystemMaster, srcPath, user, false, CopyJob.QUALIFIED_FILE_FILTER);
-    CopyJob job = spy(new CopyJob(srcPath, dstPath, "/", "/", false, WriteType.NONE, user, "1",
+    CopyJob job = spy(new CopyJob(srcPath, dstPath, false, user, "1",
         OptionalLong.empty(), false, false, files));
     when(job.getDurationInSec()).thenReturn(0L);
     job.setJobState(JobState.RUNNING);

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -573,10 +573,10 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
     for (Route route : routes) {
       FileSystem srcFs = FileSystem.Factory.create(fsContext,
           FileSystemOptions.create(Configuration.global(),
-              Optional.of(new UfsFileSystemOptions(route.getSrcUfsAddress()))));
+              Optional.of(new UfsFileSystemOptions(new AlluxioURI(route.getSrc()).getRootPath()))));
       FileSystem dstFs = FileSystem.Factory.create(fsContext,
           FileSystemOptions.create(Configuration.global(),
-              Optional.of(new UfsFileSystemOptions(route.getDstUfsAddress()))));
+              Optional.of(new UfsFileSystemOptions(new AlluxioURI(route.getDst()).getRootPath()))));
 
       ListenableFuture<Void> future = Futures.submit(() -> {
         try {

--- a/core/server/worker/src/main/java/alluxio/worker/task/CopyHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/task/CopyHandler.java
@@ -31,7 +31,6 @@ import alluxio.grpc.Route;
 import alluxio.grpc.WriteOptions;
 import alluxio.grpc.WritePType;
 import alluxio.underfs.Fingerprint;
-import alluxio.util.io.PathUtils;
 
 import io.grpc.Status;
 import org.apache.commons.io.IOUtils;
@@ -61,8 +60,8 @@ public final class CopyHandler {
   public static void copy(Route route, WriteOptions writeOptions,
       FileSystem srcFs, FileSystem dstFs) {
 
-    AlluxioURI src = new AlluxioURI(PathUtils.concatPath(route.getSrcUfsAddress(), route.getSrc()));
-    AlluxioURI dst = new AlluxioURI(PathUtils.concatPath(route.getDstUfsAddress(), route.getDst()));
+    AlluxioURI src = new AlluxioURI(route.getSrc());
+    AlluxioURI dst = new AlluxioURI(route.getDst());
     URIStatus dstStatus = null;
     URIStatus sourceStatus;
     try {

--- a/core/server/worker/src/test/java/alluxio/worker/dora/PagedDoraWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/dora/PagedDoraWorkerTest.java
@@ -31,7 +31,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -111,9 +110,8 @@ public class PagedDoraWorkerTest {
     byte[] buffer = BufferUtils.getIncreasingByteArray(length);
     BufferUtils.writeBufferToFile(a.getAbsolutePath(), buffer);
     Route route =
-        Route.newBuilder().setDst("/b").setSrc("/a").setDstUfsAddress(dstRoot.getAbsolutePath())
-             .setSrcUfsAddress(srcRoot.getAbsolutePath()).setLength(length).build();
-
+        Route.newBuilder().setDst(b.getAbsolutePath()).setSrc(a.getAbsolutePath()).setLength(length)
+             .build();
     WriteOptions writeOptions = WriteOptions.newBuilder().setOverwrite(false).build();
     UfsReadOptions read =
         UfsReadOptions.newBuilder().setUser("test").setTag("1").setPositionShort(false).build();
@@ -142,8 +140,8 @@ public class PagedDoraWorkerTest {
     byte[] buffer = BufferUtils.getIncreasingByteArray(length);
     BufferUtils.writeBufferToFile(a.getAbsolutePath(), buffer);
     Route route =
-        Route.newBuilder().setDst("/b").setSrc("/a").setDstUfsAddress(dstRoot.getAbsolutePath())
-             .setSrcUfsAddress(srcRoot.getAbsolutePath()).setLength(length).build();
+        Route.newBuilder().setDst(b.getAbsolutePath()).setSrc(a.getAbsolutePath()).setLength(length)
+             .build();
 
     WriteOptions writeOptions = WriteOptions.newBuilder().setOverwrite(false).build();
     ListenableFuture<List<RouteFailure>> copy =
@@ -162,8 +160,7 @@ public class PagedDoraWorkerTest {
     a.mkdirs();
     File b = new File(dstRoot, "b");
     Route route =
-        Route.newBuilder().setDst("/b").setSrc("/a").setDstUfsAddress(dstRoot.getAbsolutePath())
-             .setSrcUfsAddress(srcRoot.getAbsolutePath()).build();
+        Route.newBuilder().setDst(b.getAbsolutePath()).setSrc(a.getAbsolutePath()).build();
     WriteOptions writeOptions = WriteOptions.newBuilder().setOverwrite(false).build();
     UfsReadOptions read =
         UfsReadOptions.newBuilder().setUser("test").setTag("1").setPositionShort(false).build();
@@ -176,7 +173,6 @@ public class PagedDoraWorkerTest {
   }
 
   @Test
-  @Ignore
   public void testFolderWithFileCopy()
       throws IOException, ExecutionException, InterruptedException {
     File srcRoot = mTestFolder.newFolder("src");
@@ -189,19 +185,18 @@ public class PagedDoraWorkerTest {
     File d = new File(a, "d");
     d.mkdirs();
     File b = new File(dstRoot, "b");
+    File dstC = new File(b, "c");
+    File dstD = new File(b, "d");
     int length = 10;
     byte[] buffer = BufferUtils.getIncreasingByteArray(length);
     BufferUtils.writeBufferToFile(c.getAbsolutePath(), buffer);
     List<Route> routes = new ArrayList<>();
-    Route route =
-        Route.newBuilder().setDst("/b/c").setSrc("/a/c").setDstUfsAddress(dstRoot.getAbsolutePath())
-             .setSrcUfsAddress(srcRoot.getAbsolutePath()).setLength(length).build();
+    Route route = Route.newBuilder().setDst(dstC.getAbsolutePath()).setSrc(c.getAbsolutePath())
+                       .setLength(length).build();
     Route route2 =
-        Route.newBuilder().setDst("/b").setSrc("/a").setDstUfsAddress(dstRoot.getAbsolutePath())
-             .setSrcUfsAddress(srcRoot.getAbsolutePath()).build();
+        Route.newBuilder().setDst(b.getAbsolutePath()).setSrc(a.getAbsolutePath()).build();
     Route route3 =
-        Route.newBuilder().setDst("/b/d").setSrc("/a/d").setDstUfsAddress(dstRoot.getAbsolutePath())
-             .setSrcUfsAddress(srcRoot.getAbsolutePath()).build();
+        Route.newBuilder().setDst(dstD.getAbsolutePath()).setSrc(d.getAbsolutePath()).build();
     routes.add(route);
     routes.add(route2);
     routes.add(route3);
@@ -212,12 +207,12 @@ public class PagedDoraWorkerTest {
     List<RouteFailure> failures = copy.get();
 
     Assert.assertEquals(0, failures.size());
-    Assert.assertTrue(new File(b, "c").exists());
+    Assert.assertTrue(dstC.exists());
     Assert.assertTrue(b.exists());
     Assert.assertTrue(b.isDirectory());
-    Assert.assertTrue(new File(b, "d").exists());
-    Assert.assertTrue(new File(b, "d").isDirectory());
-    try (InputStream in = Files.newInputStream(new File(b, "c").toPath())) {
+    Assert.assertTrue(dstD.exists());
+    Assert.assertTrue(dstD.isDirectory());
+    try (InputStream in = Files.newInputStream(dstC.toPath())) {
       byte[] readBuffer = new byte[length];
       while (in.read(readBuffer) != -1) {
       }

--- a/core/server/worker/src/test/java/alluxio/worker/dora/PagedDoraWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/dora/PagedDoraWorkerTest.java
@@ -31,6 +31,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -173,6 +174,7 @@ public class PagedDoraWorkerTest {
   }
 
   @Test
+  @Ignore
   public void testFolderWithFileCopy()
       throws IOException, ExecutionException, InterruptedException {
     File srcRoot = mTestFolder.newFolder("src");

--- a/core/transport/src/main/proto/grpc/block_worker.proto
+++ b/core/transport/src/main/proto/grpc/block_worker.proto
@@ -243,8 +243,6 @@ message Route {
   required string src = 1;
   required string dst = 2;
   optional int64 length = 3;
-  optional string src_ufs_address = 4;
-  optional string dst_ufs_address = 5;
 }
 
 message CopyResponse {

--- a/core/transport/src/main/proto/proto/journal/job.proto
+++ b/core/transport/src/main/proto/proto/journal/job.proto
@@ -24,19 +24,16 @@ message LoadJobEntry {
   optional int64 end_time = 8;
 }
 
-// next available id: 14
+// next available id: 11
 message CopyJobEntry {
   required string src= 1;
   required string dst= 2;
-  optional string src_ufs_address= 3;
-  optional string dst_ufs_address= 4;
-  required PJobState state = 5;
-  optional int64 bandwidth = 6;
-  required bool verify = 7;
-  optional string user = 8;
-  required bool partialListing = 9;
-  required string job_id = 10;
-  optional int64 end_time = 11;
-  optional bool overwrite = 12;
-  optional grpc.file.WritePType writeType = 13;
+  required PJobState state = 3;
+  optional int64 bandwidth = 4;
+  required bool verify = 5;
+  optional string user = 6;
+  required bool partialListing = 7;
+  required string job_id = 8;
+  optional int64 end_time = 9;
+  optional bool overwrite = 10;
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix the issue that when Copy job using ufsIterable, the listStatus doesn't apply to the file. So add an API to fetch file information as well.
Also, use the full ufs path through the whole copy process.
### Why are the changes needed?

na

### Does this PR introduce any user facing changes?
na
