### PR TITLE
Resolve the UFS leak in copy job

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -103,17 +103,30 @@ public class UfsBaseFileSystem implements FileSystem {
    * @param options the ufs file system options
    */
   public UfsBaseFileSystem(FileSystemContext fsContext, UfsFileSystemOptions options) {
+    this(fsContext, options, new UfsManager.UfsClient(
+        () -> UnderFileSystem.Factory.create(options.getUfsAddress(), fsContext.getClusterConf()),
+        new AlluxioURI(options.getUfsAddress())));
+    mCloser.register(mFsContext);
+    LOG.debug("Creating file system connecting to ufs address {}", options.getUfsAddress());
+  }
+
+  /**
+   * Constructs a wrapper file system based on given UnderFileSystem. Caller should close the
+   * FileSystemContext.
+   *
+   * @param fsContext file system context
+   * @param options the ufs file system options
+   * @param ufs the under file system
+   */
+  public UfsBaseFileSystem(FileSystemContext fsContext, UfsFileSystemOptions options,
+      UfsManager.UfsClient ufs) {
     Preconditions.checkNotNull(fsContext);
     Preconditions.checkNotNull(options);
     mFsContext = fsContext;
     String ufsAddress = options.getUfsAddress();
     Preconditions.checkArgument(!ufsAddress.isEmpty(), "ufs address should not be empty");
     mRootUFS = new AlluxioURI(ufsAddress);
-    UfsManager.UfsClient ufsClient = new UfsManager.UfsClient(
-        () -> UnderFileSystem.Factory.create(ufsAddress, mFsContext.getClusterConf()),
-        new AlluxioURI(ufsAddress));
-    mUfs = ufsClient.acquireUfsResource();
-    mCloser.register(mFsContext);
+    mUfs = ufs.acquireUfsResource();
     mCloser.register(mUfs);
     LOG.debug("Creating file system connecting to ufs address {}", ufsAddress);
   }

--- a/dora/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
+++ b/dora/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
@@ -114,11 +114,11 @@ public abstract class AbstractUfsManager implements UfsManager {
    * Return a UFS instance if it already exists in the cache, otherwise, creates a new instance and
    * return it.
    *
-   * @param ufsUri the UFS path
+   * @param ufsUri  the UFS path
    * @param ufsConf the UFS configuration
    * @return the UFS instance
    */
-  private UnderFileSystem getOrAdd(AlluxioURI ufsUri, UnderFileSystemConfiguration ufsConf) {
+  public UnderFileSystem getOrAdd(AlluxioURI ufsUri, UnderFileSystemConfiguration ufsConf) {
     return getOrAddWithRecorder(ufsUri, ufsConf, Recorder.noopRecorder());
   }
 

--- a/dora/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -517,8 +517,7 @@ public class DefaultFileSystemMaster extends CoreMaster
     mSyncMetadataExecutor.allowCoreThreadTimeOut(true);
     mActiveSyncMetadataExecutor.allowCoreThreadTimeOut(true);
     FileSystemContext schedulerFsContext = FileSystemContext.create();
-    JournaledJobMetaStore jobMetaStore = new JournaledJobMetaStore(this, masterContext
-        .getUfsManager());
+    JournaledJobMetaStore jobMetaStore = new JournaledJobMetaStore(this);
     mScheduler = new Scheduler(schedulerFsContext,
         new DefaultWorkerProvider(this, schedulerFsContext), jobMetaStore);
 

--- a/dora/core/server/master/src/main/java/alluxio/master/job/CopyJobFactory.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/job/CopyJobFactory.java
@@ -12,16 +12,16 @@
 package alluxio.master.job;
 
 import alluxio.AlluxioURI;
-import alluxio.client.WriteType;
 import alluxio.conf.Configuration;
-import alluxio.conf.PropertyKey;
 import alluxio.grpc.CopyJobPOptions;
 import alluxio.job.CopyJobRequest;
+import alluxio.master.file.DefaultFileSystemMaster;
 import alluxio.scheduler.job.Job;
 import alluxio.scheduler.job.JobFactory;
 import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.wire.FileInfo;
 
 import java.util.Optional;
@@ -33,16 +33,16 @@ import java.util.UUID;
  */
 public class CopyJobFactory implements JobFactory {
 
-  private final UnderFileSystem mFs;
+  private final DefaultFileSystemMaster mFs;
   private final CopyJobRequest mRequest;
 
   /**
    * Create factory.
    * @param request load job request
-   * @param underFileSystem file system master
+   * @param fsMaster file system master
    */
-  public CopyJobFactory(CopyJobRequest request, UnderFileSystem underFileSystem) {
-    mFs = underFileSystem;
+  public CopyJobFactory(CopyJobRequest request, DefaultFileSystemMaster fsMaster) {
+    mFs = fsMaster;
     mRequest = request;
   }
 
@@ -50,17 +50,15 @@ public class CopyJobFactory implements JobFactory {
   public Job<?> create() {
     CopyJobPOptions options = mRequest.getOptions();
     String src = mRequest.getSrc();
-    String srcRoot = new AlluxioURI(src).getRootPath();
-    String dstRoot = new AlluxioURI(mRequest.getDst()).getRootPath();
     OptionalLong bandwidth =
         options.hasBandwidth() ? OptionalLong.of(options.getBandwidth()) : OptionalLong.empty();
     boolean partialListing = options.hasPartialListing() && options.getPartialListing();
     boolean verificationEnabled = options.hasVerify() && options.getVerify();
     boolean overwrite = options.hasOverwrite() && options.getOverwrite();
     boolean checkContent = options.hasCheckContent() && options.getCheckContent();
-    WriteType writeType = options.hasWriteType() ? WriteType.fromProto(options.getWriteType()) :
-        Configuration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class);
-    Iterable<FileInfo> fileIterator = new UfsFileIterable(mFs, src, Optional
+    UnderFileSystem ufs = mFs.getUfsManager().getOrAdd(new AlluxioURI(src),
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
+    Iterable<FileInfo> fileIterator = new UfsFileIterable(ufs, src, Optional
         .ofNullable(AuthenticatedClientUser.getOrNull())
         .map(User::getName), partialListing, FileInfo::isCompleted);
     Optional<String> user = Optional

--- a/dora/core/server/master/src/main/java/alluxio/master/job/JobFactoryProducer.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/job/JobFactoryProducer.java
@@ -11,16 +11,12 @@
 
 package alluxio.master.job;
 
-import alluxio.conf.Configuration;
 import alluxio.job.CopyJobRequest;
 import alluxio.job.JobRequest;
 import alluxio.job.LoadJobRequest;
 import alluxio.master.file.DefaultFileSystemMaster;
-import alluxio.master.file.FileSystemMaster;
 import alluxio.proto.journal.Journal;
 import alluxio.scheduler.job.JobFactory;
-import alluxio.underfs.UnderFileSystem;
-import alluxio.underfs.UnderFileSystemConfiguration;
 
 /**
  * Producer for {@link JobFactory}.
@@ -39,26 +35,9 @@ public class JobFactoryProducer {
       return new LoadJobFactory((LoadJobRequest) request, fsMaster);
     }
     if (request instanceof CopyJobRequest) {
-      CopyJobRequest copyRequest = (CopyJobRequest) request;
-      UnderFileSystem ufs = UnderFileSystem.Factory.create(copyRequest.getSrc(),
-          UnderFileSystemConfiguration.defaults(Configuration.global()));
-      return new CopyJobFactory((CopyJobRequest) request, ufs);
+      return new CopyJobFactory((CopyJobRequest) request, fsMaster);
     }
     throw new IllegalArgumentException("Unknown job type: " + request.getType());
-  }
-
-  /**
-   * @param entry the job journal entry
-   * @param fs    the file system master
-   * @return the job factory
-   */
-  public static JobFactory create(Journal.JournalEntry entry, UnderFileSystem fs) {
-    if (entry.hasCopyJob()) {
-      return new JournalCopyJobFactory(entry.getCopyJob(), fs);
-    }
-    else {
-      throw new IllegalArgumentException("Unknown job type: " + entry);
-    }
   }
 
   /**
@@ -66,9 +45,12 @@ public class JobFactoryProducer {
    * @param fsMaster the file system master
    * @return the job factory
    */
-  public static JobFactory create(Journal.JournalEntry entry, FileSystemMaster fsMaster) {
+  public static JobFactory create(Journal.JournalEntry entry, DefaultFileSystemMaster fsMaster) {
     if (entry.hasLoadJob()) {
       return new JournalLoadJobFactory(entry.getLoadJob(), fsMaster);
+    }
+    if (entry.hasCopyJob()) {
+      return new JournalCopyJobFactory(entry.getCopyJob(), fsMaster);
     }
     else {
       throw new IllegalArgumentException("Unknown job type: " + entry);

--- a/dora/core/server/master/src/test/java/alluxio/master/file/scheduler/SchedulerTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/file/scheduler/SchedulerTest.java
@@ -40,7 +40,7 @@ import alluxio.grpc.LoadRequest;
 import alluxio.grpc.LoadResponse;
 import alluxio.grpc.TaskStatus;
 import alluxio.job.JobDescription;
-import alluxio.master.file.FileSystemMaster;
+import alluxio.master.file.DefaultFileSystemMaster;
 import alluxio.master.job.FileIterable;
 import alluxio.master.job.LoadJob;
 import alluxio.master.journal.JournalContext;
@@ -51,7 +51,6 @@ import alluxio.proto.journal.Job;
 import alluxio.resource.CloseableResource;
 import alluxio.scheduler.job.JobState;
 import alluxio.security.authentication.AuthenticatedClientUser;
-import alluxio.underfs.UfsManager;
 import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
@@ -86,13 +85,13 @@ public final class SchedulerTest {
 
   @Test
   public void testGetActiveWorkers() throws IOException {
-    FileSystemMaster fsMaster = mock(FileSystemMaster.class);
+    DefaultFileSystemMaster fsMaster = mock(DefaultFileSystemMaster.class);
     FileSystemContext fileSystemContext = mock(FileSystemContext.class);
     CloseableResource<BlockWorkerClient> blockWorkerClient = mock(CloseableResource.class);
     DefaultWorkerProvider workerProvider =
         new DefaultWorkerProvider(fsMaster, fileSystemContext);
     Scheduler scheduler = new Scheduler(fileSystemContext, workerProvider,
-        new JournaledJobMetaStore(fsMaster, mock(UfsManager.class)));
+        new JournaledJobMetaStore(fsMaster));
     when(fsMaster.getWorkerInfoList())
         .thenReturn(ImmutableList.of(
             new WorkerInfo().setId(1).setAddress(
@@ -128,14 +127,14 @@ public final class SchedulerTest {
   @Test
   public void testSubmit() throws Exception {
     String validLoadPath = "/path/to/load";
-    FileSystemMaster fsMaster = mock(FileSystemMaster.class);
+    DefaultFileSystemMaster fsMaster = mock(DefaultFileSystemMaster.class);
     FileSystemContext fileSystemContext = mock(FileSystemContext.class);
     JournalContext journalContext = mock(JournalContext.class);
     when(fsMaster.createJournalContext()).thenReturn(journalContext);
     DefaultWorkerProvider workerProvider =
         new DefaultWorkerProvider(fsMaster, fileSystemContext);
     Scheduler scheduler = new Scheduler(fileSystemContext, workerProvider,
-        new JournaledJobMetaStore(fsMaster, mock(UfsManager.class)));
+        new JournaledJobMetaStore(fsMaster));
     FileIterable files =
         new FileIterable(fsMaster, validLoadPath, Optional.of("user"), false,
             LoadJob.QUALIFIED_FILE_FILTER);
@@ -173,14 +172,14 @@ public final class SchedulerTest {
   @Test
   public void testStop() throws Exception {
     String validLoadPath = "/path/to/load";
-    FileSystemMaster fsMaster = mock(FileSystemMaster.class);
+    DefaultFileSystemMaster fsMaster = mock(DefaultFileSystemMaster.class);
     FileSystemContext fileSystemContext = mock(FileSystemContext.class);
     JournalContext journalContext = mock(JournalContext.class);
     when(fsMaster.createJournalContext()).thenReturn(journalContext);
     DefaultWorkerProvider workerProvider =
         new DefaultWorkerProvider(fsMaster, fileSystemContext);
     Scheduler scheduler = new Scheduler(fileSystemContext, workerProvider,
-        new JournaledJobMetaStore(fsMaster, mock(UfsManager.class)));
+        new JournaledJobMetaStore(fsMaster));
     FileIterable files =
         new FileIterable(fsMaster, validLoadPath, Optional.of("user"), false,
             LoadJob.QUALIFIED_FILE_FILTER);
@@ -214,14 +213,14 @@ public final class SchedulerTest {
 
   @Test
   public void testSubmitExceedsCapacity() throws Exception {
-    FileSystemMaster fsMaster = mock(FileSystemMaster.class);
+    DefaultFileSystemMaster fsMaster = mock(DefaultFileSystemMaster.class);
     FileSystemContext fileSystemContext = mock(FileSystemContext.class);
     JournalContext journalContext = mock(JournalContext.class);
     when(fsMaster.createJournalContext()).thenReturn(journalContext);
     DefaultWorkerProvider workerProvider =
         new DefaultWorkerProvider(fsMaster, fileSystemContext);
     Scheduler scheduler = new Scheduler(fileSystemContext, workerProvider,
-        new JournaledJobMetaStore(fsMaster, mock(UfsManager.class)));
+        new JournaledJobMetaStore(fsMaster));
     IntStream.range(0, 100).forEach(
         i -> {
           String path = String.format("/path/to/load/%d", i);
@@ -241,7 +240,7 @@ public final class SchedulerTest {
 
   @Test
   public void testScheduling() throws Exception {
-    FileSystemMaster fsMaster = mock(FileSystemMaster.class);
+    DefaultFileSystemMaster fsMaster = mock(DefaultFileSystemMaster.class);
     FileSystemContext fileSystemContext = mock(FileSystemContext.class);
     JournalContext journalContext = mock(JournalContext.class);
     when(fsMaster.createJournalContext()).thenReturn(journalContext);
@@ -292,7 +291,7 @@ public final class SchedulerTest {
     DefaultWorkerProvider workerProvider =
         new DefaultWorkerProvider(fsMaster, fileSystemContext);
     Scheduler scheduler = new Scheduler(fileSystemContext, workerProvider,
-        new JournaledJobMetaStore(fsMaster, mock(UfsManager.class)));
+        new JournaledJobMetaStore(fsMaster));
     String path = "test";
     FileIterable files = new FileIterable(fsMaster, path, Optional.of("user"), false,
         LoadJob.QUALIFIED_FILE_FILTER);
@@ -366,7 +365,7 @@ public final class SchedulerTest {
 
   @Test
   public void testSchedulingFullCapacity() throws Exception {
-    FileSystemMaster fsMaster = mock(FileSystemMaster.class);
+    DefaultFileSystemMaster fsMaster = mock(DefaultFileSystemMaster.class);
     FileSystemContext fileSystemContext = mock(FileSystemContext.class);
     JournalContext journalContext = mock(JournalContext.class);
     when(fsMaster.createJournalContext()).thenReturn(journalContext);
@@ -397,7 +396,7 @@ public final class SchedulerTest {
     DefaultWorkerProvider workerProvider =
         new DefaultWorkerProvider(fsMaster, fileSystemContext);
     Scheduler scheduler = new Scheduler(fileSystemContext, workerProvider,
-        new JournaledJobMetaStore(fsMaster, mock(UfsManager.class)));
+        new JournaledJobMetaStore(fsMaster));
     for (int i = 0; i < 100; i++) {
       LoadJob loadJob = new LoadJob("test" + i, "user", OptionalLong.of(1000), files);
       scheduler.submitJob(loadJob);
@@ -415,7 +414,7 @@ public final class SchedulerTest {
 
   @Test
   public void testSchedulingWithException() throws Exception {
-    FileSystemMaster fsMaster = mock(FileSystemMaster.class);
+    DefaultFileSystemMaster fsMaster = mock(DefaultFileSystemMaster.class);
     FileSystemContext fileSystemContext = mock(FileSystemContext.class);
     JournalContext journalContext = mock(JournalContext.class);
     when(fsMaster.createJournalContext()).thenReturn(journalContext);
@@ -439,7 +438,7 @@ public final class SchedulerTest {
     DefaultWorkerProvider workerProvider =
         new DefaultWorkerProvider(fsMaster, fileSystemContext);
     Scheduler scheduler = new Scheduler(fileSystemContext, workerProvider,
-        new JournaledJobMetaStore(fsMaster, mock(UfsManager.class)));
+        new JournaledJobMetaStore(fsMaster));
     scheduler.start();
     FileIterable files =
         new FileIterable(fsMaster, "test", Optional.of("user"), false,
@@ -470,14 +469,14 @@ public final class SchedulerTest {
   @Test
   public void testJobRetention() throws Exception {
     Configuration.modifiableGlobal().set(PropertyKey.JOB_RETENTION_TIME, "0ms", Source.RUNTIME);
-    FileSystemMaster fsMaster = mock(FileSystemMaster.class);
+    DefaultFileSystemMaster fsMaster = mock(DefaultFileSystemMaster.class);
     FileSystemContext fileSystemContext = mock(FileSystemContext.class);
     JournalContext journalContext = mock(JournalContext.class);
     when(fsMaster.createJournalContext()).thenReturn(journalContext);
     DefaultWorkerProvider workerProvider =
         new DefaultWorkerProvider(fsMaster, fileSystemContext);
     Scheduler scheduler = new Scheduler(fileSystemContext, workerProvider,
-        new JournaledJobMetaStore(fsMaster, mock(UfsManager.class)));
+        new JournaledJobMetaStore(fsMaster));
     scheduler.start();
     IntStream
         .range(0, 5)


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR resolves the UFS leak problem in copy job. By making the method public in UfsManager.
### Why are the changes needed?

Since we don't have mountID in Dora, so we need a new way to identify which UFS to use. Currently, I'm following the original design which uses Scheme, Authority & Properties as the key. Later on, we should also use the token given by the client to identify the UFS.

### Does this PR introduce any user facing changes?

na
