### PR TITLE
Use local conf to create filesystem for s3proxy

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -428,7 +428,9 @@ public final class S3RestUtils {
 
     final Subject subject = new Subject();
     subject.getPrincipals().add(new User(user));
-    return FileSystem.Factory.get(subject, fs.getConf());
+    // Use local conf to create filesystem rather than fs.getConf()
+    // due to fs conf will be changed by merged cluster conf.
+    return FileSystem.Factory.get(subject, Configuration.global());
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

When the filesystem establishes a connection with the master, the configuration of the filesystem will be overridden by the master's configuration, resulting in changes. Therefore, we should not use the configuration of the filesystem anymore, but instead use the configuration of the local client.

### Why are the changes needed?

It is very common for the master configuration and client configuration to be different. We should avoid the newly created filesystem from being influenced by the server.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
