### PR TITLE
Merge cherry-picked s3 ufs changes from 2.x branch

### DIFF
--- a/dora/core/common/src/main/java/alluxio/underfs/AsyncUfsClient.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/AsyncUfsClient.java
@@ -1,0 +1,46 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs;
+
+import alluxio.file.options.DescendantType;
+
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+
+/**
+ * The async UFS client interface.
+ */
+public interface AsyncUfsClient {
+
+  /**
+   * Lists the ufs statuses for a given path. The {@link UfsStatus#getName()}
+   * function for the returned values should include the full path of each
+   * item from the UFS root (not including the bucket name for object stores).
+   * It differs from a traditional listing in that if the input variable
+   * checkStatus is true, the {@link UfsStatus} for the base path should
+   * be included at the start of the results. The function should return
+   * immediately, and perform the operation asynchronously.
+   * @param path the path in ufs
+   * @param continuationToken the continuation token
+   * @param startAfter the start after string where the loading starts from
+   * @param descendantType the load descendant type (NONE/ONE/ALL)
+   * @param checkStatus if true the call will perform a GetStatus on the path
+   *                    to see if an object exists, which should be returned
+   *                    as part of the result
+   * @param onComplete the callback when the load is complete
+   * @param onError the callback when the load encountered an error
+   */
+  void performListingAsync(
+      String path, @Nullable String continuationToken, @Nullable String startAfter,
+      DescendantType descendantType, boolean checkStatus, Consumer<UfsLoadResult> onComplete,
+      Consumer<Throwable> onError);
+}

--- a/dora/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -200,7 +200,6 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
     if (result == null) {
       return null;
     }
-    Arrays.sort(result, Comparator.comparing(UfsStatus::getName));
     return Iterators.forArray(result);
   }
 

--- a/dora/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -16,6 +16,7 @@ import alluxio.Constants;
 import alluxio.SyncInfo;
 import alluxio.collections.Pair;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.file.options.DescendantType;
 import alluxio.security.authorization.AccessControlList;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
@@ -24,21 +25,31 @@ import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
+import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterators;
+import com.google.common.io.Closer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -57,6 +68,8 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
   /** UFS Configuration options. */
   protected final UnderFileSystemConfiguration mUfsConf;
 
+  private final ExecutorService mAsyncIOExecutor;
+
   /**
    * Constructs an {@link BaseUnderFileSystem}.
    *
@@ -66,6 +79,19 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
   protected BaseUnderFileSystem(AlluxioURI uri, UnderFileSystemConfiguration ufsConf) {
     mUri = Preconditions.checkNotNull(uri, "uri");
     mUfsConf = Preconditions.checkNotNull(ufsConf, "ufsConf");
+    mAsyncIOExecutor = Executors.newCachedThreadPool(
+        ThreadFactoryUtils.build(uri.getPath() + "IOThread", true));
+  }
+
+  @Override
+  public void close() throws IOException {
+    try (Closer closer = Closer.create()) {
+      closer.register(() -> {
+        if (mAsyncIOExecutor != null) {
+          mAsyncIOExecutor.shutdown();
+        }
+      });
+    }
   }
 
   @Override
@@ -161,6 +187,94 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
   @Override
   public boolean isSeekable() {
     return false;
+  }
+
+  @Nullable
+  @Override
+  public Iterator<UfsStatus> listStatusIterable(
+      String path, ListOptions options, String startAfter, int batchSize) throws IOException {
+    // Calling this method on non s3 UFS might result in OOM because batch based fetching
+    // is not supported and this method essentially fetches all ufs status and converts it to
+    // an iterator.
+    UfsStatus[] result = listStatus(path, options);
+    if (result == null) {
+      return null;
+    }
+    Arrays.sort(result, Comparator.comparing(UfsStatus::getName));
+    return Iterators.forArray(result);
+  }
+
+  @Override
+  public void performListingAsync(
+      String path, @Nullable String continuationToken, @Nullable String startAfter,
+      DescendantType descendantType, boolean checkStatus, Consumer<UfsLoadResult> onComplete,
+      Consumer<Throwable> onError) {
+    mAsyncIOExecutor.submit(() -> {
+      try {
+        UfsStatus baseStatus = null;
+        if (checkStatus) {
+          try {
+            baseStatus = getStatus(path);
+            if (baseStatus == null && !isObjectStorage()) {
+              onComplete.accept(new UfsLoadResult(Stream.empty(), 0,
+                  null, null, false, false, false));
+              return;
+            }
+            if (baseStatus != null && (descendantType == DescendantType.NONE
+                || baseStatus.isFile())) {
+              onComplete.accept(new UfsLoadResult(Stream.of(baseStatus), 1,
+                  null, new AlluxioURI(baseStatus.getName()), false,
+                  baseStatus.isFile(), isObjectStorage()));
+              return;
+            }
+          } catch (FileNotFoundException e) {
+            // if we are not using object storage we know nothing exists at the path,
+            // so just return an empty result
+            if (!isObjectStorage()) {
+              onComplete.accept(new UfsLoadResult(Stream.empty(), 0,
+                  null, null, false, false, false));
+              return;
+            }
+          }
+        }
+        UfsStatus[] items = listStatus(path, ListOptions.defaults()
+            .setRecursive(descendantType == DescendantType.ALL));
+        if (items != null) {
+          if (descendantType == DescendantType.NONE && items.length > 0) {
+            assert isObjectStorage() && this instanceof ObjectUnderFileSystem;
+            ObjectUnderFileSystem.ObjectPermissions permissions =
+                ((ObjectUnderFileSystem) this).getPermissions();
+            items = new UfsStatus[] {
+                new UfsDirectoryStatus("", permissions.getOwner(), permissions.getGroup(),
+                    permissions.getMode())};
+          }
+          Arrays.sort(items, Comparator.comparing(UfsStatus::getName));
+          for (UfsStatus item: items) {
+            // performListingAsync is used by metadata sync v2
+            // which expects the name of an item to be a full path
+            item.setName(PathUtils.concatPath(path, item.getName()));
+          }
+        }
+        if (items != null && items.length == 0) {
+          items = null;
+        }
+        UfsStatus firstItem = baseStatus != null ? baseStatus
+            : items != null ? items[0] : null;
+        UfsStatus lastItem = items == null ? firstItem
+            : items[items.length - 1];
+        Stream<UfsStatus> itemStream = items == null ? Stream.empty() : Arrays.stream(items);
+        int itemCount = items == null ? 0 : items.length;
+        if (baseStatus != null) {
+          itemStream = Stream.concat(Stream.of(baseStatus), itemStream);
+          itemCount++;
+        }
+        onComplete.accept(new UfsLoadResult(itemStream, itemCount,
+            null, lastItem == null ? null : new AlluxioURI(lastItem.getName()), false,
+            firstItem != null && firstItem.isFile(), isObjectStorage()));
+      } catch (Throwable t) {
+        onError.accept(t);
+      }
+    });
   }
 
   @Override

--- a/dora/core/common/src/main/java/alluxio/underfs/UfsLoadResult.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/UfsLoadResult.java
@@ -1,0 +1,110 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs;
+
+import alluxio.AlluxioURI;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+/**
+ The UfsLoadResult represents the result of a load operation
+ on an Under File System (UFS).
+ It contains information about the loaded items, such as the count,
+ whether it is truncated or not, and the continuation token.
+ */
+public class UfsLoadResult {
+
+  private final Stream<UfsStatus> mItems;
+  private final String mContinuationToken;
+  private final boolean mIsTruncated;
+  private final int mItemsCount;
+  private final AlluxioURI mLastItem;
+  private final boolean mFirstIsFile;
+  private final boolean mIsObjectStore;
+
+  /**
+   * Constructs a new instance of {@link UfsLoadResult}.
+   *
+   * @param items the stream of loaded items
+   * @param itemsCount the count of loaded items
+   * @param continuationToken the continuation token for loading more items
+   * @param lastItem the URI of the last item that was loaded
+   * @param isTruncated whether the load operation was truncated due to reaching a limit
+   * @param firstIsFile whether the first item in the stream is a file
+   * @param isObjectStore whether the under file system is an object store
+   */
+  public UfsLoadResult(
+      Stream<UfsStatus> items, int itemsCount, @Nullable String continuationToken,
+      @Nullable AlluxioURI lastItem, boolean isTruncated, boolean firstIsFile,
+      boolean isObjectStore) {
+    mItems = items;
+    mContinuationToken = continuationToken;
+    mIsTruncated = isTruncated;
+    mItemsCount = itemsCount;
+    mLastItem = lastItem;
+    mFirstIsFile = firstIsFile;
+    mIsObjectStore = isObjectStore;
+  }
+
+  /**
+   * @return true if the under file system is an object store, false otherwise
+   */
+  public boolean isIsObjectStore() {
+    return mIsObjectStore;
+  }
+
+  /**
+   * @return true if the first item in the stream is a file, false otherwise
+   */
+  public boolean isFirstFile() {
+    return mFirstIsFile;
+  }
+
+  /**
+   * @return an optional containing the URI of the last item that was loaded,
+   * or empty if no items were loaded
+   */
+  public Optional<AlluxioURI> getLastItem() {
+    return Optional.ofNullable(mLastItem);
+  }
+
+  /**
+   * @return the count of loaded items
+   */
+  public int getItemsCount() {
+    return mItemsCount;
+  }
+
+  /**
+   * @return true if the load operation was truncated, false otherwise
+   */
+  public boolean isTruncated() {
+    return mIsTruncated;
+  }
+
+  /**
+   * @return the stream of loaded items
+   */
+  public Stream<UfsStatus> getItems() {
+    return mItems;
+  }
+
+  /**
+   * @return the continuation token for loading more items,
+   * or null if there are no more items to load
+   */
+  public String getContinuationToken() {
+    return mContinuationToken;
+  }
+}

