### PR TITLE
Fix building warnings due to POM issues

### DIFF
--- a/common/transport/pom.xml
+++ b/common/transport/pom.xml
@@ -137,6 +137,7 @@
       <plugin>
         <groupId>com.salesforce.servicelibs</groupId>
         <artifactId>proto-backwards-compatibility</artifactId>
+        <version>1.0.7</version>
         <configuration>
           <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
         </configuration>

--- a/dora/core/client/fs/pom.xml
+++ b/dora/core/client/fs/pom.xml
@@ -106,12 +106,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-local</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/dora/microbench/pom.xml
+++ b/dora/microbench/pom.xml
@@ -61,17 +61,6 @@
       <artifactId>alluxio-core-client-fs</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-server-master</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-tests</artifactId>
-      <version>${project.version}</version>
-      <scope>compile</scope>
-    </dependency>
 
     <!-- external dependencies -->
     <dependency>
@@ -98,16 +87,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dora/pom.xml
+++ b/dora/pom.xml
@@ -20,7 +20,7 @@
   <artifactId>alluxio-dora</artifactId>
   <packaging>pom</packaging>
   <name>Alluxio Dora</name>
-  <description>Parent POM for Alluxio common</description>
+  <description>Parent POM for Alluxio DORA</description>
 
   <modules>
     <module>core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -285,12 +285,7 @@
         <artifactId>java-xmlbuilder</artifactId>
         <version>1.3</version>
       </dependency>
-      <dependency>
-        <groupId>com.salesforce.servicelibs</groupId>
-        <artifactId>proto-backwards-compatibility</artifactId>
-        <version>1.0.7</version>
-      </dependency>
-      <dependency>
+       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
         <version>${jaxb.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
         <artifactId>java-xmlbuilder</artifactId>
         <version>1.3</version>
       </dependency>
-       <dependency>
+      <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
         <version>${jaxb.version}</version>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the following warnings

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.alluxio:alluxio-core-transport:jar:295-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for com.salesforce.servicelibs:proto-backwards-compatibility is missing. @ line 137, column 15
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.alluxio:alluxio-core-client-fs:jar:295-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.alluxio:alluxio-underfs-local:jar -> duplicate declaration of version ${project.version} @ line 109, column 17
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.alluxio:alluxio-microbench:jar:295-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.alluxio:alluxio-core-server-master:jar -> duplicate declaration of version ${project.version} @ line 64, column 17
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.alluxio:alluxio-tests:jar -> duplicate declaration of version ${project.version} @ line 69, column 17
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: junit:junit:jar -> duplicate declaration of version (?) @ line 103, column 17
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.mockito:mockito-core:jar -> duplicate declaration of version (?) @ line 108, column 17
```

### Why are the changes needed?

Code health

### Does this PR introduce any user facing changes?

No