### PR TITLE
Revert "Improve the performance of MountTable.getMountPoint"

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/PathUtils.java
@@ -22,10 +22,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.FilenameUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import javax.annotation.concurrent.ThreadSafe;
@@ -446,26 +444,4 @@ public final class PathUtils {
   }
 
   private PathUtils() {} // prevent instantiation
-
-  /**
-   * Returns the list of possible mount points of the given path.
-   *
-   * "/a/b/c" => {"/a", "/a/b", "/a/b/c"}
-   *
-   * @param path the path to get the mount points of
-   * @return a list of paths
-   */
-  public static List<String> getPossibleMountPoints(String path) throws InvalidPathException {
-    String basePath = cleanPath(path);
-    List<String> paths = new ArrayList<>();
-    if ((basePath != null) && !basePath.equals(AlluxioURI.SEPARATOR)) {
-      paths.add(basePath);
-      String parent = getParent(path);
-      while (!parent.equals(AlluxioURI.SEPARATOR)) {
-        paths.add(0, parent);
-        parent = getParent(parent);
-      }
-    }
-    return paths;
-  }
 }

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -507,34 +507,4 @@ public final class PathUtilsTest {
     assertEquals("/foo/bar//", PathUtils.normalizePath("/foo/bar//", "/"));
     assertEquals("/foo/bar%", PathUtils.normalizePath("/foo/bar", "%"));
   }
-
-  /**
-   * Tests the {@link PathUtils#getPossibleMountPoints(String)} method to
-   * throw an exception in case the path is invalid.
-   */
-  @Test
-  public void getPossibleMountPointsException() throws InvalidPathException {
-    mException.expect(InvalidPathException.class);
-    PathUtils.getPossibleMountPoints("");
-  }
-
-  /**
-   * Tests the {@link PathUtils#getPossibleMountPoints(String)} method.
-   */
-  @Test
-  public void getPossibleMountPointsNoException() throws InvalidPathException {
-    ArrayList<String> paths = new ArrayList<>();
-    assertEquals(paths, PathUtils.getPossibleMountPoints("/"));
-    assertEquals(paths, PathUtils.getPossibleMountPoints("//"));
-
-    paths.add("/a");
-    assertEquals(paths, PathUtils.getPossibleMountPoints("/a"));
-    assertEquals(paths, PathUtils.getPossibleMountPoints("/a/"));
-    paths.add("/a/b");
-    assertEquals(paths, PathUtils.getPossibleMountPoints("/a/b"));
-    assertEquals(paths, PathUtils.getPossibleMountPoints("/a/b/"));
-    paths.add("/a/b/c");
-    assertEquals(paths, PathUtils.getPossibleMountPoints("/a/b/c"));
-    assertEquals(paths, PathUtils.getPossibleMountPoints("/a/b/c/"));
-  }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -323,13 +323,13 @@ public final class MountTable implements DelegatingJournaled {
   public String getMountPoint(AlluxioURI uri) throws InvalidPathException {
     String path = uri.getPath();
     String lastMount = ROOT;
-    List<String> possibleMounts = PathUtils.getPossibleMountPoints(path);
     try (LockResource r = new LockResource(mReadLock)) {
-      Map<String, MountInfo> mountTable = mState.getMountTable();
-      for (String mount: possibleMounts) {
-        if (mountTable.containsKey(mount)) {
-          // results in `possibleMounts` are from shortest to longest, so it will get the
-          // longest matching below
+      for (Map.Entry<String, MountInfo> entry : mState.getMountTable().entrySet()) {
+        String mount = entry.getKey();
+        // we choose a new candidate path if the previous candidate path is a prefix
+        // of the current alluxioPath and the alluxioPath is a prefix of the path
+        if (!mount.equals(ROOT) && PathUtils.hasPrefix(path, mount)
+            && lastMount.length() < mount.length()) {
           lastMount = mount;
         }
       }


### PR DESCRIPTION
This reverts commit f7e811c384e8049eb32a66721834cacf03f1dd30.

this causes a 20% performance degradation for the list directory metadata operation