### PR TITLE
Fix decommissioned worker recorded twice after restart

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -674,6 +674,8 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
         selectedLiveWorkers = selectInfoByAddress(addresses, mWorkers, workerNames);
         selectedLostWorkers = selectInfoByAddress(addresses, mLostWorkers, workerNames);
+        selectedDecommissionedWorkers = selectInfoByAddress(addresses,
+                mDecommissionedWorkers, workerNames);
 
         if (!addresses.isEmpty()) {
           String info = String.format("Unrecognized worker names: %s%n"
@@ -1087,7 +1089,8 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
    */
   @Nullable
   private MasterWorkerInfo findUnregisteredWorker(WorkerNetAddress workerNetAddress) {
-    for (IndexedSet<MasterWorkerInfo> workers: Arrays.asList(mTempWorkers, mLostWorkers)) {
+    for (IndexedSet<MasterWorkerInfo> workers: Arrays.asList(mTempWorkers,
+        mLostWorkers, mDecommissionedWorkers)) {
       MasterWorkerInfo worker = workers.getFirstByField(ADDRESS_INDEX, workerNetAddress);
       if (worker != null) {
         return worker;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix a bug where when a decommissioned worker registers after restart, it is not recognized and allocated a new ID.
This bug only emerges in 2.8 and was caused by cherry picking.

Verified the fix locally
```
➜  bin/alluxio fsadmin report capacity
Capacity information for all workers:
    Total Capacity: 3072.00MB
        Tier: MEM  Size: 3072.00MB
    Used Capacity: 0B
        Tier: MEM  Size: 0B
    Used Percentage: 0%
    Free Percentage: 100%

Worker Name      State           Last Heartbeat   Storage       MEM              Version          Revision
192.168.3.5      Decommissioned  163              capacity      3072.00MB        2.8.0-SNAPSHOT   36e7d4784ee084f0ea76d513a69436c62180ab8f
                                                  used          0B (0%)
➜ bin/alluxio-start.sh worker
Assuming NoMount by default.
Successfully Killed 1 process(es) successfully on aiur.local
Starting worker @ aiur.local. Logging to /Users/jiacheng/Documents/Alluxio/alluxio-jiacheng/alluxio/logs
--- [ OK ] The worker service @ aiur.local is in a healthy state.
➜  bin/alluxio fsadmin report capacity
Capacity information for all workers:
    Total Capacity: 3072.00MB
        Tier: MEM  Size: 3072.00MB
    Used Capacity: 0B
        Tier: MEM  Size: 0B
    Used Percentage: 0%
    Free Percentage: 100%

Worker Name      State           Last Heartbeat   Storage       MEM              Version          Revision
192.168.3.5      ACTIVE          0                capacity      3072.00MB        2.8.0-SNAPSHOT   36e7d4784ee084f0ea76d513a69436c62180ab8f
                                                  used          0B (0%)
```

