### PR TITLE
Remove hardcoded VERSION in libexec/alluxio-config.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 /integration/docker/*.tar.gz
 /journal/
 /lib/*.jar
+/libexec/version.sh
 /logs/*.log*
 /logs/*.out*
 /logs/user/*

--- a/build/version/write_version.sh
+++ b/build/version/write_version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "VERSION=${1}" > libexec/version.sh
+

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -186,6 +186,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		"conf/log4j.properties",
 		"conf/metrics.properties.template",
 		"libexec/alluxio-config.sh",
+		"libexec/version.sh",
 		"LICENSE",
 	}
 	if !fuse {

--- a/dev/scripts/src/alluxio.org/build/profiles.yml
+++ b/dev/scripts/src/alluxio.org/build/profiles.yml
@@ -56,6 +56,7 @@ default:
       - integration/metrics/otel-collector-config.yaml
       - integration/metrics/prometheus.yaml
       - libexec/alluxio-config.sh
+      - libexec/version.sh
       - LICENSE
 fuse:
   mvnArgs: ""
@@ -75,6 +76,7 @@ fuse:
       - conf/metrics.properties.template
       - dora/integration/fuse/bin/alluxio-fuse
       - libexec/alluxio-config.sh
+      - libexec/version.sh
       - LICENSE
     symlinks:
       bin/alluxio-fuse: ../../dora/integration/fuse/bin/alluxio-fuse

--- a/dev/scripts/update-versions.sh
+++ b/dev/scripts/update-versions.sh
@@ -57,13 +57,6 @@ function update_poms() {
 # Arguments:
 #  $1: old version
 #  $2: new version
-function update_libexec() {
-    perl -pi -e "s/${1}/${2}/g" libexec/alluxio-config.sh
-}
-
-# Arguments:
-#  $1: old version
-#  $2: new version
 function update_readme() {
     perl -pi -e "s/${1}/${2}/g" README.md
 }
@@ -127,7 +120,6 @@ function main() {
 
     update_dataproc "$_old" "$_new"
     update_emr "$_old" "$_new"
-    update_libexec "$_old" "$_new"
     update_readme "$_old" "$_new"
     update_docs "$_old" "$_new"
     update_dockerfiles "$_old" "$_new"

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -25,9 +25,11 @@ script=$(basename "${this}")
 config_bin=$(cd "${config_bin}"; pwd)
 this="${config_bin}/${script}"
 
+# Set Alluxio version from generated script
+. ${config_bin}/version.sh
+
 # This will set the default installation for a tarball installation while os distributors can
 # set system installation locations.
-VERSION=295-SNAPSHOT
 ALLUXIO_HOME=$(dirname $(dirname "${this}"))
 ALLUXIO_ASSEMBLY_CLIENT_JAR="${ALLUXIO_HOME}/assembly/client/target/alluxio-assembly-client-${VERSION}-jar-with-dependencies.jar"
 ALLUXIO_ASSEMBLY_SERVER_JAR="${ALLUXIO_HOME}/assembly/server/target/alluxio-assembly-server-${VERSION}-jar-with-dependencies.jar"

--- a/pom.xml
+++ b/pom.xml
@@ -1238,6 +1238,7 @@
                 <exclude>dev/scripts/tarballs/**/*</exclude>
                 <exclude>dev/scripts/workdir/**/*</exclude>
                 <exclude>generated/**</exclude>
+                <exclude>libexec/version.sh</exclude>
                 <exclude>**/.checkstyle</exclude>
                 <exclude>**/src/main/assembly/*</exclude>
                 <exclude>**/.idea/**</exclude>
@@ -1303,6 +1304,26 @@
             </goals>
             <configuration>
               <executable>${build.path}/style/check_no_windows_line_endings.sh</executable>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Create libexec/version.sh -->
+      <plugin>
+        <artifactId>exec-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>Write version string in generated packaged script</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${build.path}/version/write_version.sh</executable>
+              <arguments>${project.version}</arguments>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
previously the VERSION env variable was defined in libexec/alluxio-config.sh. the variable exists to properly locate various files bundled as part of the compiled alluxio package, such as when bundling as a tarball, because the pom.xml file is not included. however this led to having two sources of defining the version string, one in pom.xml and the other in alluxio-config.sh. they happened to be usually in sync because update-versions.sh will replace the version string in both of them simultaneously.

after this change, the version string is printed out when compiling the repo, written to a generated version.sh file. this file is sourced by alluxio-config.sh to maintain backcompat and is included in the tarball packaging. this results in the single source of truth:
- within the repo, the pom.xml defines the version and subsequently generates libexec/version.sh
- outside of the repo when pom.xml is not present, such as in the packaged tarball, libexec/version.sh defines the version
