### PR TITLE
Fix startup master health check

### DIFF
--- a/shell/src/main/java/alluxio/common/RpcPortHealthCheckClient.java
+++ b/shell/src/main/java/alluxio/common/RpcPortHealthCheckClient.java
@@ -14,6 +14,7 @@ package alluxio.common;
 import alluxio.HealthCheckClient;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.AlluxioStatusException;
+import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.ServiceType;
 import alluxio.retry.RetryPolicy;
@@ -66,7 +67,7 @@ public class RpcPortHealthCheckClient implements HealthCheckClient {
         NetworkAddressUtils.pingService(mNodeAddress, mServiceType, mConf, mUserState);
         LOG.debug("Successfully connected to {}", mNodeAddress);
         return true;
-      } catch (UnavailableException e) {
+      } catch (UnavailableException | NotFoundException e) {
         LOG.debug("Failed to connect to {} on attempt #{}", mNodeAddress,
             retry.getAttemptCount());
       } catch (AlluxioStatusException e) {


### PR DESCRIPTION
Fix #17382.
Follower masters have a gRPC server always active. When the `MasterHealthCheckClient` connects to the gRPC server, it may find that some services aren't registered (NotFound) rather than unavailable. 
This manifests in a bug where `bin/alluxio-start.sh master` performs a health check after starting a master and incorrectly reports the master as unhealthy. 