### PR TITLE
Bump grpc & netty version

### DIFF
--- a/dora/core/common/pom.xml
+++ b/dora/core/common/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>2.0.26.Final</version>
+      <version>2.0.56.Final</version>
     </dependency>
 
     <!-- Internal dependencies -->
@@ -153,6 +153,12 @@
       <artifactId>netty-buffer</artifactId>
       <version>${netty.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${jupiter.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -128,9 +128,9 @@
     <build.path>build</build.path>
     <catalyst.version>1.2.1</catalyst.version>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
-    <grpc.version>1.37.0</grpc.version>
+    <grpc.version>1.54.1</grpc.version>
     <gson.version>2.8.9</gson.version>
-    <netty.version>4.1.52.Final</netty.version>
+    <netty.version>4.1.87.Final</netty.version>
     <rocksdb.version>7.0.3</rocksdb.version>
     <hadoop.version>3.3.1</hadoop.version>
     <jacoco.version>0.8.5</jacoco.version>
@@ -139,6 +139,7 @@
     <jersey.version>2.34</jersey.version>
     <jetty.version>9.4.46.v20220331</jetty.version>
     <junit.version>4.13.1</junit.version>
+    <jupiter.version>5.9.2</jupiter.version>
     <log4j.version>2.17.1</log4j.version>
     <maven.version>3.8.6</maven.version>
     <metrics.version>4.1.11</metrics.version>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Bump grpc & netty version

### Why are the changes needed?

1. We want to try netty io_uring feature 
2. The new aws client we are going to introduce relies on newer version of netty 
3. Current grpc & netty versions do not match. (https://github.com/grpc/grpc-java/blob/master/SECURITY.md)

### Does this PR introduce any user facing changes?

N/A