### PR TITLE
Update java.version in pom.xml to 1.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <rocksdb.version>7.0.3</rocksdb.version>
     <hadoop.version>3.3.1</hadoop.version>
     <jacoco.version>0.8.5</jacoco.version>
-    <java.version>1.8</java.version>
+    <java.version>1.11</java.version>
     <jaxb.version>2.3.3</jaxb.version>
     <jersey.version>2.34</jersey.version>
     <jetty.version>9.4.46.v20220331</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1374,7 +1374,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
-              <source>8</source>
+              <source>11</source>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
not sure how this `java.version` property in the pom.xml affects the build after changing everything else to java 11. referenced as a configuration value for the `maven-compiler-plugin` and `maven-enforcer-plugin`