### PR TITLE
Upgrade maven surefire plugin to remove build warnings

### DIFF
--- a/dev/github/run_tests.sh
+++ b/dev/github/run_tests.sh
@@ -30,7 +30,7 @@ fi
 mvn_args=""
 if [ -n "${ALLUXIO_MVN_RUNTOEND}" ]
 then
-  mvn_args+=" -fn -DfailIfNoTests=false --fail-at-end"
+  mvn_args+=" -fn -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false --fail-at-end"
 fi
 
 mvn_project_list=""

--- a/pom.xml
+++ b/pom.xml
@@ -1010,7 +1010,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0</version>
           <configuration>
             <argLine>@{argLine} -Djava.net.preferIPv4Stack=true</argLine>
             <excludesFile>${build.path}/surefire/${surefire.excludesFile}</excludesFile>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Upgrade maven-surefire-plugin to 3.0.0 to eliminate the following warning message: 

```
[WARNING] Parameter 'localRepository' is deprecated core expression; 
Avoid use of ArtifactRepository type. 
If you need access to local repository, switch to '${repositorySystemSession}' expression and get LRM from it instead.
```

### Why are the changes needed?

Codebase hygiene

This warning is because maven deprecated parameter `localRepository` MNG-7706 in maven 3.9.1;
But there are a set of maven plugins still using it and upgrade is needed to adopt the change on maven.
Upgrade surefire [SUREFIRE-2154] to remove this message

### Does this PR introduce any user facing changes?

No
