### PR TITLE
Add config check for alluxio.master.ttl.checker.interval at start time

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -490,8 +490,8 @@ public class InstancedConfiguration implements AlluxioConfiguration {
   private void checkMasterTTLInterval() {
     long interval = getMs(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS);
     checkState(interval > 0, 
-        "invalid value of alluxio.master.ttl.checker.interval %s, "
-        + "it must be lager than 0", interval);
+        "invalid value of " + PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS + "=%s, "
+        + "it must be greater than 0", interval);
   }
 
   /**

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -391,6 +391,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     checkTieredStorage();
     checkMasterThrottleThresholds();
     checkCheckpointZipConfig();
+    checkMasterTTLInterval();
   }
 
   @Override
@@ -480,6 +481,17 @@ public class InstancedConfiguration implements AlluxioConfiguration {
       checkState(System.getProperty(PropertyKey.Name.WORKER_WEB_PORT) == null,
           message, PropertyKey.WORKER_WEB_PORT);
     }
+  }
+  
+  /**
+   * Checks that master TTL checker interval
+   * @throws IllegalStateException if the TTL check interval <= 0
+   */
+  private void checkMasterTTLInterval() {
+    long interval = getMs(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS);
+    checkState(interval > 0, 
+        "invalid value of alluxio.master.ttl.checker.interval %s, "
+        + "it must be lager than 0", interval);
   }
 
   /**

--- a/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
@@ -675,6 +675,7 @@ public class InstancedConfigurationTest {
   public void shortMasterHeartBeatTimeout() {
     mConfiguration.set(PropertyKey.MASTER_STANDBY_HEARTBEAT_INTERVAL, "5min");
     mConfiguration.set(PropertyKey.MASTER_HEARTBEAT_TIMEOUT, "4min");
+    mConfiguration.set(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, "0");
     mThrown.expect(IllegalStateException.class);
     mConfiguration.validate();
   }

--- a/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
@@ -675,6 +675,12 @@ public class InstancedConfigurationTest {
   public void shortMasterHeartBeatTimeout() {
     mConfiguration.set(PropertyKey.MASTER_STANDBY_HEARTBEAT_INTERVAL, "5min");
     mConfiguration.set(PropertyKey.MASTER_HEARTBEAT_TIMEOUT, "4min");
+    mThrown.expect(IllegalStateException.class);
+    mConfiguration.validate();
+  }
+  
+  @Test
+  public void setMasterTTLIntervalZero() {
     mConfiguration.set(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, "0");
     mThrown.expect(IllegalStateException.class);
     mConfiguration.validate();


### PR DESCRIPTION
### What changes are proposed in this pull request?

#17405

### Why are the changes needed?
add pre-check for alluxio.master.ttl.checker.interval, to avoid resources waste when starting alluxio.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
