### PR TITLE
Add default option and merge it to existing one of ListStatus

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -190,7 +190,10 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
     ufsFullPath = new AlluxioURI(PathUtils.normalizePath(ufsFullPath.toString(), "/"));
 
     try {
-      return mDoraClient.listStatus(ufsFullPath.toString(), options);
+      ListStatusPOptions mergedOptions = FileSystemOptionsUtils.listStatusDefaults(
+          mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
+
+      return mDoraClient.listStatus(ufsFullPath.toString(), mergedOptions);
     } catch (RuntimeException ex) {
       if (ex instanceof StatusRuntimeException) {
         if (((StatusRuntimeException) ex).getStatus().getCode() == Status.NOT_FOUND.getCode()) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Prepare default options for ListStatus and merge it with the existing one from user.

### Why are the changes needed?

So the configurations can be passed from client/user to worker.
For example, user can use the following command to refresh the root dir:
```
bin/alluxio fs -Dalluxio.user.file.metadata.sync.interval=0 ls /
```
the `alluxio.user.file.metadata.sync.interval=0` must be added to the listStatus option.

### Does this PR introduce any user facing changes?

N/A
