### PR TITLE
[DOCFIX] Add docs for rolling upgrade and decommission worker

### DIFF
--- a/docs/en/administration/Upgrade.md
+++ b/docs/en/administration/Upgrade.md
@@ -87,6 +87,150 @@ $ ./bin/alluxio-start.sh all
 ```
 5. If you have updated the Alluxio client jar for an application, restart that application to use the new Alluxio client jar.
 
+### Rolling upgrade/restart masters
+
+When the cluster is running in high-availability mode (running multiple Alluxio masters), if the admin wants to restart all masters
+in the cluster, it should be done in a rolling restart fashion to minimize service unavailable time.
+The service should only be unavailable during primary master failover, once there is a primary master in HA,
+restarting standby masters will not interrupt the service.
+
+If the HA is on Embeddded Journal (using Raft), this is an example of how to perform rolling upgrade:
+```shell
+# First check all master nodes in the cluster
+$ ./bin/alluxio fsadmin report
+...
+Raft journal addresses:
+  master-0:19200
+  master-1:19200
+  master-2:19200
+Master Address        State      Version       REVISION
+master-0:19998        PRIMARY  alluxio-2.9.0  abcde
+master-1:19998        STANDBY  alluxio-2.9.0  abcde
+master-2:19998        STANDBY  alluxio-2.9.0  abcde
+
+# Pick one standby master and restart it using the higher version
+$ ssh master-1
+$ bin/alluxio-start.sh master
+
+# Wait for that master to join the quorum and observe it is using the higher verison
+$ ./bin/alluxio fsadmin report
+...
+Raft journal addresses:
+  master-0:19200
+  master-1:19200
+  master-2:19200
+Master Address        State      Version       REVISION
+master-0:19998        PRIMARY  alluxio-2.9.0  abcde
+master-1:19998        STANDBY  alluxio-2.9.1  hijkl
+master-2:19998        STANDBY  alluxio-2.9.0  abcde
+
+# Do the same for the other standby master master2
+
+# Manually failover the primary to one upgraded standby master, now master-0 becomes standby
+$ ./bin/alluxio fsadmin journal quorum elect -address master-1:19200
+
+# Restart master-0 with the higher version and wait for it to re-join the quorum
+# Then you should observe all masters are on the higher version
+$ ./bin/alluxio fsadmin report
+...
+Raft journal addresses:
+  master-0:19200
+  master-1:19200
+  master-2:19200
+Master Address        State      Version       REVISION
+master-0:19998        STANDBY  alluxio-2.9.1  hijkl
+master-1:19998        PRIMARY  alluxio-2.9.1  hijkl
+master-2:19998        STANDBY  alluxio-2.9.1  hijkl
+
+# Wait for all workers register with the new primary, and run tests to validate the service
+$ bin/alluxio runTests
+```
+
+Similarly, if the HA is on UFS Journal (using ZooKeeper), the admin can restart masters one by one in the same order.
+The only difference is there is no command to manually trigger a primary master failover. The admin can
+directly kill the primary master process, after a brief timeout, one standby master will realize and become the new primary.
+
+### Rolling upgrade/restart workers
+
+If the admin wants to restart workers without interrupting ongoing service, there are now ways to rolling restart
+all workers without failing ongoing I/O requests. Typically, we want to restart workers to apply configuration changes,
+or to upgrade to a newer version.
+
+A typical workflow of rolling upgrade workers looks as follows:
+```shell
+# First check all worker nodes in the cluster
+$ ./bin/alluxio fsadmin report capacity
+...
+Worker Name        State            Last Heartbeat   Storage       MEM              Version          Revision
+data-worker-1      ACTIVE           1                capacity      10.67GB          2.9.0            abcde
+                                                     used          0B (0%)
+data-worker-0      ACTIVE           2                capacity      10.67GB          2.9.0            abcde
+                                                     used          0B (0%)
+data-worker-2      ACTIVE           0                capacity      10.67GB          2.9.0            abcde
+                                                     used          0B (0%)
+...
+
+# Pick a batch of workers to decommission, e.g. this batch is 2 workers
+$ ./bin/alluxio fsadmin decommissionWorker -a data-worker-0,data-worker-1 -w 5m
+Decommissioning worker data-worker-0:30000
+Set worker data-worker-0:30000 decommissioned on master
+Decommissioning worker data-worker-1:30000
+Set worker data-worker-1:30000 decommissioned on master
+Sent decommission messages to the master, 0 failed and 2 succeeded
+Failed ones: []
+Clients take alluxio.user.worker.list.refresh.interval=2min to be updated on the new worker list so this command will block for the same amount of time to ensure the update propagates to clients in the cluster.
+Verifying the decommission has taken effect by listing all available workers on the master
+Now on master the available workers are: [data-worker-2,data-worker-3,...]
+Polling status from worker data-worker-0:30000
+Polling status from worker data-worker-1:30000
+...
+There is no operation on worker data-worker-0:30000 for 20 times in a row. Worker is considered safe to stop.
+Polling status from worker data-worker-1:30000
+There is no operation on worker data-worker-1:30000 for 20 times in a row. Worker is considered safe to stop.
+Waited 3 minutes for workers to be idle
+All workers are successfully decommissioned and now idle. Safe to kill or restart this batch of workers now.
+
+# Now you will be able to observe those workers' state have changed from ACTIVE to DECOMMISSIONED.
+$ ./bin/alluxio fsadmin report capacity
+...
+Worker Name        State            Last Heartbeat   Storage       MEM              Version          Revision
+data-worker-1      DECOMMISSIONED   1                capacity      10.67GB          2.9.0            abcde
+                                                     used          0B (0%)
+data-worker-0      DECOMMISSIONED   2                capacity      10.67GB          2.9.0            abcde
+                                                     used          0B (0%)
+data-worker-2      ACTIVE           0                capacity      10.67GB          2.9.0            abcde
+                                                     used          0B (0%)
+
+# Then you can restart the decommissioned workers. The workers will start normally and join the cluster.
+$ ssh data-worker-0
+$ ./bin/alluxio-start.sh worker
+...
+
+# Now you will be able to observe those workers become ACTIVE again and have a higher version
+$ ./bin/alluxio fsadmin report capacity
+...
+Worker Name        State            Last Heartbeat   Storage       MEM              Version          Revision
+data-worker-1      ACTIVE           1                capacity      10.67GB          2.9.1            hijkl
+                                                     used          0B (0%)
+data-worker-0      ACTIVE           2                capacity      10.67GB          2.9.1            hijkl
+                                                     used          0B (0%)
+data-worker-2      ACTIVE           0                capacity      10.67GB          2.9.0            abcde
+                                                     used          0B (0%)
+
+# You can run I/O tests against the upgraded workers to validate they are serving, before moving to upgrade the next batch
+$ bin/alluxio runTests --workers data-worker-0,data-worker-1
+
+# Keep performing the steps above until all workers are upgraded
+```
+
+See more details about the `decommissionWorker` command in
+[documentation]({{ '/en/operation/Admin-CLI.html' | relativize_url }}#decommissionworker).
+
+### Rolling restart/upgrade other components
+
+Other components like the Job Master, Job Worker and Proxy do not support rolling upgrade at the moment.
+The admin can manually restart them in batches.
+
 ## Additional Options
 
 ### Alluxio worker ramdisk cache persistence

--- a/docs/en/operation/Admin-CLI.md
+++ b/docs/en/operation/Admin-CLI.md
@@ -411,7 +411,7 @@ $ ./bin/alluxio fsadmin decommissionWorker --addresses data-worker-0,data-worker
 ```
 The arguments are explained as follows:
 
