### PR TITLE
Fix standby master version not shown

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -634,6 +634,18 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
     }
 
     master.updateLastUpdatedTimeMs();
+    if (options.hasStartTimeMs()) {
+      master.setStartTimeMs(options.getStartTimeMs());
+    }
+    if (options.hasLosePrimacyTimeMs()) {
+      master.setLosePrimacyTimeMs(options.getLosePrimacyTimeMs());
+    }
+    if (options.hasVersion()) {
+      master.setVersion(options.getVersion());
+    }
+    if (options.hasRevision()) {
+      master.setRevision(options.getRevision());
+    }
 
     mMasterConfigStore.registerNewConf(master.getAddress(), options.getConfigsList());
 

--- a/core/server/master/src/main/java/alluxio/master/meta/RetryHandlingMetaMasterMasterClient.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/RetryHandlingMetaMasterMasterClient.java
@@ -96,18 +96,7 @@ public final class RetryHandlingMetaMasterMasterClient extends AbstractMasterCli
    * @return whether this master should re-register
    */
   public MetaCommand heartbeat(final long masterId) throws IOException {
-    final Map<String, Gauge> gauges = MetricsSystem.METRIC_REGISTRY.getGauges();
-    Gauge lastCheckpointGauge = gauges
-            .get(MetricKey.MASTER_JOURNAL_LAST_CHECKPOINT_TIME.getName());
-    Gauge journalEntriesGauge = gauges
-            .get(MetricKey.MASTER_JOURNAL_ENTRIES_SINCE_CHECKPOINT.getName());
     MasterHeartbeatPOptions.Builder optionsBuilder = MasterHeartbeatPOptions.newBuilder();
-    if (lastCheckpointGauge != null) {
-      optionsBuilder.setLastCheckpointTime((long) lastCheckpointGauge.getValue());
-    }
-    if (journalEntriesGauge != null) {
-      optionsBuilder.setJournalEntriesSinceCheckpoint((long) journalEntriesGauge.getValue());
-    }
     return retryRPC(() -> mClient
         .masterHeartbeat(MasterHeartbeatPRequest.newBuilder().setMasterId(masterId)
             .setOptions(optionsBuilder).build())

--- a/core/server/master/src/main/java/alluxio/master/meta/RetryHandlingMetaMasterMasterClient.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/RetryHandlingMetaMasterMasterClient.java
@@ -13,8 +13,10 @@ package alluxio.master.meta;
 
 import alluxio.AbstractMasterClient;
 import alluxio.Constants;
+import alluxio.ProjectConstants;
 import alluxio.grpc.ConfigProperty;
 import alluxio.grpc.GetMasterIdPRequest;
+import alluxio.grpc.MasterHeartbeatPOptions;
 import alluxio.grpc.MasterHeartbeatPRequest;
 import alluxio.grpc.MetaCommand;
 import alluxio.grpc.MetaMasterMasterServiceGrpc;
@@ -22,13 +24,17 @@ import alluxio.grpc.RegisterMasterPOptions;
 import alluxio.grpc.RegisterMasterPRequest;
 import alluxio.grpc.ServiceType;
 import alluxio.master.MasterClientContext;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.wire.Address;
 
+import com.codahale.metrics.Gauge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -90,8 +96,21 @@ public final class RetryHandlingMetaMasterMasterClient extends AbstractMasterCli
    * @return whether this master should re-register
    */
   public MetaCommand heartbeat(final long masterId) throws IOException {
+    final Map<String, Gauge> gauges = MetricsSystem.METRIC_REGISTRY.getGauges();
+    Gauge lastCheckpointGauge = gauges
+            .get(MetricKey.MASTER_JOURNAL_LAST_CHECKPOINT_TIME.getName());
+    Gauge journalEntriesGauge = gauges
+            .get(MetricKey.MASTER_JOURNAL_ENTRIES_SINCE_CHECKPOINT.getName());
+    MasterHeartbeatPOptions.Builder optionsBuilder = MasterHeartbeatPOptions.newBuilder();
+    if (lastCheckpointGauge != null) {
+      optionsBuilder.setLastCheckpointTime((long) lastCheckpointGauge.getValue());
+    }
+    if (journalEntriesGauge != null) {
+      optionsBuilder.setJournalEntriesSinceCheckpoint((long) journalEntriesGauge.getValue());
+    }
     return retryRPC(() -> mClient
-        .masterHeartbeat(MasterHeartbeatPRequest.newBuilder().setMasterId(masterId).build())
+        .masterHeartbeat(MasterHeartbeatPRequest.newBuilder().setMasterId(masterId)
+            .setOptions(optionsBuilder).build())
         .getCommand(), LOG, "Heartbeat", "masterId=%d", masterId);
   }
 
@@ -103,10 +122,22 @@ public final class RetryHandlingMetaMasterMasterClient extends AbstractMasterCli
    */
   public void register(final long masterId, final List<ConfigProperty> configList)
       throws IOException {
+    final Map<String, Gauge> gauges = MetricsSystem.METRIC_REGISTRY.getGauges();
+    RegisterMasterPOptions.Builder optionsBuilder = RegisterMasterPOptions.newBuilder()
+            .addAllConfigs(configList)
+            .setVersion(ProjectConstants.VERSION)
+            .setRevision(ProjectConstants.REVISION);
+    Gauge startTimeGauge = gauges.get(MetricKey.MASTER_START_TIME.getName());
+    if (startTimeGauge != null) {
+      optionsBuilder.setStartTimeMs((long) startTimeGauge.getValue());
+    }
+    Gauge lastLosePrimacyGuage = gauges.get(MetricKey.MASTER_LAST_LOSE_PRIMACY_TIME.getName());
+    if (lastLosePrimacyGuage != null) {
+      optionsBuilder.setLosePrimacyTimeMs((long) lastLosePrimacyGuage.getValue());
+    }
     retryRPC(() -> {
       mClient.registerMaster(RegisterMasterPRequest.newBuilder().setMasterId(masterId)
-          .setOptions(RegisterMasterPOptions.newBuilder().addAllConfigs(configList).build())
-          .build());
+          .setOptions(optionsBuilder).build());
       return null;
     }, LOG, "Register", "masterId=%d,configList=%s", masterId, configList);
   }

--- a/core/transport/src/main/proto/grpc/meta_master.proto
+++ b/core/transport/src/main/proto/grpc/meta_master.proto
@@ -269,6 +269,10 @@ enum MetaCommand {
 
 message RegisterMasterPOptions {
   repeated grpc.ConfigProperty configs = 1;
+  optional int64 startTimeMs = 2;
+  optional int64 losePrimacyTimeMs = 3;
+  optional string version = 4;
+  optional string revision = 5;
 }
 message RegisterMasterPRequest {
   optional int64 masterId = 1;
@@ -276,7 +280,10 @@ message RegisterMasterPRequest {
 }
 message RegisterMasterPResponse {}
 
-message MasterHeartbeatPOptions {}
+message MasterHeartbeatPOptions {
+  optional int64 lastCheckpointTime = 1;
+  optional int64 journalEntriesSinceCheckpoint = 2;
+}
 message MasterHeartbeatPRequest {
   optional int64 masterId = 1;
   optional MasterHeartbeatPOptions options = 2;

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -6011,6 +6011,26 @@
                 "name": "configs",
                 "type": "grpc.ConfigProperty",
                 "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "startTimeMs",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "losePrimacyTimeMs",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "revision",
+                "type": "string"
               }
             ]
           },
@@ -6033,7 +6053,19 @@
             "name": "RegisterMasterPResponse"
           },
           {
-            "name": "MasterHeartbeatPOptions"
+            "name": "MasterHeartbeatPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "lastCheckpointTime",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "journalEntriesSinceCheckpoint",
+                "type": "int64"
+              }
+            ]
           },
           {
             "name": "MasterHeartbeatPRequest",


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix a bug where standby masters don't send the version info to primary.
This bug only emerges in 2.8 and was caused by cherry picking.