### PR TITLE
Deprecate some Raft journal RPCs

### DIFF
--- a/core/transport/src/main/proto/grpc/raft_journal.proto
+++ b/core/transport/src/main/proto/grpc/raft_journal.proto
@@ -9,12 +9,13 @@ package alluxio.grpc.meta;
 import "grpc/common.proto";
 
 message JournalQueryRequest {
-  optional GetSnapshotInfoRequest snapshotInfoRequest = 1;
-  optional GetSnapshotRequest snapshotRequest = 2;
+  optional GetSnapshotInfoRequest snapshotInfoRequest = 1 [deprecated = true];
+  optional GetSnapshotRequest snapshotRequest = 2 [deprecated = true];
   optional AddQuorumServerRequest addQuorumServerRequest = 3;
 }
 
 message JournalQueryResponse {
+  option deprecated = true;
   optional GetSnapshotInfoResponse snapshotInfoResponse = 1;
 }
 
@@ -23,14 +24,17 @@ message AddQuorumServerRequest {
 }
 
 message GetSnapshotInfoRequest {
+  option deprecated = true;
   optional SnapshotMetadata snapshotInfo = 1;
 }
 
 message GetSnapshotInfoResponse {
+  option deprecated = true;
   optional SnapshotMetadata latest = 1;
 }
 
 message GetSnapshotRequest {
+  option deprecated = true;
 }
 
 message SnapshotMetadata {
@@ -43,23 +47,27 @@ message SnapshotData {
   optional int64 snapshotTerm = 1;
   optional int64 snapshotIndex = 2;
   optional bytes chunk = 3;
-  optional int64 offset = 4;
-  optional bool eof = 5;
+  optional int64 offset = 4 [deprecated = true];
+  optional bool eof = 5 [deprecated = true];
 }
 
 message UploadSnapshotPRequest {
+  option deprecated = true;
   optional SnapshotData data = 1;
 }
 
 message UploadSnapshotPResponse {
+  option deprecated = true;
   optional int64 offsetReceived = 1;
 }
 
 message DownloadSnapshotPRequest {
+  option deprecated = true;
   optional int64 offsetReceived = 1;
 }
 
 message DownloadSnapshotPResponse {
+  option deprecated = true;
   optional SnapshotData data = 1;
 }
 
@@ -71,16 +79,18 @@ message LatestSnapshotInfoPRequest {}
 service RaftJournalService {
 
   /**
-   * Deprecated.
    * Uploads a snapshot to primary master.
    */
-  rpc UploadSnapshot (stream UploadSnapshotPRequest) returns (stream UploadSnapshotPResponse);
+  rpc UploadSnapshot (stream UploadSnapshotPRequest) returns (stream UploadSnapshotPResponse) {
+    option deprecated = true;
+  };
 
   /**
-   * Deprecated.
    * Downloads a snapshot from primary master.
    */
-  rpc DownloadSnapshot (stream DownloadSnapshotPRequest) returns (stream DownloadSnapshotPResponse);
+  rpc DownloadSnapshot (stream DownloadSnapshotPRequest) returns (stream DownloadSnapshotPResponse) {
+    option deprecated = true;
+  };
 
   /**
    * Requests information about snapshots on a particular machine.

--- a/core/transport/src/main/proto/grpc/raft_journal.proto
+++ b/core/transport/src/main/proto/grpc/raft_journal.proto
@@ -16,7 +16,7 @@ message JournalQueryRequest {
 
 message JournalQueryResponse {
   option deprecated = true;
-  optional GetSnapshotInfoResponse snapshotInfoResponse = 1;
+  optional GetSnapshotInfoResponse snapshotInfoResponse = 1 [deprecated = true];
 }
 
 message AddQuorumServerRequest {
@@ -25,12 +25,12 @@ message AddQuorumServerRequest {
 
 message GetSnapshotInfoRequest {
   option deprecated = true;
-  optional SnapshotMetadata snapshotInfo = 1;
+  optional SnapshotMetadata snapshotInfo = 1 [deprecated = true];
 }
 
 message GetSnapshotInfoResponse {
   option deprecated = true;
-  optional SnapshotMetadata latest = 1;
+  optional SnapshotMetadata latest = 1 [deprecated = true];
 }
 
 message GetSnapshotRequest {
@@ -53,22 +53,22 @@ message SnapshotData {
 
 message UploadSnapshotPRequest {
   option deprecated = true;
-  optional SnapshotData data = 1;
+  optional SnapshotData data = 1 [deprecated = true];
 }
 
 message UploadSnapshotPResponse {
   option deprecated = true;
-  optional int64 offsetReceived = 1;
+  optional int64 offsetReceived = 1 [deprecated = true];
 }
 
 message DownloadSnapshotPRequest {
   option deprecated = true;
-  optional int64 offsetReceived = 1;
+  optional int64 offsetReceived = 1 [deprecated = true];
 }
 
 message DownloadSnapshotPResponse {
   option deprecated = true;
-  optional SnapshotData data = 1;
+  optional SnapshotData data = 1 [deprecated = true];
 }
 
 message LatestSnapshotInfoPRequest {}

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -6965,7 +6965,13 @@
               {
                 "id": 1,
                 "name": "snapshotInfoResponse",
-                "type": "GetSnapshotInfoResponse"
+                "type": "GetSnapshotInfoResponse",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               }
             ],
             "options": [
@@ -6991,7 +6997,13 @@
               {
                 "id": 1,
                 "name": "snapshotInfo",
-                "type": "SnapshotMetadata"
+                "type": "SnapshotMetadata",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               }
             ],
             "options": [
@@ -7007,7 +7019,13 @@
               {
                 "id": 1,
                 "name": "latest",
-                "type": "SnapshotMetadata"
+                "type": "SnapshotMetadata",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               }
             ],
             "options": [
@@ -7094,7 +7112,13 @@
               {
                 "id": 1,
                 "name": "data",
-                "type": "SnapshotData"
+                "type": "SnapshotData",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               }
             ],
             "options": [
@@ -7110,7 +7134,13 @@
               {
                 "id": 1,
                 "name": "offsetReceived",
-                "type": "int64"
+                "type": "int64",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               }
             ],
             "options": [
@@ -7126,7 +7156,13 @@
               {
                 "id": 1,
                 "name": "offsetReceived",
-                "type": "int64"
+                "type": "int64",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               }
             ],
             "options": [
@@ -7142,7 +7178,13 @@
               {
                 "id": 1,
                 "name": "data",
-                "type": "SnapshotData"
+                "type": "SnapshotData",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               }
             ],
             "options": [

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -6933,12 +6933,24 @@
               {
                 "id": 1,
                 "name": "snapshotInfoRequest",
-                "type": "GetSnapshotInfoRequest"
+                "type": "GetSnapshotInfoRequest",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 2,
                 "name": "snapshotRequest",
-                "type": "GetSnapshotRequest"
+                "type": "GetSnapshotRequest",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 3,
@@ -6954,6 +6966,12 @@
                 "id": 1,
                 "name": "snapshotInfoResponse",
                 "type": "GetSnapshotInfoResponse"
+              }
+            ],
+            "options": [
+              {
+                "name": "deprecated",
+                "value": "true"
               }
             ]
           },
@@ -6975,6 +6993,12 @@
                 "name": "snapshotInfo",
                 "type": "SnapshotMetadata"
               }
+            ],
+            "options": [
+              {
+                "name": "deprecated",
+                "value": "true"
+              }
             ]
           },
           {
@@ -6985,10 +7009,22 @@
                 "name": "latest",
                 "type": "SnapshotMetadata"
               }
+            ],
+            "options": [
+              {
+                "name": "deprecated",
+                "value": "true"
+              }
             ]
           },
           {
-            "name": "GetSnapshotRequest"
+            "name": "GetSnapshotRequest",
+            "options": [
+              {
+                "name": "deprecated",
+                "value": "true"
+              }
+            ]
           },
           {
             "name": "SnapshotMetadata",
@@ -7031,12 +7067,24 @@
               {
                 "id": 4,
                 "name": "offset",
-                "type": "int64"
+                "type": "int64",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 5,
                 "name": "eof",
-                "type": "bool"
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               }
             ]
           },
@@ -7048,6 +7096,12 @@
                 "name": "data",
                 "type": "SnapshotData"
               }
+            ],
+            "options": [
+              {
+                "name": "deprecated",
+                "value": "true"
+              }
             ]
           },
           {
@@ -7057,6 +7111,12 @@
                 "id": 1,
                 "name": "offsetReceived",
                 "type": "int64"
+              }
+            ],
+            "options": [
+              {
+                "name": "deprecated",
+                "value": "true"
               }
             ]
           },
@@ -7068,6 +7128,12 @@
                 "name": "offsetReceived",
                 "type": "int64"
               }
+            ],
+            "options": [
+              {
+                "name": "deprecated",
+                "value": "true"
+              }
             ]
           },
           {
@@ -7077,6 +7143,12 @@
                 "id": 1,
                 "name": "data",
                 "type": "SnapshotData"
+              }
+            ],
+            "options": [
+              {
+                "name": "deprecated",
+                "value": "true"
               }
             ]
           },
@@ -7093,14 +7165,26 @@
                 "in_type": "UploadSnapshotPRequest",
                 "out_type": "UploadSnapshotPResponse",
                 "in_streamed": true,
-                "out_streamed": true
+                "out_streamed": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "name": "DownloadSnapshot",
                 "in_type": "DownloadSnapshotPRequest",
                 "out_type": "DownloadSnapshotPResponse",
                 "in_streamed": true,
-                "out_streamed": true
+                "out_streamed": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "name": "RequestLatestSnapshotInfo",


### PR DESCRIPTION
Following #16998, some messages, fields, and RPCs are no longer in use. This PR marks them as deprecated. 