### PR TITLE
Fix legacy config in licence checking

### DIFF
--- a/dora/integration/pom.xml
+++ b/dora/integration/pom.xml
@@ -32,30 +32,4 @@
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
   </properties>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>com.mycila</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>kubernetes/operator/alluxio/hack/boilerplate.go.txt</exclude>
-          </excludes>
-          <mapping>
-            <alluxio>SCRIPT_STYLE</alluxio>
-            <go>SLASHSTAR_STYLE</go>
-            <java>SLASHSTAR_STYLE</java>
-            <tsx>SLASHSTAR_STYLE</tsx>
-            <scss>SLASHSTAR_STYLE</scss>
-            <properties.template>SCRIPT_STYLE</properties.template>
-            <sh.template>SCRIPT_STYLE</sh.template>
-            <workers>SCRIPT_STYLE</workers>
-            <xml.template>XML_STYLE</xml.template>
-          </mapping>
-          <useDefaultMapping>true</useDefaultMapping>
-          <strictCheck>true</strictCheck>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/dora/microbench/pom.xml
+++ b/dora/microbench/pom.xml
@@ -101,12 +101,16 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
-          <excludes>
-            <!-- exclude build configuration files -->
-            <exclude>build/**/*</exclude>
-            <!-- exclude generated code -->
-            <exclude>target/**</exclude>
-          </excludes>
+          <licenseSets>
+            <licenseSet>
+              <excludes>
+                <!-- exclude build configuration files -->
+                <exclude>build/**/*</exclude>
+                <!-- exclude generated code -->
+                <exclude>target/**</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -896,7 +896,7 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>4.0.rc1</version>
+          <version>4.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1211,64 +1211,68 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
-          <header>${build.path}/license/HEADER.txt</header>
-          <failIfMissing>true</failIfMissing>
           <aggregate>false</aggregate>
-          <excludes>
+          <failIfMissing>true</failIfMissing>
+          <licenseSets>
+            <licenseSet>
+              <header>${build.path}/license/HEADER.txt</header>
+              <excludes>
 
-            <!-- Code Exclusions -->
-            <exclude>**/src/main/resources/*</exclude>
-            <exclude>**/src/proto/**</exclude>
-            <exclude>**/src/deb/**/*</exclude>
-            <exclude>**/src/test/resources/**</exclude>
-            <exclude>**/\?/.java/**/*</exclude>
+                <!-- Code Exclusions -->
+                <exclude>**/src/main/resources/*</exclude>
+                <exclude>**/src/proto/**</exclude>
+                <exclude>**/src/deb/**/*</exclude>
+                <exclude>**/src/test/resources/**</exclude>
+                <exclude>**/\?/.java/**/*</exclude>
 
