### PR TITLE
Update copy job

### DIFF
--- a/common/transport/src/main/proto/grpc/file_system_master.proto
+++ b/common/transport/src/main/proto/grpc/file_system_master.proto
@@ -626,7 +626,7 @@ message CopyJobPOptions {
   optional bool partialListing = 3;
   optional bool overwrite = 4;
   optional WritePType writeType = 5;
-  optional bool ufs_only = 6;
+  optional bool check_content = 6;
 }
 
 message StopJobPRequest {

--- a/common/transport/src/main/proto/proto/journal/job.proto
+++ b/common/transport/src/main/proto/proto/journal/job.proto
@@ -24,7 +24,7 @@ message LoadJobEntry {
   optional int64 end_time = 8;
 }
 
-// next available id: 11
+// next available id: 12
 message CopyJobEntry {
   required string src= 1;
   required string dst= 2;
@@ -36,4 +36,5 @@ message CopyJobEntry {
   required string job_id = 8;
   optional int64 end_time = 9;
   optional bool overwrite = 10;
+  optional bool check_content = 11;
 }

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -54,7 +54,7 @@ import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
-import alluxio.underfs.options.GetFileStatusOptions;
+import alluxio.underfs.options.GetStatusOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
@@ -222,8 +222,8 @@ public class UfsBaseFileSystem implements FileSystem {
   @Override
   public URIStatus getStatus(AlluxioURI path, final GetStatusPOptions options) {
     return callWithReturn(() -> {
-      UfsStatus ufsStatus = mUfs.get().getStatus(path.toString(), GetFileStatusOptions.defaults()
-                              .setIncludeRealContentHash(options.getIncludeRealContentHash()));
+      UfsStatus ufsStatus = mUfs.get().getStatus(path.toString(), GetStatusOptions.defaults()
+                            .setIncludeRealContentHash(options.getIncludeRealContentHash()));
       return transformStatus(ufsStatus, path.toString());
     });
   }

--- a/dora/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
+++ b/dora/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
@@ -29,7 +29,7 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
-import alluxio.underfs.options.GetFileStatusOptions;
+import alluxio.underfs.options.GetStatusOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
@@ -263,11 +263,11 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public UfsFileStatus getFileStatus(String path, GetFileStatusOptions options) throws IOException {
+  public UfsFileStatus getFileStatus(String path, GetStatusOptions options) throws IOException {
     return new ManagedBlockingUfsMethod<UfsFileStatus>() {
       @Override
       public UfsFileStatus execute() throws IOException {
-        return mUfs.getFileStatus(path);
+        return mUfs.getFileStatus(path, options);
       }
     }.get();
   }
@@ -318,11 +318,11 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public UfsStatus getStatus(String path) throws IOException {
+  public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
     return new ManagedBlockingUfsMethod<UfsStatus>() {
       @Override
       public UfsStatus execute() throws IOException {
-        return mUfs.getStatus(path);
+        return mUfs.getStatus(path, options);
       }
     }.get();
   }

--- a/dora/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
@@ -81,9 +81,9 @@ public class AtomicFileOutputStream extends OutputStream implements ContentHasha
         throw new IOException(
             ExceptionMessage.FAILED_UFS_RENAME.getMessage(mTemporaryPath, mPermanentPath));
       }
-    } finally {
+    } catch (IOException e) {
       if (!mUfs.deleteFile(mTemporaryPath)) {
-        LOG.error("Failed to delete temporary file {}", mTemporaryPath);
+        LOG.warn("Failed to delete temporary file {}", mTemporaryPath);
       }
     }
 

--- a/dora/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/AtomicFileOutputStream.java
@@ -82,9 +82,16 @@ public class AtomicFileOutputStream extends OutputStream implements ContentHasha
             ExceptionMessage.FAILED_UFS_RENAME.getMessage(mTemporaryPath, mPermanentPath));
       }
     } catch (IOException e) {
-      if (!mUfs.deleteFile(mTemporaryPath)) {
-        LOG.warn("Failed to delete temporary file {}", mTemporaryPath);
+      try {
+        if (!mUfs.deleteFile(mTemporaryPath)) {
+          LOG.warn("Failed to delete temporary file {} after failing to rename it to {}",
+              mTemporaryPath, mPermanentPath);
+        }
+      } catch (IOException e2) {
+        LOG.warn("Exception when deleting temporary file {} after failing to rename it to {}",
+            mTemporaryPath, mPermanentPath, e2);
       }
+      throw e;
     }
 
     // Preserve owner and group in case delegation was used to create the path

--- a/dora/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -22,7 +22,7 @@ import alluxio.retry.RetryPolicy;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
-import alluxio.underfs.options.GetFileStatusOptions;
+import alluxio.underfs.options.GetStatusOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
@@ -512,7 +512,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public UfsFileStatus getFileStatus(String path, GetFileStatusOptions options) throws IOException {
+  public UfsFileStatus getFileStatus(String path, GetStatusOptions options) throws IOException {
     ObjectStatus details = getObjectStatus(stripPrefixIfPresent(path));
     if (details != null) {
       ObjectPermissions permissions = getPermissions();
@@ -531,7 +531,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public UfsStatus getStatus(String path) throws IOException {
+  public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
     if (isRoot(path)) {
       return getDirectoryStatus(path);
     }

--- a/dora/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -25,7 +25,7 @@ import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
-import alluxio.underfs.options.GetFileStatusOptions;
+import alluxio.underfs.options.GetStatusOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
@@ -426,7 +426,7 @@ public interface UnderFileSystem extends Closeable {
    * @throws FileNotFoundException when the path does not exist
    */
   default UfsFileStatus getFileStatus(String path) throws IOException {
-    return getFileStatus(path, GetFileStatusOptions.defaults());
+    return getFileStatus(path, GetStatusOptions.defaults());
   }
 
   /**
@@ -438,7 +438,7 @@ public interface UnderFileSystem extends Closeable {
    * @return the file status
    * @throws FileNotFoundException when the path does not exist
    */
-  UfsFileStatus getFileStatus(String path, GetFileStatusOptions options) throws IOException;
+  UfsFileStatus getFileStatus(String path, GetStatusOptions options) throws IOException;
 
   /**
    * Gets the file status.
@@ -532,7 +532,9 @@ public interface UnderFileSystem extends Closeable {
    * @return the file or directory status
    * @throws FileNotFoundException when the path does not exist
    */
-  UfsStatus getStatus(String path) throws IOException;
+  default UfsStatus getStatus(String path) throws IOException {
+    return getStatus(path, GetStatusOptions.defaults());
+  }
 
   /**
    * Gets the file or directory status. The caller does not need to know if the path is a file or
@@ -543,9 +545,7 @@ public interface UnderFileSystem extends Closeable {
    * @return the file or directory status
    * @throws FileNotFoundException when the path does not exist
    */
-  default UfsStatus getStatus(String path, GetFileStatusOptions options) throws IOException {
-    return getStatus(path);
-  }
+  UfsStatus getStatus(String path, GetStatusOptions options) throws IOException;
 
   /**
    * Gets the file or directory status.

--- a/dora/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -30,7 +30,7 @@ import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
-import alluxio.underfs.options.GetFileStatusOptions;
+import alluxio.underfs.options.GetStatusOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
@@ -523,12 +523,12 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public UfsFileStatus getFileStatus(final String path, GetFileStatusOptions options)
+  public UfsFileStatus getFileStatus(final String path, GetStatusOptions options)
       throws IOException {
     return call(new UfsCallable<UfsFileStatus>() {
       @Override
       public UfsFileStatus call() throws IOException {
-        return mUnderFileSystem.getFileStatus(path);
+        return mUnderFileSystem.getFileStatus(path, options);
       }
 
       @Override
@@ -664,11 +664,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public UfsStatus getStatus(String path) throws IOException {
+  public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
     return call(new UfsCallable<UfsStatus>() {
       @Override
       public UfsStatus call() throws IOException {
-        return mUnderFileSystem.getStatus(path);
+        return mUnderFileSystem.getStatus(path, options);
       }
 
       @Override

--- a/dora/core/common/src/main/java/alluxio/underfs/options/GetStatusOptions.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/options/GetStatusOptions.java
@@ -14,7 +14,7 @@ package alluxio.underfs.options;
 /**
  * Method options for getting the status of a file in {@link alluxio.underfs.UnderFileSystem}.
  */
-public class GetFileStatusOptions {
+public class GetStatusOptions {
   private boolean mIncludeRealContentHash = false;
 
   /**
@@ -28,15 +28,15 @@ public class GetFileStatusOptions {
    * @param includeRealContentHash include real content hash flag value
    * @return the updated options object
    */
-  public GetFileStatusOptions setIncludeRealContentHash(boolean includeRealContentHash) {
+  public GetStatusOptions setIncludeRealContentHash(boolean includeRealContentHash) {
     mIncludeRealContentHash = includeRealContentHash;
     return this;
   }
 
   /**
-   * @return the default {@link GetFileStatusOptions}
+   * @return the default {@link GetStatusOptions}
    */
-  public static GetFileStatusOptions defaults() {
-    return new GetFileStatusOptions();
+  public static GetStatusOptions defaults() {
+    return new GetStatusOptions();
   }
 }

--- a/dora/core/server/master/src/main/java/alluxio/master/job/CopyJob.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/job/CopyJob.java
@@ -120,7 +120,7 @@ public class CopyJob extends AbstractJob<CopyJob.CopyTask> {
    * @param bandwidth           bandwidth
    * @param usePartialListing   whether to use partial listing
    * @param verificationEnabled whether to verify the job after loaded
-   * @param checkContent
+   * @param checkContent        whether to check content
    * @param fileIterable        file iterable
    */
   public CopyJob(String src, String dst, boolean overwrite, Optional<String> user, String jobId,

--- a/dora/core/server/master/src/main/java/alluxio/master/job/CopyJobFactory.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/job/CopyJobFactory.java
@@ -57,6 +57,7 @@ public class CopyJobFactory implements JobFactory {
     boolean partialListing = options.hasPartialListing() && options.getPartialListing();
     boolean verificationEnabled = options.hasVerify() && options.getVerify();
     boolean overwrite = options.hasOverwrite() && options.getOverwrite();
+    boolean checkContent = options.hasCheckContent() && options.getCheckContent();
     WriteType writeType = options.hasWriteType() ? WriteType.fromProto(options.getWriteType()) :
         Configuration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class);
     Iterable<FileInfo> fileIterator = new UfsFileIterable(mFs, src, Optional
@@ -66,7 +67,7 @@ public class CopyJobFactory implements JobFactory {
         .ofNullable(AuthenticatedClientUser.getOrNull())
         .map(User::getName);
     return new CopyJob(src, mRequest.getDst(), overwrite, user, UUID.randomUUID().toString(),
-        bandwidth, partialListing, verificationEnabled, fileIterator);
+        bandwidth, partialListing, verificationEnabled, checkContent, fileIterator);
   }
 }
 

--- a/dora/core/server/master/src/main/java/alluxio/master/job/JournalCopyJobFactory.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/job/JournalCopyJobFactory.java
@@ -61,7 +61,7 @@ public class JournalCopyJobFactory implements JobFactory {
             mJobEntry.getJobId(),
             mJobEntry.hasBandwidth() ? OptionalLong.of(mJobEntry.getBandwidth()) :
                 OptionalLong.empty(), mJobEntry.getPartialListing(), mJobEntry.getVerify(),
-            fileIterator);
+            mJobEntry.getCheckContent(), fileIterator);
     return job;
   }
 }

--- a/dora/core/server/master/src/main/java/alluxio/master/job/UfsFileIterable.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/job/UfsFileIterable.java
@@ -119,7 +119,8 @@ public class UfsFileIterable implements Iterable<FileInfo> {
     private void listFileInfos() {
       try {
         AuthenticatedClientUser.set(mUser.orElse(null));
-        Optional<UfsStatus[]> ufsStatuses = mFs.listStatuses(mPath, ListOptions.defaults());
+        Optional<UfsStatus[]> ufsStatuses =
+            mFs.listStatuses(mPath, ListOptions.defaults().setRecursive(true));
         if (!ufsStatuses.isPresent() || ufsStatuses.get().length == 0) {
           mFiles = Collections.emptyList();
           mFileInfoIterator = Collections.emptyIterator();

--- a/dora/core/server/master/src/main/java/alluxio/master/job/UfsFileIterable.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/job/UfsFileIterable.java
@@ -140,7 +140,7 @@ public class UfsFileIterable implements Iterable<FileInfo> {
       AlluxioURI ufsUri = new AlluxioURI(PathUtils.concatPath(mPath,
           CommonUtils.stripPrefixIfPresent(ufsStatus.getName(), mPath)));
       FileInfo info = new FileInfo().setName(ufsUri.getName()).setPath(ufsUri.getPath())
-                                    .setUfsPath(ufsUri.getPath())
+                                    .setUfsPath(ufsUri.toString())
                                     .setFolder(ufsStatus.isDirectory())
                                     .setOwner(ufsStatus.getOwner()).setGroup(ufsStatus.getGroup())
                                     .setMode(ufsStatus.getMode()).setCompleted(true);

--- a/dora/core/server/master/src/main/java/alluxio/master/scheduler/Scheduler.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/scheduler/Scheduler.java
@@ -473,7 +473,9 @@ public final class Scheduler {
             job.setJobSuccess();
           }
           else {
-            job.failJob(new InternalRuntimeException("Job failed because it's not healthy."));
+            if (job.getJobState() != JobState.FAILED) {
+              job.failJob(new InternalRuntimeException("Job failed because it's not healthy."));
+            }
           }
         }
       }

--- a/dora/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTest.java
@@ -340,7 +340,8 @@ public final class FileSystemMasterSyncMetadataTest {
     Mockito.when(mUfs.exists(dir1Path.toString())).thenReturn(true);
     Mockito.when(mUfs.isDirectory(dir1Path.toString())).thenReturn(true);
     Mockito.when(mUfs.isFile(dir1Path.toString())).thenReturn(false);
-    Mockito.when(mUfs.getStatus(dir1Path.toString())).thenReturn(dir1Status);
+    Mockito.when(mUfs.getStatus(eq(dir1Path.toString()), any(GetStatusOptions.class)))
+           .thenReturn(dir1Status);
     Mockito.when(mUfs.getDirectoryStatus(dir1Path.toString())).thenReturn(dir1Status);
 
     // Mock nested ufs path /dir1/dir2
@@ -353,7 +354,8 @@ public final class FileSystemMasterSyncMetadataTest {
     Mockito.when(mUfs.exists(nestedDirectoryPath.toString())).thenReturn(true);
     Mockito.when(mUfs.isDirectory(nestedDirectoryPath.toString())).thenReturn(true);
     Mockito.when(mUfs.isFile(nestedDirectoryPath.toString())).thenReturn(false);
-    Mockito.when(mUfs.getStatus(nestedDirectoryPath.toString())).thenReturn(nestedDirStatus);
+    Mockito.when(mUfs.getStatus(eq(nestedDirectoryPath.toString()), any(GetStatusOptions.class)))
+           .thenReturn(nestedDirStatus);
     Mockito.when(mUfs.getDirectoryStatus(nestedDirectoryPath.toString()))
         .thenReturn(nestedDirStatus);
 
@@ -375,7 +377,7 @@ public final class FileSystemMasterSyncMetadataTest {
     Mockito.verify(mUfs, Mockito.times(1))
         .listStatus(eq(nestedDirectoryPath.toString()));
     Mockito.verify(mUfs, Mockito.times(1))
-        .getStatus(eq(nestedDirectoryPath.toString()));
+        .getStatus(eq(nestedDirectoryPath.toString()), any(GetStatusOptions.class));
 
     // Get the file info of the directory /dir1
     // listStatus is called on UFS /dir1/dir2
@@ -388,7 +390,7 @@ public final class FileSystemMasterSyncMetadataTest {
     Mockito.verify(mUfs, Mockito.times(1))
         .listStatus(eq(nestedDirectoryPath.toString()));
     Mockito.verify(mUfs, Mockito.times(1))
-        .getStatus(eq(nestedDirectoryPath.toString()));
+        .getStatus(eq(nestedDirectoryPath.toString()), any(GetStatusOptions.class));
   }
 
   private static class SyncAwareFileSystemMaster extends DefaultFileSystemMaster {

--- a/dora/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTestBase.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTestBase.java
@@ -35,6 +35,7 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.local.LocalUnderFileSystem;
 import alluxio.underfs.options.DeleteOptions;
+import alluxio.underfs.options.GetStatusOptions;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.io.PathUtils;
@@ -146,7 +147,7 @@ public class FileSystemMasterSyncMetadataTestBase {
     }
 
     @Override
-    public UfsStatus getStatus(String path) throws IOException {
+    public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
       for (String failedPathsString: mFailedPaths) {
         if (path.contains(failedPathsString)) {
           throw new RuntimeException();
@@ -166,7 +167,7 @@ public class FileSystemMasterSyncMetadataTestBase {
           throw new RuntimeException(e);
         }
       }
-      return super.getStatus(path);
+      return super.getStatus(path, options);
     }
 
     @Override

--- a/dora/core/server/master/src/test/java/alluxio/master/file/scheduler/CopyJobTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/file/scheduler/CopyJobTest.java
@@ -55,7 +55,7 @@ public class CopyJobTest {
     FileIterable files =
         new FileIterable(fileSystemMaster, srcPath, user, false, CopyJob.QUALIFIED_FILE_FILTER);
     CopyJob copy = new CopyJob(srcPath, dstPath, false, user, "1",
-        OptionalLong.empty(), false, false, files);
+        OptionalLong.empty(), false, false, false, files);
     Optional<CopyJob.CopyTask> nextTask = copy.getNextTask(null);
     Assert.assertEquals(5, nextTask.get().getRoutes().size());
   }
@@ -72,7 +72,7 @@ public class CopyJobTest {
     FileIterable files =
         new FileIterable(fileSystemMaster, srcPath, user, false, CopyJob.QUALIFIED_FILE_FILTER);
     CopyJob copy = new CopyJob(srcPath, dstPath, false, user, "1",
-        OptionalLong.empty(), false, false, files);
+        OptionalLong.empty(), false, false, false, files);
     List<Route> routes = copy.getNextRoutes(100);
     assertTrue(copy.isHealthy());
     routes.forEach(copy::addToRetry);
@@ -94,7 +94,7 @@ public class CopyJobTest {
     FileIterable files =
         new FileIterable(fileSystemMaster, srcPath, user, false, CopyJob.QUALIFIED_FILE_FILTER);
     CopyJob job = spy(new CopyJob(srcPath, dstPath, false, user, "1",
-        OptionalLong.empty(), false, false, files));
+        OptionalLong.empty(), false, false, false, files));
     when(job.getDurationInSec()).thenReturn(0L);
     job.setJobState(JobState.RUNNING);
     List<Route> nextRoutes = job.getNextRoutes(25);

--- a/dora/core/server/worker/src/main/java/alluxio/worker/task/CopyHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/task/CopyHandler.java
@@ -25,6 +25,7 @@ import alluxio.grpc.Bits;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.ErrorType;
+import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.PMode;
 import alluxio.grpc.Route;
 import alluxio.grpc.WriteOptions;
@@ -47,6 +48,8 @@ import java.util.Objects;
  */
 public final class CopyHandler {
   private static final Logger LOG = LoggerFactory.getLogger(CopyHandler.class);
+  private static final GetStatusPOptions GET_STATUS_OPTIONS =
+      GetStatusPOptions.getDefaultInstance().toBuilder().setIncludeRealContentHash(true).build();
 
   /**
    * Copies a file from source to destination.
@@ -64,7 +67,7 @@ public final class CopyHandler {
     URIStatus dstStatus = null;
     URIStatus sourceStatus;
     try {
-      dstStatus = dstFs.getStatus(dst);
+      dstStatus = dstFs.getStatus(dst, GET_STATUS_OPTIONS);
     } catch (FileNotFoundException | NotFoundRuntimeException ignore) {
       // ignored
     } catch (FileDoesNotExistException ignore) {
@@ -73,7 +76,7 @@ public final class CopyHandler {
       throw new InternalRuntimeException(e);
     }
     try {
-      sourceStatus = srcFs.getStatus(src);
+      sourceStatus = srcFs.getStatus(src, GET_STATUS_OPTIONS);
     } catch (Exception e) {
       throw AlluxioRuntimeException.from(e);
     }
@@ -159,7 +162,7 @@ public final class CopyHandler {
       String srcContentHash = parseContentHash(sourceStatus);
       URIStatus dstStatus;
       try {
-        dstStatus = dstFs.getStatus(dst);
+        dstStatus = dstFs.getStatus(dst, GET_STATUS_OPTIONS);
       } catch (Exception e) {
         throw AlluxioRuntimeException.from(e);
       }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/task/CopyHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/task/CopyHandler.java
@@ -18,7 +18,6 @@ import alluxio.client.file.URIStatus;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.runtime.AlluxioRuntimeException;
-import alluxio.exception.runtime.AlreadyExistsRuntimeException;
 import alluxio.exception.runtime.InternalRuntimeException;
 import alluxio.exception.runtime.InvalidArgumentRuntimeException;
 import alluxio.exception.runtime.NotFoundRuntimeException;
@@ -79,8 +78,10 @@ public final class CopyHandler {
       throw AlluxioRuntimeException.from(e);
     }
     if (dstStatus != null && !writeOptions.getOverwrite()) {
-      throw new AlreadyExistsRuntimeException("File " + route.getDst()
+      // skip the file if it already exists
+      LOG.debug("File " + route.getDst()
           + " is already persisted in UFS, to overwrite the file, please set the overwrite flag");
+      return;
     }
 
     if (dstStatus != null && (dstStatus.isFolder() != sourceStatus.isFolder())) {

--- a/dora/core/server/worker/src/test/java/alluxio/worker/dora/PagedDoraWorkerTest.java
+++ b/dora/core/server/worker/src/test/java/alluxio/worker/dora/PagedDoraWorkerTest.java
@@ -113,7 +113,8 @@ public class PagedDoraWorkerTest {
     Route route =
         Route.newBuilder().setDst(b.getAbsolutePath()).setSrc(a.getAbsolutePath()).setLength(length)
              .build();
-    WriteOptions writeOptions = WriteOptions.newBuilder().setOverwrite(false).build();
+    WriteOptions writeOptions =
+        WriteOptions.newBuilder().setOverwrite(false).setCheckContent(true).build();
     UfsReadOptions read =
         UfsReadOptions.newBuilder().setUser("test").setTag("1").setPositionShort(false).build();
     ListenableFuture<List<RouteFailure>> copy =
@@ -162,7 +163,8 @@ public class PagedDoraWorkerTest {
     File b = new File(dstRoot, "b");
     Route route =
         Route.newBuilder().setDst(b.getAbsolutePath()).setSrc(a.getAbsolutePath()).build();
-    WriteOptions writeOptions = WriteOptions.newBuilder().setOverwrite(false).build();
+    WriteOptions writeOptions =
+        WriteOptions.newBuilder().setOverwrite(false).setCheckContent(true).build();
     UfsReadOptions read =
         UfsReadOptions.newBuilder().setUser("test").setTag("1").setPositionShort(false).build();
     ListenableFuture<List<RouteFailure>> copy =
@@ -202,7 +204,8 @@ public class PagedDoraWorkerTest {
     routes.add(route);
     routes.add(route2);
     routes.add(route3);
-    WriteOptions writeOptions = WriteOptions.newBuilder().setOverwrite(false).build();
+    WriteOptions writeOptions =
+        WriteOptions.newBuilder().setOverwrite(false).setCheckContent(true).build();
     UfsReadOptions read =
         UfsReadOptions.newBuilder().setUser("test").setTag("1").setPositionShort(false).build();
     ListenableFuture<List<RouteFailure>> copy = mWorker.copy(routes, read, writeOptions);

--- a/dora/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
+++ b/dora/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
@@ -28,7 +28,7 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
-import alluxio.underfs.options.GetFileStatusOptions;
+import alluxio.underfs.options.GetStatusOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
@@ -167,7 +167,7 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public UfsFileStatus getFileStatus(String path, GetFileStatusOptions options) throws IOException {
+  public UfsFileStatus getFileStatus(String path, GetStatusOptions options) throws IOException {
     return mUfs.getFileStatus(path, options);
   }
 
@@ -207,8 +207,8 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public UfsStatus getStatus(String path) throws IOException {
-    return mUfs.getStatus(path);
+  public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
+    return mUfs.getStatus(path, options);
   }
 
   @Override

--- a/dora/tests/src/test/java/alluxio/testutils/underfs/sleeping/SleepingUnderFileSystem.java
+++ b/dora/tests/src/test/java/alluxio/testutils/underfs/sleeping/SleepingUnderFileSystem.java
@@ -21,7 +21,7 @@ import alluxio.underfs.local.LocalUnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
-import alluxio.underfs.options.GetFileStatusOptions;
+import alluxio.underfs.options.GetStatusOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
@@ -133,15 +133,15 @@ public class SleepingUnderFileSystem extends LocalUnderFileSystem {
   }
 
   @Override
-  public UfsStatus getStatus(String path) throws IOException {
+  public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
     sleepIfNecessary(mOptions.getGetStatusMs());
-    return super.getStatus(cleanPath(path));
+    return super.getStatus(cleanPath(path), options);
   }
 
   @Override
-  public UfsFileStatus getFileStatus(String path, GetFileStatusOptions options) throws IOException {
+  public UfsFileStatus getFileStatus(String path, GetStatusOptions options) throws IOException {
     sleepIfNecessary(mOptions.getGetFileStatusMs());
-    return super.getFileStatus(cleanPath(path));
+    return super.getFileStatus(cleanPath(path), options);
   }
 
   @Override

--- a/dora/underfs/abfs/src/main/java/alluxio/underfs/abfs/AbfsUnderFileSystem.java
+++ b/dora/underfs/abfs/src/main/java/alluxio/underfs/abfs/AbfsUnderFileSystem.java
@@ -18,6 +18,7 @@ import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.hdfs.HdfsUnderFileSystem;
 import alluxio.underfs.options.FileLocationOptions;
+import alluxio.underfs.options.GetStatusOptions;
 
 import com.google.common.base.MoreObjects;
 import org.apache.hadoop.conf.Configuration;
@@ -128,8 +129,8 @@ public class AbfsUnderFileSystem extends HdfsUnderFileSystem {
   }
 
   @Override
-  public UfsStatus getStatus(String path) throws IOException {
-    UfsStatus status = super.getStatus(path);
+  public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
+    UfsStatus status = super.getStatus(path, options);
     if (status instanceof UfsFileStatus) {
       // abfs is backed by an object store but always claims its block size to be 512MB.
       // reset the block size in UfsFileStatus according to getBlockSizeByte

--- a/dora/underfs/adl/src/main/java/alluxio/underfs/adl/AdlUnderFileSystem.java
+++ b/dora/underfs/adl/src/main/java/alluxio/underfs/adl/AdlUnderFileSystem.java
@@ -19,6 +19,7 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.hdfs.HdfsUnderFileSystem;
 import alluxio.underfs.options.FileLocationOptions;
+import alluxio.underfs.options.GetStatusOptions;
 
 import com.google.common.base.MoreObjects;
 import org.apache.hadoop.conf.Configuration;
@@ -100,8 +101,8 @@ public class AdlUnderFileSystem extends HdfsUnderFileSystem {
   }
 
   @Override
-  public UfsStatus getStatus(String path) throws IOException {
-    UfsStatus status = super.getStatus(path);
+  public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
+    UfsStatus status = super.getStatus(path, options);
     if (status instanceof UfsFileStatus) {
       // adl is backed by an object store but always claims its block size to be 512MB.
       // reset the block size in UfsFileStatus according to getBlockSizeByte

--- a/dora/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystem.java
+++ b/dora/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystem.java
@@ -30,7 +30,7 @@ import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
-import alluxio.underfs.options.GetFileStatusOptions;
+import alluxio.underfs.options.GetStatusOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
 import alluxio.util.UnderFileSystemUtils;
@@ -354,7 +354,7 @@ public class CephFSUnderFileSystem extends ConsistentUnderFileSystem
   }
 
   @Override
-  public UfsStatus getStatus(String path) throws IOException {
+  public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
     path = stripPath(path);
     CephStat stat = new CephStat();
     lstat(path, stat);
@@ -389,7 +389,7 @@ public class CephFSUnderFileSystem extends ConsistentUnderFileSystem
    * @throws FileNotFoundException if the path could not be resolved
    */
   @Override
-  public UfsFileStatus getFileStatus(String path, GetFileStatusOptions options) throws IOException {
+  public UfsFileStatus getFileStatus(String path, GetStatusOptions options) throws IOException {
     path = stripPath(path);
     CephStat stat = new CephStat();
     lstat(path, stat);

--- a/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -33,7 +33,7 @@ import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
-import alluxio.underfs.options.GetFileStatusOptions;
+import alluxio.underfs.options.GetStatusOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
 import alluxio.util.CommonUtils;
@@ -437,7 +437,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
   }
 
   @Override
-  public UfsFileStatus getFileStatus(String path, GetFileStatusOptions options) throws IOException {
+  public UfsFileStatus getFileStatus(String path, GetStatusOptions options) throws IOException {
     Path tPath = new Path(path);
     FileSystem hdfs = getFs();
     FileStatus fs = hdfs.getFileStatus(tPath);
@@ -481,7 +481,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
   }
 
   @Override
-  public UfsStatus getStatus(String path, GetFileStatusOptions options) throws IOException {
+  public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
     Path tPath = new Path(path);
     FileSystem hdfs = getFs();
     FileStatus fs = hdfs.getFileStatus(tPath);
@@ -495,23 +495,6 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
         contentHash =
             UnderFileSystemUtils.approximateContentHash(fs.getLen(), fs.getModificationTime());
       }
-      return new UfsFileStatus(path, contentHash, fs.getLen(), fs.getModificationTime(),
-          fs.getOwner(), fs.getGroup(), fs.getPermission().toShort(), fs.getBlockSize());
-    }
-    // Return directory status.
-    return new UfsDirectoryStatus(path, fs.getOwner(), fs.getGroup(), fs.getPermission().toShort(),
-        fs.getModificationTime());
-  }
-
-  @Override
-  public UfsStatus getStatus(String path) throws IOException {
-    Path tPath = new Path(path);
-    FileSystem hdfs = getFs();
-    FileStatus fs = hdfs.getFileStatus(tPath);
-    if (!fs.isDir()) {
-      // Return file status.
-      String contentHash =
-          UnderFileSystemUtils.approximateContentHash(fs.getLen(), fs.getModificationTime());
       return new UfsFileStatus(path, contentHash, fs.getLen(), fs.getModificationTime(),
           fs.getOwner(), fs.getGroup(), fs.getPermission().toShort(), fs.getBlockSize());
     }

--- a/dora/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
+++ b/dora/underfs/wasb/src/main/java/alluxio/underfs/wasb/WasbUnderFileSystem.java
@@ -20,6 +20,7 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.hdfs.HdfsUnderFileSystem;
 import alluxio.underfs.options.FileLocationOptions;
+import alluxio.underfs.options.GetStatusOptions;
 
 import com.google.common.base.MoreObjects;
 import org.apache.hadoop.conf.Configuration;
@@ -103,8 +104,8 @@ public class WasbUnderFileSystem extends HdfsUnderFileSystem {
   }
 
   @Override
-  public UfsStatus getStatus(String path) throws IOException {
-    UfsStatus status = super.getStatus(path);
+  public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
+    UfsStatus status = super.getStatus(path, options);
     if (status instanceof UfsFileStatus) {
       // wasb is backed by an object store but always claims its block size to be 512MB.
       // reset the block size in UfsFileStatus according to getBlockSizeByte

--- a/dora/underfs/web/src/main/java/alluxio/underfs/web/WebUnderFileSystem.java
+++ b/dora/underfs/web/src/main/java/alluxio/underfs/web/WebUnderFileSystem.java
@@ -24,7 +24,7 @@ import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
-import alluxio.underfs.options.GetFileStatusOptions;
+import alluxio.underfs.options.GetStatusOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
 import alluxio.util.UnderFileSystemUtils;
@@ -135,8 +135,8 @@ public class WebUnderFileSystem extends ConsistentUnderFileSystem {
   }
 
   @Override
-  public UfsFileStatus getFileStatus(String path, GetFileStatusOptions options) throws IOException {
-    UfsStatus ufsStatus = getStatus(path);
+  public UfsFileStatus getFileStatus(String path, GetStatusOptions options) throws IOException {
+    UfsStatus ufsStatus = getStatus(path, options);
     if (ufsStatus instanceof UfsFileStatus) {
       return (UfsFileStatus) ufsStatus;
     }
@@ -187,8 +187,8 @@ public class WebUnderFileSystem extends ConsistentUnderFileSystem {
   }
 
   @Override
-  public UfsStatus getStatus(String path) throws IOException {
-    return getStatus(path, GetFileStatusOptions.defaults());
+  public UfsStatus getStatus(String path, GetStatusOptions options) throws IOException {
+    return getStatus(path, (String) null);
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?
Couple fixes for copy on dora
1. support passing check content option from cli
2. support passing ufs full path from cli
3. delete temp file only when exceptional case
4. skip if file is already in dst instead of throw exception
5. cleanup getStatus method in ufs and fix bugs that we don't pass options down to some ufs
6. add real content hash to local ufs and test


### Why are the changes needed?

improvement

### Does this PR introduce any user facing changes?

new `checkContent`option for copy job