--- a/dora/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -59,7 +60,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @PublicApi
 @ThreadSafe
 // TODO(adit); API calls should use a URI instead of a String wherever appropriate
-public interface UnderFileSystem extends Closeable {
+public interface UnderFileSystem extends Closeable, AsyncUfsClient {
   /**
    * The factory for the {@link UnderFileSystem}.
    */
@@ -652,6 +653,20 @@ public interface UnderFileSystem extends Closeable {
    */
   @Nullable
   UfsStatus[] listStatus(String path, ListOptions options) throws IOException;
+
+  /**
+   * Lists the ufs statuses iteratively.
+   *
+   * @param path the abstract pathname to list
+   * @param options for list directory
+   * @param startAfter the start after token
+   * @param batchSize the batch size
+   * @return An iterator of ufs status. Returns
+   *  {@code null} if this abstract pathname does not denote a directory.
+   */
+  @Nullable
+  Iterator<UfsStatus> listStatusIterable(
+      String path, ListOptions options, String startAfter, int batchSize) throws IOException;
 
   /**
    * Returns an array of statuses of the files and directories in the directory denoted by this

--- a/dora/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -19,7 +19,9 @@ import alluxio.collections.Pair;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.runtime.AlluxioRuntimeException;
+import alluxio.exception.runtime.InternalRuntimeException;
 import alluxio.exception.status.UnimplementedException;
+import alluxio.file.options.DescendantType;
 import alluxio.metrics.Metric;
 import alluxio.metrics.MetricInfo;
 import alluxio.metrics.MetricsSystem;
@@ -38,14 +40,17 @@ import alluxio.util.SecurityUtils;
 
 import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterators;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 /**
@@ -819,6 +824,38 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
     });
   }
 
+  @Override
+  public Iterator<UfsStatus> listStatusIterable(
+      String path, ListOptions options, String startAfter,
+      int batchSize) throws IOException {
+    return call(new UfsCallable<Iterator<UfsStatus>>() {
+      @Override
+      public Iterator<UfsStatus> call() throws IOException {
+        Iterator<UfsStatus> result =
+            mUnderFileSystem.listStatusIterable(path, options, startAfter, batchSize);
+        return filterInvalidPaths(result, path);
+      }
+
+      @Override
+      public String methodName() {
+        return "ListStatusIterable";
+      }
+
+      @Override
+      public String toString() {
+        return String.format("path=%s, options=%s", path, options);
+      }
+    });
+  }
+
+  @Nullable
+  Iterator<UfsStatus> filterInvalidPaths(Iterator<UfsStatus> statuses, String listedPath) {
+    if (statuses == null) {
+      return null;
+    }
+    return Iterators.filter(statuses, (it) -> !it.getName().contains("?"));
+  }
+
   @Nullable
   private UfsStatus[] filterInvalidPaths(UfsStatus[] statuses, String listedPath) {
     // This is a temporary fix to prevent us from choking on paths containing '?'.
@@ -1250,6 +1287,37 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
    */
   public UnderFileSystem getUnderFileSystem() {
     return mUnderFileSystem;
+  }
+
+  @Override
+  public void performListingAsync(
+      String path, @Nullable String continuationToken, @Nullable String startAfter,
+      DescendantType descendantType, boolean checkStatus, Consumer<UfsLoadResult> onComplete,
+      Consumer<Throwable> onError) {
+    try {
+      call(new UfsCallable<Void>() {
+        @Override
+        public Void call() {
+          mUnderFileSystem.performListingAsync(path, continuationToken, startAfter,
+              descendantType, checkStatus, onComplete, onError);
+          return null;
+        }
+
+        @Override
+        public String methodName() {
+          return "PerformListingAsync";
+        }
+
+        @Override
+        public String toString() {
+          return String.format("path=%s, continuationToken=%s, startAfter=%s, descendantType=%s,"
+                  + " checkStatus=%s",
+              path, continuationToken, startAfter, descendantType, checkStatus);
+        }
+      });
+    } catch (IOException e) {
+      throw new InternalRuntimeException("should not reach");
+    }
   }
 
   /**

--- a/dora/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -828,7 +828,7 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   public Iterator<UfsStatus> listStatusIterable(
       String path, ListOptions options, String startAfter,
       int batchSize) throws IOException {
-    return call(new UfsCallable<Iterator<UfsStatus>>() {
+    return call(new UfsCallable<>() {
       @Override
       public Iterator<UfsStatus> call() throws IOException {
         Iterator<UfsStatus> result =

--- a/dora/core/common/src/main/java/alluxio/util/RateLimiter.java
+++ b/dora/core/common/src/main/java/alluxio/util/RateLimiter.java
@@ -1,0 +1,60 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import java.util.Optional;
+
+/**
+ * Used to limit the rate of operations. This rate limiter is not thread safe
+ * and the operations are non-blocking. It is used by acquiring a permit for
+ * each operation, then checking how the operation should wait by calling
+ * {@link RateLimiter#getWaitTimeNanos(long)}.
+ */
+public interface RateLimiter {
+
+  /**
+   * Acquire a permit for the next operation.
+   * @return {@link Optional#empty()} if no waiting is needed, otherwise
+   * the value contained in the returned optional is the permit, which
+   * can be used in calls to {@link RateLimiter#getWaitTimeNanos}
+   * to see how long to wait for the operation to be ready.
+   */
+  Optional<Long> acquire();
+
+  /**
+   * Checks how long is needed to wait for this permit to be ready.
+   * @param permit the permit returned by {@link RateLimiter#acquire()}
+   * @return the amount of time needed to wait in nanoseconds
+   */
+  long getWaitTimeNanos(long permit);
+
+  /**
+   * @param permitsPerSecond permits per second
+   * @return a rate limiter
+   */
+  static RateLimiter createRateLimiter(long permitsPerSecond) {
+    if (permitsPerSecond <= 0) {
+      return new RateLimiter() {
+        @Override
+        public Optional<Long> acquire() {
+          return Optional.empty();
+        }
+
+        @Override
+        public long getWaitTimeNanos(long permit) {
+          return 0;
+        }
+      };
+    }
+    return new SimpleRateLimiter(permitsPerSecond);
+  }
+}

--- a/dora/core/common/src/main/java/alluxio/util/SimpleRateLimiter.java
+++ b/dora/core/common/src/main/java/alluxio/util/SimpleRateLimiter.java
@@ -1,0 +1,65 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ticker;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * A basic implementation of {@link RateLimiter}.
+ */
+public class SimpleRateLimiter implements RateLimiter {
+
+  final Ticker mTicker;
+  final long mMinDuration;
+
+  long mLastAcquire = 0;
+
+  SimpleRateLimiter(long permitsPerSecond) {
+    this(permitsPerSecond, new Ticker() {
+      @Override
+      public long read() {
+        return System.nanoTime();
+      }
+    });
+  }
+
+  /**
+   * Creates a simple rate limiter for testing purpose.
+   * @param permitsPerSecond permits per second
+   * @param ticker the ticker
+   */
+  @VisibleForTesting
+  public SimpleRateLimiter(long permitsPerSecond, Ticker ticker) {
+    mTicker = ticker;
+    mMinDuration = Duration.ofSeconds(1).toNanos() / permitsPerSecond;
+  }
+
+  @Override
+  public long getWaitTimeNanos(long permit) {
+    return permit - mTicker.read();
+  }
+
+  @Override
+  public Optional<Long> acquire() {
+    long nxtElapsed = mTicker.read();
+    if (nxtElapsed - mLastAcquire >= mMinDuration) {
+      mLastAcquire = nxtElapsed;
+      return Optional.empty();
+    }
+    mLastAcquire += mMinDuration;
+    return Optional.of(mLastAcquire);
+  }
+}

--- a/dora/core/common/src/test/java/alluxio/underfs/ObjectUnderFileSystemTest.java
+++ b/dora/core/common/src/test/java/alluxio/underfs/ObjectUnderFileSystemTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.underfs;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -19,6 +20,8 @@ import alluxio.ConfigurationRule;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
+import alluxio.file.options.DescendantType;
+import alluxio.underfs.options.ListOptions;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
@@ -28,6 +31,7 @@ import org.mockito.Mockito;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.SocketException;
+import java.util.stream.Collectors;
 
 public class ObjectUnderFileSystemTest {
   private static final AlluxioConfiguration CONF = Configuration.global();
@@ -68,5 +72,48 @@ public class ObjectUnderFileSystemTest {
     } catch (IOException e) {
       fail();
     }
+  }
+
+  @Test
+  public void testListObjectStorageDescendantTypeNone() throws Throwable {
+    mObjectUFS = new MockObjectUnderFileSystem(new AlluxioURI("/"),
+        UnderFileSystemConfiguration.defaults(CONF)) {
+      final UfsStatus mF1Status = new UfsFileStatus("f1", "", 0L, 0L, "", "", (short) 0777, 0L);
+      final UfsStatus mF2Status = new UfsFileStatus("f2", "", 1L, 0L, "", "", (short) 0777, 0L);
+
+      @Override
+      public UfsStatus getStatus(String path) throws IOException {
+        if (path.equals("root/f1")) {
+          return mF1Status;
+        } else if (path.equals("root/f2")) {
+          return mF2Status;
+        }
+        throw new FileNotFoundException();
+      }
+
+      @Override
+      public UfsStatus[] listStatus(String path) throws IOException {
+        if (path.equals("root") || path.equals("root/")) {
+          return new UfsStatus[] {mF1Status, mF2Status};
+        }
+        return new UfsStatus[0];
+      }
+
+      @Override
+      public UfsStatus[] listStatus(String path, ListOptions options) throws IOException {
+        return listStatus(path);
+      }
+
+      @Override
+      protected ObjectPermissions getPermissions() {
+        return new ObjectPermissions("foo", "bar", (short) 0777);
+      }
+    };
+
+    UfsLoadResult result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mObjectUFS, "root", DescendantType.NONE);
+    assertEquals(1, result.getItemsCount());
+    UfsStatus status = result.getItems().collect(Collectors.toList()).get(0);
+    assertEquals("root", status.getName());
   }
 }

--- a/dora/core/common/src/test/java/alluxio/underfs/UnderFileSystemTestUtil.java
+++ b/dora/core/common/src/test/java/alluxio/underfs/UnderFileSystemTestUtil.java
@@ -1,0 +1,49 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs;
+
+import alluxio.file.options.DescendantType;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Test utils for UFS.
+ */
+public class UnderFileSystemTestUtil {
+  /**
+   * A test helper convert the async performListingAsync call to a sync one.
+   * @param ufs the ufs object
+   * @param path the path
+   * @param descendantType the descendant type
+   * @return the ufs load result
+   */
+  public static UfsLoadResult performListingAsyncAndGetResult(
+      UnderFileSystem ufs, String path, DescendantType descendantType) throws Throwable {
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<Throwable> throwable = new AtomicReference<>();
+    AtomicReference<UfsLoadResult> result = new AtomicReference<>();
+    ufs.performListingAsync(path, null, null, descendantType, descendantType == DescendantType.NONE,
+        (r) -> {
+          result.set(r);
+          latch.countDown();
+        }, (t) -> {
+          throwable.set(t);
+          latch.countDown();
+        });
+    latch.await();
+    if (throwable.get() != null) {
+      throw throwable.get();
+    }
+    return result.get();
+  }
+}

--- a/dora/core/server/master/pom.xml
+++ b/dora/core/server/master/pom.xml
@@ -83,6 +83,10 @@
       <groupId>it.unimi.dsi</groupId>
       <artifactId>fastutil-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>
@@ -111,6 +115,17 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.gaul</groupId>
+      <artifactId>s3proxy</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-stress-shell</artifactId>
       <version>${project.version}</version>
@@ -134,6 +149,12 @@
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-underfs-local</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-s3a</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/dora/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterS3UfsTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterS3UfsTest.java
@@ -1,0 +1,111 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file;
+
+import static org.junit.Assert.assertTrue;
+
+import alluxio.AlluxioURI;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.AccessControlException;
+import alluxio.exception.BlockInfoException;
+import alluxio.exception.FileAlreadyCompletedException;
+import alluxio.exception.FileAlreadyExistsException;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.exception.InvalidFileSizeException;
+import alluxio.exception.InvalidPathException;
+import alluxio.master.file.contexts.ExistsContext;
+import alluxio.master.file.contexts.MountContext;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.gaul.s3proxy.junit.S3ProxyRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Unit tests for {@link FileSystemMaster}.
+ */
+public final class FileSystemMasterS3UfsTest extends FileSystemMasterTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(FileSystemMasterS3UfsTest.class);
+  private static final String TEST_BUCKET = "test-bucket";
+  private static final String TEST_FILE = "test_file";
+  private static final String TEST_DIRECTORY = "test_directory";
+  private static final String TEST_CONTENT = "test_content";
+  private static final AlluxioURI UFS_ROOT = new AlluxioURI("s3://test-bucket/");
+  private static final AlluxioURI MOUNT_POINT = new AlluxioURI("/s3_mount");
+  private AmazonS3 mS3Client;
+  @Rule
+  public S3ProxyRule mS3Proxy = S3ProxyRule.builder()
+      .withPort(8001)
+      .withCredentials("_", "_")
+      .build();
+
+  @Override
+  public void before() throws Exception {
+    Configuration.set(PropertyKey.UNDERFS_S3_ENDPOINT, "localhost:8001");
+    Configuration.set(PropertyKey.UNDERFS_S3_ENDPOINT_REGION, "us-west-2");
+    Configuration.set(PropertyKey.UNDERFS_S3_DISABLE_DNS_BUCKETS, true);
+    Configuration.set(PropertyKey.S3A_ACCESS_KEY, mS3Proxy.getAccessKey());
+    Configuration.set(PropertyKey.S3A_SECRET_KEY, mS3Proxy.getSecretKey());
+
+    mS3Client = AmazonS3ClientBuilder
+        .standard()
+        .withPathStyleAccessEnabled(true)
+        .withCredentials(
+            new AWSStaticCredentialsProvider(
+                new BasicAWSCredentials(mS3Proxy.getAccessKey(), mS3Proxy.getSecretKey())))
+        .withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration(mS3Proxy.getUri().toString(),
+                Regions.US_WEST_2.getName()))
+        .build();
+    mS3Client.createBucket(TEST_BUCKET);
+
+    super.before();
+  }
+
+  @Ignore
+  @Test
+  public void basicWrite()
+      throws FileDoesNotExistException, FileAlreadyExistsException, AccessControlException,
+      IOException, InvalidPathException, BlockInfoException, InvalidFileSizeException,
+      FileAlreadyCompletedException {
+    // Not testable:
+    // when you create a directory, there's nothing created correspondingly in S3
+    // when you create a file, you need to open it on the client side to write the content,
+    // which is out of the scope of this testing.
+  }
+
+  @Test
+  public void basicSync()
+      throws FileDoesNotExistException, FileAlreadyExistsException, AccessControlException,
+      IOException, InvalidPathException {
+    mFileSystemMaster.mount(MOUNT_POINT, UFS_ROOT, MountContext.defaults());
+    mS3Client.putObject(TEST_BUCKET, TEST_FILE, TEST_CONTENT);
+    assertTrue(mFileSystemMaster.exists(MOUNT_POINT.join(TEST_FILE), ExistsContext.defaults()));
+  }
+
+  @Override
+  public void after() throws Exception {
+    mS3Client = null;
+    super.after();
+  }
+}