-            <!-- Build and Packaging Exclusions -->
-            <exclude>webui/node_modules/*</exclude>
-            <exclude>build/**/*</exclude>
-            <exclude>conf/alluxio-env.sh</exclude>
-            <exclude>conf/alluxio-site.properties</exclude>
-            <exclude>conf/masters</exclude>
-            <exclude>conf/tiered_identity.sh</exclude>
-            <exclude>conf/workers</exclude>
-            <exclude>dev/scripts/src/alluxio.org/go.mod</exclude>
-            <exclude>dev/scripts/src/alluxio.org/go.sum</exclude>
-            <exclude>dev/scripts/tarballs/**/*</exclude>
-            <exclude>dev/scripts/workdir/**/*</exclude>
-            <exclude>generated/**</exclude>
-            <exclude>**/.checkstyle</exclude>
-            <exclude>**/src/main/assembly/*</exclude>
-            <exclude>**/.idea/**</exclude>
-            <exclude>webui/**/.nvmrc</exclude>
-            <exclude>webui/**/*.svg</exclude>
-            <exclude>webui/**/.env*</exclude>
-            <exclude>webui/**/node/**</exclude>
-            <exclude>webui/**/node_modules/**</exclude>
-            <exclude>webui/**/src/**/*.css</exclude>
-            <exclude>webui/**/build/**</exclude>
+                <!-- Build and Packaging Exclusions -->
+                <exclude>webui/node_modules/*</exclude>
+                <exclude>build/**/*</exclude>
+                <exclude>conf/alluxio-env.sh</exclude>
+                <exclude>conf/alluxio-site.properties</exclude>
+                <exclude>conf/masters</exclude>
+                <exclude>conf/tiered_identity.sh</exclude>
+                <exclude>conf/workers</exclude>
+                <exclude>dev/scripts/src/alluxio.org/go.mod</exclude>
+                <exclude>dev/scripts/src/alluxio.org/go.sum</exclude>
+                <exclude>dev/scripts/tarballs/**/*</exclude>
+                <exclude>dev/scripts/workdir/**/*</exclude>
+                <exclude>generated/**</exclude>
+                <exclude>**/.checkstyle</exclude>
+                <exclude>**/src/main/assembly/*</exclude>
+                <exclude>**/.idea/**</exclude>
+                <exclude>webui/**/.nvmrc</exclude>
+                <exclude>webui/**/*.svg</exclude>
+                <exclude>webui/**/.env*</exclude>
+                <exclude>webui/**/node/**</exclude>
+                <exclude>webui/**/node_modules/**</exclude>
+                <exclude>webui/**/src/**/*.css</exclude>
+                <exclude>webui/**/build/**</exclude>
 
-            <!-- Documentation Exclusions -->
-            <exclude>docs/**/*</exclude>
-            <exclude>LICENSE</exclude>
-            <exclude>NOTICE</exclude>
-            <exclude>templates/*</exclude>
+                <!-- Documentation Exclusions -->
+                <exclude>docs/**/*</exclude>
+                <exclude>LICENSE</exclude>
+                <exclude>NOTICE</exclude>
+                <exclude>templates/*</exclude>
 
-            <!-- Default Local File System Exclusions -->
-            <exclude>logs/**/*</exclude>
-            <exclude>journal/**/*</exclude>
-            <exclude>metastore/**/*</exclude>
-            <exclude>underFSStorage/**/*</exclude>
-          </excludes>
+                <!-- Default Local File System Exclusions -->
+                <exclude>logs/**/*</exclude>
+                <exclude>journal/**/*</exclude>
+                <exclude>metastore/**/*</exclude>
+                <exclude>underFSStorage/**/*</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
           <mapping>
             <alluxio>SCRIPT_STYLE</alluxio>
-            <go>SLASHSTAR_STYLE</go>
             <cc>SLASHSTAR_STYLE</cc>
+            <go>SLASHSTAR_STYLE</go>
             <h>SLASHSTAR_STYLE</h>
             <java>SLASHSTAR_STYLE</java>
-            <tsx>SLASHSTAR_STYLE</tsx>
-            <scss>SLASHSTAR_STYLE</scss>
             <properties.template>SCRIPT_STYLE</properties.template>
+            <scss>SLASHSTAR_STYLE</scss>
             <sh.template>SCRIPT_STYLE</sh.template>
+            <tsx>SLASHSTAR_STYLE</tsx>
             <workers>SCRIPT_STYLE</workers>
             <xml.template>XML_STYLE</xml.template>
           </mapping>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -165,15 +165,19 @@
           <mapping>
             <ts>PHP_STYLE</ts>
           </mapping>
-          <excludes>
-            <exclude>**/node_modules/**</exclude>
-            <exclude>node/**</exclude>
-            <exclude>**/build/**</exclude>
-            <exclude>**/*.snap</exclude>
-            <exclude>**/coverage/**</exclude>
-            <!-- auto-generated css -->
-            <exclude>**/*.css</exclude>
-          </excludes>
+          <licenseSets>
+            <licenseSet>
+              <excludes>
+                <exclude>**/node_modules/**</exclude>
+                <exclude>node/**</exclude>
+                <exclude>**/build/**</exclude>
+                <exclude>**/*.snap</exclude>
+                <exclude>**/coverage/**</exclude>
+                <!-- auto-generated css -->
+                <exclude>**/*.css</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Fix maven building warnings like "[warning] parameter 'legacyConfigExcludes' (user property 'license.excludes') is deprecated: use {@link licenseset#excludes}". The previous way to config `license-maven-plugin` is deprecated.

### Why are the changes needed?

Code hygiene

### Does this PR introduce any user facing changes?

No
