### PR TITLE
Fix pl path for modules

### DIFF
--- a/dev/scripts/src/alluxio.org/build/modules.yml
+++ b/dev/scripts/src/alluxio.org/build/modules.yml
@@ -76,7 +76,7 @@ pluginModules:
   ufs-hadoop-2.7:
     moduleType: hdfs
     enumName: hadoop-2.7
-    mavenArgs: "-pl underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.7.3 -PhdfsActiveSync"
+    mavenArgs: "-pl dora/underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.7.3 -PhdfsActiveSync"
     generatedJarPath: "lib/alluxio-underfs-hdfs-2.7.3-${VERSION}.jar"
     tarballJarPath: "lib/alluxio-underfs-hadoop-2.7-${VERSION}.jar"
     bundleWith:
@@ -85,7 +85,7 @@ pluginModules:
   ufs-hadoop-2.10:
     moduleType: hdfs
     enumName: hadoop-2.10
-    mavenArgs: "-pl underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.10.1 -PhdfsActiveSync"
+    mavenArgs: "-pl dora/underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.10.1 -PhdfsActiveSync"
     generatedJarPath: "lib/alluxio-underfs-hdfs-2.10.1-${VERSION}.jar"
     tarballJarPath: "lib/alluxio-underfs-hadoop-2.10-${VERSION}.jar"
     bundleWith:
@@ -93,7 +93,7 @@ pluginModules:
   ufs-hadoop-3.3:
     moduleType: hdfs
     enumName: hadoop-3.3
-    mavenArgs: "-pl underfs/hdfs -Pufs-hadoop-3 -Dufs.hadoop.version=3.3.1 -PhdfsActiveSync"
+    mavenArgs: "-pl dora/underfs/hdfs -Pufs-hadoop-3 -Dufs.hadoop.version=3.3.1 -PhdfsActiveSync"
     generatedJarPath: "lib/alluxio-underfs-hdfs-3.3.1-${VERSION}.jar"
     tarballJarPath: "lib/alluxio-underfs-hadoop-3.3-${VERSION}.jar"
     bundleWith:
@@ -101,14 +101,14 @@ pluginModules:
       - fuse
   ufs-hadoop-ozone-1.2.1:
     moduleType: ozone
-    mavenArgs: "-pl underfs/ozone -Pufs-hadoop-3 -Dufs.ozone.version=1.2.1"
+    mavenArgs: "-pl dora/underfs/ozone -Pufs-hadoop-3 -Dufs.ozone.version=1.2.1"
     generatedJarPath: "lib/alluxio-underfs-ozone-${VERSION}.jar"
     tarballJarPath: "lib/alluxio-underfs-hadoop-ozone-1.2.1-${VERSION}.jar"
     bundleWith:
       - default
   ufs-hadoop-cosn-3.1.0-5.8.5:
     moduleType: cosn
-    mavenArgs: "-pl underfs/cosn -Dufs.cosn.version=3.1.0-5.8.5"
+    mavenArgs: "-pl dora/underfs/cosn -Dufs.cosn.version=3.1.0-5.8.5"
     generatedJarPath: "lib/alluxio-underfs-cosn-${VERSION}.jar"
     tarballJarPath: "lib/alluxio-underfs-hadoop-cosn-3.1.0-5.8.5-${VERSION}.jar"
     bundleWith:


### PR DESCRIPTION
module paths need to be renamed after moving module directories under `dora/`