-`--address/-a` is a required argument, followed by a list of comma-separated worker addresses. Each worker address is <host>:<web port>.
+`--address/-a` is a required argument, followed by a list of comma-separated worker addresses. Each worker address is `<host>:<web port>`.
 Unlike many other commands which specify the RPC port, we use the web port here because the command will monitor the worker's workload
 exposed at the web port. If the port is not specified, the value in `alluxio.worker.web.port` will be used. Note that `alluxio.worker.web.port`
 will be resolved from the node where this command is run.
@@ -501,7 +501,7 @@ data-worker-0      DECOMMISSIONED   2                capacity      10.67GB      
                                                      used          0B (0%)
 data-worker-2      ACTIVE           0                capacity      10.67GB          2.9.0            abcde
                                                      used          0B (0%)
-                                                     
+
 # Then you can restart the decommissioned workers. The workers will start normally and join the cluster.
 $ ssh data-worker-0
 $ ./bin/alluxio-start.sh worker
@@ -527,11 +527,12 @@ $ bin/alluxio runTests --workers data-worker-0,data-worker-1
 This command is idempotent and can be retried, but the admin is advised to manually check if there's an error. 
 
 The return codes have different meanings:
-0(OK): All workers are successfully decommissioned and now idle. Safe to kill or restart this batch of workers now.
-1(DECOMMISSION_FAILED): Failed to decommission all workers. The admin should double check the worker addresses and the primary master status.
-2(LOST_MASTER_CONNECTION): Lost connection to the primary master while this command is running. This suggests the configured master address is wrong or the primary master failed over.
-3(WORKERS_NOT_IDLE): Some workers were still not idle after the wait. Either the wait time is too short or those workers failed to mark decommissioned. The admin should manually intervene and check those workers.
-10(LOST_SOME_WORKERS): Workers are decommissioned but some or all workers lost contact while this command is running. If a worker is not serving then it is safe to kill or restart. But the admin is advised to double check the status of those workers.
+
+1. `0(OK)`: All workers are successfully decommissioned and now idle. Safe to kill or restart this batch of workers now.
+2. `1(DECOMMISSION_FAILED)`: Failed to decommission all workers. The admin should double check the worker addresses and the primary master status.
+3. `2(LOST_MASTER_CONNECTION)`: Lost connection to the primary master while this command is running. This suggests the configured master address is wrong or the primary master failed over.
+4. `3(WORKERS_NOT_IDLE)`: Some workers were still not idle after the wait. Either the wait time is too short or those workers failed to mark decommissioned. The admin should manually intervene and check those workers.
+5. `10(LOST_SOME_WORKERS)`: Workers are decommissioned but some or all workers lost contact while this command is running. If a worker is not serving then it is safe to kill or restart. But the admin is advised to double check the status of those workers.
 
 ### enableWorker
 