--- a/dora/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/dora/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -224,7 +224,11 @@ public abstract class AbstractLocalAlluxioCluster {
     String underfsAddress = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
 
     // Deletes the ufs dir for this test from to avoid permission problems
-    UnderFileSystemUtils.deleteDirIfExists(ufs, underfsAddress);
+    // Do not delete the ufs root if the ufs is an object storage.
+    // In test environment, this means s3 mock is used.
+    if (!ufs.isObjectStorage()) {
+      UnderFileSystemUtils.deleteDirIfExists(ufs, underfsAddress);
+    }
 
     // Creates ufs dir. This must be called before starting UFS with UnderFileSystemCluster.create()
     UnderFileSystemUtils.mkdirIfNotExists(ufs, underfsAddress);

--- a/dora/tests/pom.xml
+++ b/dora/tests/pom.xml
@@ -223,6 +223,17 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.gaul</groupId>
+      <artifactId>s3proxy</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/dora/tests/src/test/java/alluxio/client/fs/FileSystemS3UfsIntegrationTest.java
+++ b/dora/tests/src/test/java/alluxio/client/fs/FileSystemS3UfsIntegrationTest.java
@@ -1,0 +1,117 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.fs;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystem;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.AlluxioException;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.WritePType;
+import alluxio.testutils.BaseIntegrationTest;
+import alluxio.testutils.LocalAlluxioClusterResource;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.S3Object;
+import org.apache.commons.io.IOUtils;
+import org.gaul.s3proxy.junit.S3ProxyRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class FileSystemS3UfsIntegrationTest extends BaseIntegrationTest {
+  private static final String TEST_CONTENT = "TestContents";
+  private static final String TEST_FILE = "test_file";
+  private static final String TEST_FILE2 = "test_file2";
+  private static final int USER_QUOTA_UNIT_BYTES = 1000;
+
+  @Rule
+  public S3ProxyRule mS3Proxy = S3ProxyRule.builder()
+      .withPort(8001)
+      .withCredentials("_", "_")
+      .build();
+
+  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
+      new LocalAlluxioClusterResource.Builder()
+          .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, USER_QUOTA_UNIT_BYTES)
+          .setProperty(PropertyKey.UNDERFS_S3_ENDPOINT, "localhost:8001")
+          .setProperty(PropertyKey.UNDERFS_S3_ENDPOINT_REGION, "us-west-2")
+          .setProperty(PropertyKey.UNDERFS_S3_DISABLE_DNS_BUCKETS, true)
+          .setProperty(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, "s3://" + TEST_BUCKET)
+          .setProperty(PropertyKey.S3A_ACCESS_KEY, mS3Proxy.getAccessKey())
+          .setProperty(PropertyKey.S3A_SECRET_KEY, mS3Proxy.getSecretKey())
+          .setStartCluster(false)
+          .build();
+  private FileSystem mFileSystem = null;
+  private AmazonS3 mS3Client = null;
+  @Rule
+  public ExpectedException mThrown = ExpectedException.none();
+
+  private static final String TEST_BUCKET = "test-bucket";
+
+  @Before
+  public void before() throws Exception {
+    mS3Client = AmazonS3ClientBuilder
+        .standard()
+        .withPathStyleAccessEnabled(true)
+        .withCredentials(
+            new AWSStaticCredentialsProvider(
+                new BasicAWSCredentials(mS3Proxy.getAccessKey(), mS3Proxy.getSecretKey())))
+        .withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration(mS3Proxy.getUri().toString(),
+                Regions.US_WEST_2.getName()))
+        .build();
+    mS3Client.createBucket(TEST_BUCKET);
+
+    mLocalAlluxioClusterResource.start();
+    mFileSystem = mLocalAlluxioClusterResource.get().getClient();
+  }
+
+  @After
+  public void after() {
+    mS3Client = null;
+  }
+
+  @Test
+  public void basicMetadataSync() throws IOException, AlluxioException {
+    mS3Client.putObject(TEST_BUCKET, TEST_FILE, TEST_CONTENT);
+    FileInStream fis = mFileSystem.openFile(new AlluxioURI("/" + TEST_FILE));
+    assertEquals(TEST_CONTENT, IOUtils.toString(fis, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void basicWriteThrough() throws IOException, AlluxioException {
+    FileOutStream fos = mFileSystem.createFile(
+        new AlluxioURI("/" + TEST_FILE2),
+        CreateFilePOptions.newBuilder().setWriteType(WritePType.CACHE_THROUGH).build());
+    fos.write(TEST_CONTENT.getBytes());
+    fos.close();
+    try (S3Object s3Object = mS3Client.getObject(TEST_BUCKET, TEST_FILE2)) {
+      assertEquals(
+          TEST_CONTENT, IOUtils.toString(s3Object.getObjectContent(), StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/dora/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
+++ b/dora/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
@@ -16,12 +16,14 @@ import alluxio.PositionReader;
 import alluxio.SyncInfo;
 import alluxio.collections.Pair;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.file.options.DescendantType;
 import alluxio.security.authorization.AccessControlList;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.underfs.Fingerprint;
 import alluxio.underfs.UfsDirectoryStatus;
 import alluxio.underfs.UfsFileStatus;
+import alluxio.underfs.UfsLoadResult;
 import alluxio.underfs.UfsMode;
 import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
@@ -38,8 +40,10 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * UFS which delegates to another UFS. Extend this class to override method behavior.
@@ -256,6 +260,14 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
     return mUfs.listStatus(path, options);
   }
 
+  @Nullable
+  @Override
+  public Iterator<UfsStatus> listStatusIterable(
+      String path, ListOptions options, String startAfter,
+      int batchSize) throws IOException {
+    return mUfs.listStatusIterable(path, options, startAfter, batchSize);
+  }
+
   @Override
   public boolean mkdirs(String path) throws IOException {
     return mUfs.mkdirs(path);
@@ -364,5 +376,15 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   @Override
   public boolean stopActiveSyncPolling() throws IOException {
     return mUfs.stopActiveSyncPolling();
+  }
+
+  @Override
+  public void performListingAsync(
+      String path, @Nullable String continuationToken,
+      @Nullable String startAfter,
+      DescendantType descendantType, boolean checkStatus,
+      Consumer<UfsLoadResult> onComplete, Consumer<Throwable> onError) {
+    mUfs.performListingAsync(path, continuationToken,
+        startAfter, descendantType, checkStatus, onComplete, onError);
   }
 }

--- a/dora/underfs/local/pom.xml
+++ b/dora/underfs/local/pom.xml
@@ -35,6 +35,14 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <!-- Internal test dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/dora/underfs/pom.xml
+++ b/dora/underfs/pom.xml
@@ -67,6 +67,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.gaul</groupId>
+      <artifactId>s3proxy</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>

--- a/dora/underfs/s3a/pom.xml
+++ b/dora/underfs/s3a/pom.xml
@@ -41,6 +41,19 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>4.4</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>netty-nio-client</artifactId>
+    </dependency>
     <!--aws sdk requires jaxb binding at runtime-->
     <dependency>
       <groupId>com.sun.xml.bind</groupId>

--- a/dora/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/dora/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -14,8 +14,13 @@ package alluxio.underfs.s3a;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
+import alluxio.file.options.DescendantType;
 import alluxio.retry.RetryPolicy;
 import alluxio.underfs.ObjectUnderFileSystem;
+import alluxio.underfs.UfsDirectoryStatus;
+import alluxio.underfs.UfsFileStatus;
+import alluxio.underfs.UfsLoadResult;
+import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.OpenOptions;
@@ -62,19 +67,48 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.collections4.IteratorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientAsyncConfiguration;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.http.nio.netty.Http2Configuration;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.ProxyConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -98,6 +132,8 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
 
   /** AWS-SDK S3 client. */
   private final AmazonS3 mClient;
+
+  private final S3AsyncClient mAsyncClient;
 
   /** Bucket name of user's configured Alluxio bucket. */
   private final String mBucketName;
@@ -212,6 +248,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
 
     AmazonS3 amazonS3Client
         = createAmazonS3(credentials, clientConf, endpointConfiguration, conf);
+    S3AsyncClient asyncClient = createAmazonS3Async(conf, clientConf);
 
     ExecutorService service = ExecutorServiceFactories
         .fixedThreadPool("alluxio-s3-transfer-manager-worker",
@@ -223,8 +260,93 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
         .withMultipartCopyThreshold(MULTIPART_COPY_THRESHOLD)
         .build();
 
-    return new S3AUnderFileSystem(uri, amazonS3Client, bucketName,
+    return new S3AUnderFileSystem(uri, amazonS3Client, asyncClient, bucketName,
         service, transferManager, conf, streamingUploadEnabled);
+  }
+
+  /**
+   * Create an async S3 client.
+   * @param conf the conf
+   * @param clientConf the client conf
+   * @return the client
+   */
+  public static S3AsyncClient createAmazonS3Async(
+      UnderFileSystemConfiguration conf,
+      ClientConfiguration clientConf) {
+
+    S3AsyncClientBuilder clientBuilder = S3AsyncClient.builder();
+    // need to check all the additional parameters for these
+    S3Configuration.builder();
+    ClientOverrideConfiguration.builder();
+    Http2Configuration.builder();
+    ClientAsyncConfiguration.builder();
+
+    NettyNioAsyncHttpClient.Builder httpClientBuilder = NettyNioAsyncHttpClient.builder();
+    AwsCredentialsProvider credentialsProvider;
+    // Set the aws credential system properties based on Alluxio properties, if they are set;
+    // otherwise, use the default credential provider.
+    if (conf.isSet(PropertyKey.S3A_ACCESS_KEY)
+        && conf.isSet(PropertyKey.S3A_SECRET_KEY)) {
+      credentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create(
+          conf.getString(PropertyKey.S3A_ACCESS_KEY), conf.getString(PropertyKey.S3A_SECRET_KEY)));
+    } else {
+      // Checks, in order, env variables, system properties, profile file, and instance profile.
+      credentialsProvider = DefaultCredentialsProvider.builder().build();
+    }
+
+    if (conf.getBoolean(PropertyKey.UNDERFS_S3_DISABLE_DNS_BUCKETS)) {
+      clientBuilder.forcePathStyle(true);
+    }
+
+    // Proxy host
+    if (conf.isSet(PropertyKey.UNDERFS_S3_PROXY_HOST)) {
+      ProxyConfiguration.Builder proxyBuilder = ProxyConfiguration.builder();
+      proxyBuilder.host(conf.getString(PropertyKey.UNDERFS_S3_PROXY_HOST));
+      // Proxy port
+      if (conf.isSet(PropertyKey.UNDERFS_S3_PROXY_PORT)) {
+        proxyBuilder.port(conf.getInt(PropertyKey.UNDERFS_S3_PROXY_PORT));
+      }
+      httpClientBuilder.proxyConfiguration(proxyBuilder.build());
+    }
+    boolean regionSet = false;
+    if (conf.isSet(PropertyKey.UNDERFS_S3_ENDPOINT)) {
+      String endpoint = conf.getString(PropertyKey.UNDERFS_S3_ENDPOINT);
+      final URI epr = RuntimeHttpUtils.toUri(endpoint, clientConf);
+      clientBuilder.endpointOverride(epr);
+      if (conf.isSet(PropertyKey.UNDERFS_S3_ENDPOINT_REGION)) {
+        regionSet = setRegionAsync(clientBuilder,
+            conf.getString(PropertyKey.UNDERFS_S3_ENDPOINT_REGION));
+      }
+    } else if (conf.isSet(PropertyKey.UNDERFS_S3_REGION)) {
+      regionSet = setRegionAsync(clientBuilder,
+          conf.getString(PropertyKey.UNDERFS_S3_REGION));
+    }
+
+    if (!regionSet) {
+      String defaultRegion = Regions.US_EAST_1.getName();
+      clientBuilder.region(Region.of(defaultRegion));
+      LOG.warn("Cannot find S3 endpoint or s3 region in Alluxio configuration, "
+              + "set region to {} as default. S3 client v2 does not support global bucket access, "
+              + "considering specify the region in alluxio config.",
+          defaultRegion);
+    }
+    clientBuilder.httpClientBuilder(httpClientBuilder);
+    clientBuilder.credentialsProvider(credentialsProvider);
+    return clientBuilder.build();
+  }
+
+  private static boolean setRegionAsync(
+      S3AsyncClientBuilder builder, String region) {
+    try {
+      builder.region(Region.of(region));
+      LOG.debug("Set S3 region {} to {}", PropertyKey.UNDERFS_S3_REGION.getName(), region);
+      return true;
+    } catch (SdkClientException e) {
+      LOG.error("S3 region {} cannot be recognized, "
+              + "fall back to use global bucket access with an extra HEAD request",
+          region, e);
+      return false;
+    }
   }
 
   /**
@@ -321,17 +443,20 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
    *
    * @param uri the {@link AlluxioURI} for this UFS
    * @param amazonS3Client AWS-SDK S3 client
+   * @param asyncClient AWS S3 async client
    * @param bucketName bucket name of user's configured Alluxio bucket
    * @param executor the executor for executing upload tasks
    * @param transferManager Transfer Manager for efficient I/O to S3
    * @param conf configuration for this S3A ufs
    * @param streamingUploadEnabled whether streaming upload is enabled
    */
-  protected S3AUnderFileSystem(AlluxioURI uri, AmazonS3 amazonS3Client, String bucketName,
+  protected S3AUnderFileSystem(
+      AlluxioURI uri, AmazonS3 amazonS3Client, S3AsyncClient asyncClient, String bucketName,
       ExecutorService executor, TransferManager transferManager, UnderFileSystemConfiguration conf,
       boolean streamingUploadEnabled) {
     super(uri, conf);
     mClient = amazonS3Client;
+    mAsyncClient = asyncClient;
     mBucketName = bucketName;
     mExecutor = MoreExecutors.listeningDecorator(executor);
     mManager = transferManager;
@@ -462,6 +587,14 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   @Nullable
   protected ObjectListingChunk getObjectListingChunk(String key, boolean recursive)
       throws IOException {
+    return getObjectListingChunk(key, recursive, null, 0);
+  }
+
+  @Nullable
+  @Override
+  protected ObjectListingChunk getObjectListingChunk(
+      String key, boolean recursive, @Nullable String startAfter, int batchSize)
+      throws IOException {
     String delimiter = recursive ? "" : PATH_SEPARATOR;
     key = PathUtils.normalizePath(key, PATH_SEPARATOR);
     // In case key is root (empty string) do not normalize prefix.
@@ -479,6 +612,12 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
       ListObjectsV2Request request =
           new ListObjectsV2Request().withBucketName(mBucketName).withPrefix(key)
               .withDelimiter(delimiter).withMaxKeys(getListingChunkLength(mUfsConf));
+      if (startAfter != null) {
+        request.setStartAfter(startAfter);
+      }
+      if (batchSize > 0) {
+        request.setMaxKeys(batchSize);
+      }
       ListObjectsV2Result result = getObjectListingChunk(request);
       if (result != null) {
         return new S3AObjectListingChunk(request, result);
@@ -513,6 +652,222 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
       throw AlluxioS3Exception.from(e);
     }
     return result;
+  }
+
+  void performGetStatusAsync(
+      String path, Consumer<UfsStatus> onComplete,
+      Consumer<Throwable> onError) {
+    String folderSuffix = getFolderSuffix();
+    path = stripPrefixIfPresent(path);
+    path = path.equals(folderSuffix) ? "" : path;
+    if (path.isEmpty()) {
+      onComplete.accept(null);
+      return;
+    }
+    HeadObjectRequest request =
+        HeadObjectRequest.builder().bucket(mBucketName).key(path).build();
+    String finalPath = path;
+    mAsyncClient.headObject(request).whenCompleteAsync((result, err) -> {
+      if (err != null) {
+        if (err.getCause() instanceof NoSuchKeyException) {
+          onComplete.accept(null);
+        } else {
+          onError.accept(parseS3AsyncException(err));
+        }
+      } else {
+        try {
+          ObjectPermissions permissions = getPermissions();
+          long bytes = mUfsConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
+          Instant lastModifiedDate = result.lastModified();
+          Long lastModifiedTime = lastModifiedDate == null ? null
+              : lastModifiedDate.toEpochMilli();
+          UfsStatus status;
+          if (finalPath.endsWith(folderSuffix)) {
+            status = new UfsDirectoryStatus(finalPath, permissions.getOwner(),
+                permissions.getGroup(), permissions.getMode());
+          } else {
+            status = new UfsFileStatus(finalPath,
+                result.eTag().substring(1, result.eTag().length() - 1),
+                result.contentLength(), lastModifiedTime, permissions.getOwner(),
+                permissions.getGroup(), permissions.getMode(), bytes);
+          }
+          onComplete.accept(status);
+        } catch (Throwable t) {
+          onError.accept(t);
+        }
+      }
+    });
+  }
+
+  @Override
+  public void performListingAsync(
+      String path, @Nullable String continuationToken, @Nullable String startAfter,
+      DescendantType descendantType, boolean checkStatus,
+      Consumer<UfsLoadResult> onComplete, Consumer<Throwable> onError) {
+    if (checkStatus) {
+      Preconditions.checkState(continuationToken == null);
+      performGetStatusAsync(path, status -> {
+        if (status != null && (status.isFile() || descendantType == DescendantType.NONE)) {
+          onComplete.accept(new UfsLoadResult(Stream.of(status), 1, null,
+              null, false, status.isFile(), true));
+        } else {
+          finishListingAsync(status, path, null, startAfter,
+              descendantType, onComplete, onError);
+        }
+      }, onError);
+    } else {
+      finishListingAsync(null, path, continuationToken, startAfter,
+          descendantType, onComplete, onError);
+    }
+  }
+
+  private Throwable parseS3AsyncException(Throwable e) {
+    if (e instanceof CompletionException) {
+      final Throwable innerErr = e.getCause();
+      if (innerErr instanceof S3Exception) {
+        S3Exception innerS3Err = (S3Exception) innerErr;
+        if (innerS3Err.statusCode() == 307
+            || (innerS3Err.awsErrorDetails().errorCode().equals("AuthorizationHeaderMalformed")
+            && innerS3Err.getMessage().contains("region"))) {
+          return new IOException(
+              "AWS s3 v2 client does not support global region. "
+                  + "Please either specify the region using alluxio.underfs.s3.region "
+                  + "or in your s3 endpoint alluxio.underfs.s3.endpoint.", innerS3Err);
+        }
+      }
+      return new IOException(e.getCause());
+    }
+    return e;
+  }
+
+  private void finishListingAsync(
+      @Nullable UfsStatus baseStatus,
+      String path, @Nullable String continuationToken, @Nullable String startAfter,
+      DescendantType descendantType,
+      Consumer<UfsLoadResult> onComplete, Consumer<Throwable> onError) {
+    // if descendant type is NONE then we only want to return the directory itself
+    int maxKeys = descendantType == DescendantType.NONE ? 1 : getListingChunkLength(mUfsConf);
+    path = stripPrefixIfPresent(path);
+    String delimiter = descendantType == DescendantType.ALL ? "" : PATH_SEPARATOR;
+    path = PathUtils.normalizePath(path, PATH_SEPARATOR);
+    // In case key is root (empty string) do not normalize prefix.
+    path = path.equals(PATH_SEPARATOR) ? "" : path;
+    String s3StartAfter = null;
+    if (path.equals("")) {
+      s3StartAfter = startAfter;
+    } else if (startAfter != null) {
+      s3StartAfter = PathUtils.concatPath(path, startAfter);
+    }
+    software.amazon.awssdk.services.s3.model.ListObjectsV2Request.Builder request =
+        software.amazon.awssdk.services.s3.model.ListObjectsV2Request
+            .builder().bucket(mBucketName).prefix(path).continuationToken(continuationToken)
+            .startAfter(startAfter == null ? null : s3StartAfter)
+            .delimiter(delimiter).maxKeys(maxKeys);
+    String finalPath = path;
+    mAsyncClient.listObjectsV2(request.build())
+        .whenCompleteAsync((result, err) -> {
+          if (err != null) {
+            onError.accept(parseS3AsyncException(err));
+          } else {
+            try {
+              AlluxioURI lastItem = null;
+              String lastPrefix = result.commonPrefixes().size() == 0 ? null
+                  : result.commonPrefixes().get(result.commonPrefixes().size() - 1).prefix();
+              String lastResult = result.contents().size() == 0 ? null
+                  : result.contents().get(result.contents().size() - 1).key();
+              if (lastPrefix == null && lastResult != null) {
+                lastItem = new AlluxioURI(lastResult);
+              } else if (lastPrefix != null && lastResult == null) {
+                lastItem = new AlluxioURI(lastPrefix);
+              } else if (lastPrefix != null) { // both are non-null
+                lastItem = new AlluxioURI(lastPrefix.compareTo(lastResult) > 0
+                    ? lastPrefix : lastResult);
+              }
+              int keyCount = result.keyCount();
+              Stream<UfsStatus> resultStream = resultToStream(baseStatus, result);
+              if (descendantType == DescendantType.NONE) {
+                Preconditions.checkState(baseStatus == null);
+                // if descendant type is NONE then we only want to return the directory itself
+                Optional<Stream<UfsStatus>> str = resultStream.findFirst().map(item -> {
+                  if (item.isDirectory() && item.getName().equals(finalPath)) {
+                    return Stream.of(item);
+                  } else {
+                    if (item.getName().startsWith(finalPath)) {
+                      // in this case we received a file nested under the path, this can happen
+                      // if there was no marker object for the directory, and it contained
+                      // a nested object
+                      ObjectPermissions permissions = getPermissions();
+                      return Stream.of(new UfsDirectoryStatus(finalPath,
+                          permissions.getOwner(), permissions.getGroup(), permissions.getMode()));
+                    }
+                  }
+                  return Stream.empty();
+                });
+                resultStream = str.orElse(Stream.empty());
+              }
+              onComplete.accept(
+                  new UfsLoadResult(resultStream,
+                      keyCount,
+                      result.nextContinuationToken(), lastItem,
+                      descendantType != DescendantType.NONE && result.isTruncated(),
+                      false, true));
+            } catch (Throwable t) {
+              onError.accept(t);
+            }
+          }
+        });
+  }
+
+  private UfsStatus s3ObjToUfsStatus(
+      S3Object obj, String folderSuffix, ObjectPermissions permissions, long bytes) {
+    if (obj.key().endsWith(folderSuffix)) {
+      return new UfsDirectoryStatus(obj.key(), permissions.getOwner(),
+          permissions.getGroup(), permissions.getMode());
+    } else {
+      Instant lastModifiedDate = obj.lastModified();
+      Long lastModifiedTime = lastModifiedDate == null ? null
+          : lastModifiedDate.toEpochMilli();
+      return new UfsFileStatus(obj.key(),
+          obj.eTag().substring(1, obj.eTag().length() - 1), obj.size(), lastModifiedTime,
+          permissions.getOwner(), permissions.getGroup(), permissions.getMode(), bytes);
+    }
+  }
+
+  private UfsStatus prefixToUfsStatus(CommonPrefix prefix, ObjectPermissions permissions) {
+    return new UfsDirectoryStatus(
+        prefix.prefix(), permissions.getOwner(), permissions.getGroup(),
+        permissions.getMode());
+  }
+
+  private Stream<UfsStatus> resultToStream(
+      @Nullable UfsStatus baseStatus, ListObjectsV2Response response) {
+    // Directories are either keys that end with /
+    // Or common prefixes which will also end with /
+    // All results contain the full path from the bucket root
+    ObjectPermissions permissions = getPermissions();
+    String folderSuffix = getFolderSuffix();
+    long bytes = mUfsConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
+    Iterator<UfsStatus> prefixes = response.commonPrefixes().stream().map(
+        prefix -> prefixToUfsStatus(prefix, permissions)).iterator();
+    Stream<UfsStatus> itemStream = response.contents().stream().map(obj ->
+        s3ObjToUfsStatus(obj, folderSuffix, permissions, bytes));
+    if (baseStatus != null) {
+      itemStream = Stream.concat(Stream.of(baseStatus), itemStream);
+    }
+    Iterator<UfsStatus> items = itemStream.iterator();
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(
+        IteratorUtils.collatedIterator((s1, s2) -> {
+          int val = s1.getName().compareTo(s2.getName());
+          if (val != 0) {
+            return val;
+          }
+          // If they have the same name, then return the directory first
+          if (s1.isDirectory() && s2.isDirectory()) {
+            return 0;
+          }
+          return s1.isDirectory() ? -1 : 1;
+        }, prefixes, items),
+        Spliterator.ORDERED), false);
   }
 
   /**
@@ -558,6 +913,11 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
         }
       }
       return null;
+    }
+
+    @Override
+    public Boolean hasNextChunk() {
+      return mResult.isTruncated();
     }
   }
 

--- a/dora/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemMockServerTest.java
+++ b/dora/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemMockServerTest.java
@@ -1,0 +1,230 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.s3a;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import alluxio.AlluxioURI;
+import alluxio.conf.Configuration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.file.options.DescendantType;
+import alluxio.underfs.UfsLoadResult;
+import alluxio.underfs.UfsStatus;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.UnderFileSystemTestUtil;
+import alluxio.underfs.options.ListOptions;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.google.common.collect.Iterators;
+import org.apache.commons.io.IOUtils;
+import org.gaul.s3proxy.junit.S3ProxyRule;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+
+/**
+ * Unit tests for the {@link S3AUnderFileSystem} using a s3 mock server.
+ */
+public class S3AUnderFileSystemMockServerTest {
+  private static final InstancedConfiguration CONF = Configuration.copyGlobal();
+
+  private static final String TEST_BUCKET = "test-bucket";
+  private static final String TEST_FILE = "test_file";
+  private static final AlluxioURI TEST_FILE_URI = new AlluxioURI("s3://test-bucket/test_file");
+  private static final String TEST_CONTENT = "test_content";
+
+  private S3AUnderFileSystem mS3UnderFileSystem;
+  private AmazonS3 mClient;
+
+  @Rule
+  public S3ProxyRule mS3Proxy = S3ProxyRule.builder()
+      // This is a must to close the behavior gap between native s3 and s3 proxy
+      .withBlobStoreProvider("transient")
+      .withPort(8001)
+      .withCredentials("_", "_")
+      .build();
+
+  @Rule
+  public final ExpectedException mThrown = ExpectedException.none();
+
+  @Before
+  public void before() throws AmazonClientException {
+    AwsClientBuilder.EndpointConfiguration
+        endpoint = new AwsClientBuilder.EndpointConfiguration(
+        "http://localhost:8001", "us-west-2");
+    mClient = AmazonS3ClientBuilder
+        .standard()
+        .withPathStyleAccessEnabled(true)
+        .withCredentials(
+            new AWSStaticCredentialsProvider(
+                new BasicAWSCredentials(mS3Proxy.getAccessKey(), mS3Proxy.getSecretKey())))
+        .withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration(mS3Proxy.getUri().toString(),
+                Regions.US_WEST_2.getName()))
+        .build();
+    S3AsyncClient asyncClient =
+        S3AsyncClient.builder().credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(mS3Proxy.getAccessKey(), mS3Proxy.getSecretKey())))
+            .endpointOverride(mS3Proxy.getUri()).region(Region.US_WEST_2).build();
+    mClient.createBucket(TEST_BUCKET);
+
+    mS3UnderFileSystem =
+        new S3AUnderFileSystem(new AlluxioURI("s3://" + TEST_BUCKET), mClient,
+            asyncClient, TEST_BUCKET,
+            Executors.newSingleThreadExecutor(), new TransferManager(),
+            UnderFileSystemConfiguration.defaults(CONF), false);
+  }
+
+  @After
+  public void after() {
+    mClient = null;
+  }
+
+  @Test
+  public void read() throws IOException {
+    mClient.putObject(TEST_BUCKET, TEST_FILE, TEST_CONTENT);
+
+    InputStream is =
+        mS3UnderFileSystem.open(TEST_FILE_URI.getPath());
+    assertEquals(TEST_CONTENT, IOUtils.toString(is, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void nestedDirectory() throws Throwable {
+    mClient.putObject(TEST_BUCKET, "d1/d1/f1", TEST_CONTENT);
+    mClient.putObject(TEST_BUCKET, "d1/d1/f2", TEST_CONTENT);
+    mClient.putObject(TEST_BUCKET, "d1/d2/f1", TEST_CONTENT);
+    mClient.putObject(TEST_BUCKET, "d2/d1/f1", TEST_CONTENT);
+    mClient.putObject(TEST_BUCKET, "d3/", "");
+    mClient.putObject(TEST_BUCKET, "d4/", "");
+    mClient.putObject(TEST_BUCKET, "d4/f1", TEST_CONTENT);
+    mClient.putObject(TEST_BUCKET, "f1", TEST_CONTENT);
+    mClient.putObject(TEST_BUCKET, "f2", TEST_CONTENT);
+
+    /*
+      Objects:
+       d1/
+       d1/d1/
+       d1/d1/f1
+       d1/d1/f2
+       d1/d2/
+       d1/d2/f1
+       d2/
+       d2/d1/
+       d2/d1/f1
+       d3/
+       d4/
+       d4/f1
+       f1
+       f2
+     */
+
+    UfsStatus[] ufsStatuses = mS3UnderFileSystem.listStatus(
+        "/", ListOptions.defaults().setRecursive(true));
+    assertNotNull(ufsStatuses);
+    assertEquals(14, ufsStatuses.length);
+
+    UfsLoadResult result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "/", DescendantType.ALL);
+    Assert.assertEquals(9, result.getItemsCount());
+
+    result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "/", DescendantType.ONE);
+    Assert.assertEquals(6, result.getItemsCount());
+
+    result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "d1", DescendantType.NONE);
+    assertEquals(1, result.getItemsCount());
+
+    result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "d1/", DescendantType.NONE);
+    assertEquals(1, result.getItemsCount());
+
+    result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "d3", DescendantType.NONE);
+    assertEquals(1, result.getItemsCount());
+
+    result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "d3/", DescendantType.NONE);
+    assertEquals(1, result.getItemsCount());
+
+    result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "d4", DescendantType.NONE);
+    assertEquals(1, result.getItemsCount());
+
+    result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "d4/", DescendantType.NONE);
+    assertEquals(1, result.getItemsCount());
+
+    result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "f1", DescendantType.NONE);
+    assertEquals(1, result.getItemsCount());
+
+    result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "f1/", DescendantType.NONE);
+    assertEquals(0, result.getItemsCount());
+
+    result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "f3", DescendantType.NONE);
+    assertEquals(0, result.getItemsCount());
+
+    result = UnderFileSystemTestUtil.performListingAsyncAndGetResult(
+        mS3UnderFileSystem, "f3/", DescendantType.NONE);
+    assertEquals(0, result.getItemsCount());
+  }
+
+  @Test
+  public void iterator() throws IOException {
+    for (int i = 0; i < 5; ++i) {
+      for (int j = 0; j < 5; ++j) {
+        for (int k = 0; k < 5; ++k) {
+          mClient.putObject(TEST_BUCKET, String.format("%d/%d/%d", i, j, k), TEST_CONTENT);
+        }
+      }
+    }
+
+    Iterator<UfsStatus> ufsStatusesIterator = mS3UnderFileSystem.listStatusIterable(
+        "/", ListOptions.defaults().setRecursive(true), null, 5);
+    UfsStatus[] statusesFromListing =
+        mS3UnderFileSystem.listStatus("/", ListOptions.defaults().setRecursive(true));
+    assertNotNull(statusesFromListing);
+    assertNotNull(ufsStatusesIterator);
+    UfsStatus[] statusesFromIterator =
+        Iterators.toArray(ufsStatusesIterator, UfsStatus.class);
+    Arrays.sort(statusesFromListing, Comparator.comparing(UfsStatus::getName));
+    assertArrayEquals(statusesFromIterator, statusesFromListing);
+  }
+}

--- a/dora/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/dora/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -64,6 +65,7 @@ public class S3AUnderFileSystemTest {
   private AmazonS3Client mClient;
   private ListeningExecutorService mExecutor;
   private TransferManager mManager;
+  private S3AsyncClient mAsyncClient;
 
   @Rule
   public final ExpectedException mThrown = ExpectedException.none();
@@ -73,8 +75,10 @@ public class S3AUnderFileSystemTest {
     mClient = Mockito.mock(AmazonS3Client.class);
     mExecutor = Mockito.mock(ListeningExecutorService.class);
     mManager = Mockito.mock(TransferManager.class);
+    mAsyncClient = Mockito.mock(S3AsyncClient.class);
     mS3UnderFileSystem =
-        new S3AUnderFileSystem(new AlluxioURI("s3a://" + BUCKET_NAME), mClient, BUCKET_NAME,
+        new S3AUnderFileSystem(new AlluxioURI("s3a://" + BUCKET_NAME),
+            mClient, mAsyncClient, BUCKET_NAME,
             mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false);
   }
 
@@ -183,8 +187,9 @@ public class S3AUnderFileSystemTest {
     conf.put(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING, "111=altname");
     try (Closeable c = new ConfigurationRule(conf, CONF).toResource()) {
       S3AUnderFileSystem s3UnderFileSystem =
-              new S3AUnderFileSystem(new AlluxioURI("s3a://" + BUCKET_NAME), mClient, BUCKET_NAME,
-                      mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false);
+          new S3AUnderFileSystem(
+              new AlluxioURI("s3a://" + BUCKET_NAME), mClient, mAsyncClient, BUCKET_NAME,
+              mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false);
 
       Mockito.when(mClient.getS3AccountOwner()).thenReturn(new Owner("111", "test"));
       Mockito.when(mClient.getBucketAcl(Mockito.anyString())).thenReturn(new AccessControlList());
@@ -202,8 +207,9 @@ public class S3AUnderFileSystemTest {
     conf.put(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING, "111=userid");
     try (Closeable c = new ConfigurationRule(conf, CONF).toResource()) {
       S3AUnderFileSystem s3UnderFileSystem =
-              new S3AUnderFileSystem(new AlluxioURI("s3a://" + BUCKET_NAME), mClient, BUCKET_NAME,
-                      mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false);
+          new S3AUnderFileSystem(new AlluxioURI("s3a://" + BUCKET_NAME), mClient,
+              mAsyncClient, BUCKET_NAME,
+              mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false);
 
       Mockito.when(mClient.getS3AccountOwner()).thenReturn(new Owner("0", "test"));
       Mockito.when(mClient.getBucketAcl(Mockito.anyString())).thenReturn(new AccessControlList());

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
     <argLine />
     <apache.curator.version>4.2.0</apache.curator.version>
     <aws.amazonaws.version>1.11.815</aws.amazonaws.version>
+    <awssdk.version>2.20.56</awssdk.version>
     <build.path>build</build.path>
     <catalyst.version>1.2.1</catalyst.version>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
@@ -158,6 +159,7 @@
     <jackson.version>2.13.5</jackson.version>
     <hadoop-cos.version>3.1.0-5.8.5</hadoop-cos.version>
     <cos_api.version>5.6.19</cos_api.version>
+    <s3proxy.version>2.0.0</s3proxy.version>
     <stateless4j.version>2.6.0</stateless4j.version>
     <surefire.forkCount>2</surefire.forkCount>
     <surefire.useSystemClassLoader>true</surefire.useSystemClassLoader>
@@ -703,6 +705,13 @@
         <version>${kerby.version}</version>
       </dependency>
       <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${awssdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil-core</artifactId>
         <version>${fastutil.version}</version>
@@ -742,6 +751,18 @@
         <artifactId>hadoop-test</artifactId>
         <version>${hadoop.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.gaul</groupId>
+        <artifactId>s3proxy</artifactId>
+        <version>${s3proxy.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Partially cherry picked changes from 
https://github.com/Alluxio/alluxio/pull/17102 and
https://github.com/Alluxio/alluxio/pull/17242

1. Introduced s3 mock for unit tests & corresponding unit tests for s3
2. UFS ListStatus iterator interface
3.  Async S3 listing & get interfaces & integration with the new s3 client 

### Why are the changes needed?

Better performance & memory control for s3

### Does this PR introduce any user facing changes?

N/A