--- a/docs/en/operation/Admin-CLI.md
+++ b/docs/en/operation/Admin-CLI.md
@@ -442,6 +442,7 @@ A worker is considered "idle" if it is not actively serving RPCs(including contr
 The `decommissionWorker` command stops all clients from using those workers, and waits for all ongoing requests to complete.
 The command waits for those all clients to stop using those workers, and waits for those workers to become idle,
 so when this command returns success(exit code 0), it is safe for the admin to kill/restart those worker processes.
+
 The primary Alluxio master maintains a list of available Alluxio workers, and all Alluxio components(including Proxy, Job Master/Job Worker and Client)
 will regularly refresh this list with the primary master. The refresh interval is defined by `alluxio.user.worker.list.refresh.interval`.
 So after those workers are taken off the available list, after another refresh interval has elapsed,


### PR DESCRIPTION
### What changes are proposed in this pull request?

This is the doc update from a few recent commits:
1. https://github.com/Alluxio/alluxio/commit/aee3c5cb960b2e472f4fcdb86e731ca3b91d2f8c
2. https://github.com/Alluxio/alluxio/commit/9a4e154e7293667572fec25c63136462fb58a345
3. https://github.com/Alluxio/alluxio/commit/dbac084c1e1d89c1e9253da036746e2df9e1ef14
4. https://github.com/Alluxio/alluxio/commit/8da59539201cff376c33256846bd565d976a148e
5. https://github.com/Alluxio/alluxio/commit/141ee0e567a4c6c60907f85ea66b828704bd761d
6. https://github.com/Alluxio/alluxio/commit/26257e6f35c57d937f6f5bdee831facc2fcf7e1a

In short, a few improvements have been added that the admin can now see the version/revision of the running Alluxio components in the cluster. A few commands were also added to help with gracefully decommissioning/restarting workers in the cluster.

### Why are the changes needed?

This doc change helps users understand how to utilize those features.

