### PR TITLE
Support multipart upload of S3, OSS, COS and OBS

### DIFF
--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1290,7 +1290,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey UNDERFS_OBJECT_STORE_STREAMING_UPLOAD_PART_TIMEOUT =
       durationBuilder(Name.UNDERFS_OBJECT_STORE_STREAMING_UPLOAD_PART_TIMEOUT)
+          .setAlias("alluxio.underfs.object.store.streaming.upload.part.timeout")
           .setDescription("Timeout for uploading part when using streaming uploads.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OBJECT_STORE_MULTIPART_UPLOAD_TIMEOUT =
+      durationBuilder(Name.UNDERFS_OBJECT_STORE_MULTIPART_UPLOAD_TIMEOUT)
+          .setAlias("alluxio.underfs.object.store.multipart.upload.timeout")
+          .setDescription("Timeout for uploading part when using multipart upload.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
@@ -1570,7 +1578,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       durationBuilder(Name.UNDERFS_S3_INTERMEDIATE_UPLOAD_CLEAN_AGE)
           .setAlias("alluxio.underfs.s3a.intermediate.upload.clean.age")
           .setDefaultValue("3day")
-          .setDescription("Streaming uploads may not have been completed/aborted correctly "
+          .setDescription("Streaming uploads or multipart uploads"
+              + " may not have been completed/aborted correctly "
               + "and need periodical ufs cleanup. If ufs cleanup is enabled, "
               + "intermediate multipart uploads in all non-readonly S3 mount points "
               + "older than this age will be cleaned. This may impact other "
@@ -1663,6 +1672,25 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "S3A streaming upload. When the buffer file reaches the partition size, "
               + "it will be uploaded and the upcoming data will write to other buffer files."
               + "If the partition size is too small, S3A upload speed might be affected. ")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_S3_MULTIPART_UPLOAD_ENABLED =
+      booleanBuilder(Name.UNDERFS_S3_MULTIPART_UPLOAD_ENABLED)
+          .setAlias("alluxio.underfs.s3.multipart.upload.enabled")
+          .setDefaultValue(false)
+          .setDescription("(Experimental) If true, using multipart upload to write to S3.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_S3_MULTIPART_UPLOAD_PARTITION_SIZE =
+      dataSizeBuilder(Name.UNDERFS_S3_MULTIPART_UPLOAD_PARTITION_SIZE)
+          .setAlias("alluxio.underfs.s3.multipart.upload.partition.size")
+          .setDefaultValue("64MB")
+          .setDescription("Maximum allowable size of a single buffer file when using "
+              + "S3 Multipart upload. When the buffer file reaches the partition size, "
+              + "it will be uploaded and the upcoming data will write to other buffer files."
+              + "If the partition size is too small, S3 upload speed might be affected. ")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
@@ -1831,7 +1859,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey UNDERFS_OSS_INTERMEDIATE_UPLOAD_CLEAN_AGE =
       durationBuilder(Name.UNDERFS_OSS_INTERMEDIATE_UPLOAD_CLEAN_AGE)
           .setDefaultValue("3day")
-          .setDescription("Streaming uploads may not have been completed/aborted correctly "
+          .setDescription("Streaming uploads or multipart uploads"
+              + " may not have been completed/aborted correctly "
               + "and need periodical ufs cleanup. If ufs cleanup is enabled, "
               + "intermediate multipart uploads in all non-readonly OSS mount points "
               + "older than this age will be cleaned. This may impact other "
@@ -1861,6 +1890,30 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue(20)
           .setDescription("the number of threads to use for streaming upload data to OSS.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_MULTIPART_UPLOAD_ENABLED =
+      booleanBuilder(Name.UNDERFS_OSS_MULTIPART_UPLOAD_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("(Experimental) If true, using multipart upload to write to OSS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_MULTIPART_UPLOAD_THREADS =
+      intBuilder(Name.UNDERFS_OSS_MULTIPART_UPLOAD_THREADS)
+          .setDefaultValue(20)
+          .setDescription("the number of threads to use for multipart upload data to OSS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_MULTIPART_UPLOAD_PARTITION_SIZE =
+      dataSizeBuilder(Name.UNDERFS_OSS_MULTIPART_UPLOAD_PARTITION_SIZE)
+          .setDefaultValue("64MB")
+          .setDescription("Maximum allowable size of a single buffer file when using "
+              + "OSS multipart upload. When the buffer file reaches the partition size, "
+              + "it will be uploaded and the upcoming data will write to other buffer files."
+              + "If the partition size is too small, OSS upload speed might be affected. ")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey S3A_ACCESS_KEY = stringBuilder(Name.S3A_ACCESS_KEY)
@@ -2017,7 +2070,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey UNDERFS_OBS_INTERMEDIATE_UPLOAD_CLEAN_AGE =
       durationBuilder(Name.UNDERFS_OBS_INTERMEDIATE_UPLOAD_CLEAN_AGE)
           .setDefaultValue("3day")
-          .setDescription("Streaming uploads may not have been completed/aborted correctly "
+          .setDescription("Streaming uploads or multipart uploads"
+              + " may not have been completed/aborted correctly "
               + "and need periodical ufs cleanup. If ufs cleanup is enabled, "
               + "intermediate multipart uploads in all non-readonly OBS mount points "
               + "older than this age will be cleaned. This may impact other "
@@ -2047,6 +2101,54 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue(20)
           .setDescription("the number of threads to use for streaming upload data to OBS.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OBS_MULTIPART_UPLOAD_ENABLED =
+      booleanBuilder(Name.UNDERFS_OBS_MULTIPART_UPLOAD_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("(Experimental) If true, using multipart upload to write to OBS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OBS_MULTIPART_UPLOAD_THREADS =
+      intBuilder(Name.UNDERFS_OBS_MULTIPART_UPLOAD_THREADS)
+          .setDefaultValue(20)
+          .setDescription("the number of threads to use for multipart upload data to OBS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OBS_MULTIPART_UPLOAD_PARTITION_SIZE =
+      dataSizeBuilder(Name.UNDERFS_OBS_MULTIPART_UPLOAD_PARTITION_SIZE)
+          .setDefaultValue("64MB")
+          .setDescription("Maximum allowable size of a single buffer file when using "
+              + "OBS multipart upload. When the buffer file reaches the partition size, "
+              + "it will be uploaded and the upcoming data will write to other buffer files."
+              + "If the partition size is too small, OSS upload speed might be affected. ")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_COS_MULTIPART_UPLOAD_ENABLED =
+      booleanBuilder(Name.UNDERFS_COS_MULTIPART_UPLOAD_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("(Experimental) If true, using multipart upload to write to COS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_COS_MULTIPART_UPLOAD_THREADS =
+      intBuilder(Name.UNDERFS_COS_MULTIPART_UPLOAD_THREADS)
+          .setDefaultValue(20)
+          .setDescription("the number of threads to use for multipart upload data to COS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_COS_MULTIPART_UPLOAD_PARTITION_SIZE =
+      dataSizeBuilder(Name.UNDERFS_COS_MULTIPART_UPLOAD_PARTITION_SIZE)
+          .setDefaultValue("64MB")
+          .setDescription("Maximum allowable size of a single buffer file when using "
+              + "COS multipart upload. When the buffer file reaches the partition size, "
+              + "it will be uploaded and the upcoming data will write to other buffer files."
+              + "If the partition size is too small, OSS upload speed might be affected. ")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
   //
@@ -8035,6 +8137,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_VERSION = "alluxio.underfs.version";
     public static final String UNDERFS_OBJECT_STORE_STREAMING_UPLOAD_PART_TIMEOUT =
         "alluxio.underfs.object.store.streaming.upload.part.timeout";
+    public static final String UNDERFS_OBJECT_STORE_MULTIPART_UPLOAD_TIMEOUT =
+        "alluxio.underfs.object.store.multipart.upload.timeout";
     public static final String UNDERFS_OBJECT_STORE_BREADCRUMBS_ENABLED =
         "alluxio.underfs.object.store.breadcrumbs.enabled";
     public static final String UNDERFS_OBJECT_STORE_SERVICE_THREADS =
@@ -8065,6 +8169,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.oss.streaming.upload.partition.size";
     public static final String UNDERFS_OSS_STREAMING_UPLOAD_THREADS =
         "alluxio.underfs.oss.streaming.upload.threads";
+    public static final String UNDERFS_OSS_MULTIPART_UPLOAD_ENABLED =
+        "alluxio.underfs.oss.multipart.upload.enabled";
+    public static final String UNDERFS_OSS_MULTIPART_UPLOAD_THREADS =
+        "alluxio.underfs.oss.multipart.upload.threads";
+    public static final String UNDERFS_OSS_MULTIPART_UPLOAD_PARTITION_SIZE =
+        "alluxio.underfs.oss.multipart.upload.part.size";
     public static final String UNDERFS_S3_BULK_DELETE_ENABLED =
         "alluxio.underfs.s3.bulk.delete.enabled";
     public static final String UNDERFS_S3_DEFAULT_MODE = "alluxio.underfs.s3.default.mode";
@@ -8107,6 +8217,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_S3_THREADS_MAX = "alluxio.underfs.s3.threads.max";
     public static final String UNDERFS_S3_UPLOAD_THREADS_MAX =
         "alluxio.underfs.s3.upload.threads.max";
+    public static final String UNDERFS_S3_MULTIPART_UPLOAD_ENABLED =
+        "alluxio.underfs.s3.multipart.upload.enabled";
+    public static final String UNDERFS_S3_MULTIPART_UPLOAD_PARTITION_SIZE =
+        "alluxio.underfs.s3.multipart.upload.partition.size";
     public static final String KODO_ENDPOINT = "alluxio.underfs.kodo.endpoint";
     public static final String KODO_DOWNLOAD_HOST = "alluxio.underfs.kodo.downloadhost";
     public static final String UNDERFS_KODO_CONNECT_TIMEOUT =
@@ -8144,6 +8258,18 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.obs.streaming.upload.partition.size";
     public static final String UNDERFS_OBS_STREAMING_UPLOAD_THREADS =
         "alluxio.underfs.obs.streaming.upload.threads";
+    public static final String UNDERFS_OBS_MULTIPART_UPLOAD_ENABLED =
+        "alluxio.underfs.obs.multipart.upload.enabled";
+    public static final String UNDERFS_OBS_MULTIPART_UPLOAD_THREADS =
+        "alluxio.underfs.obs.multipart.upload.threads";
+    public static final String UNDERFS_OBS_MULTIPART_UPLOAD_PARTITION_SIZE =
+        "alluxio.underfs.obs.multipart.upload.part.size";
+    public static final String UNDERFS_COS_MULTIPART_UPLOAD_ENABLED =
+        "alluxio.underfs.cos.multipart.upload.enabled";
+    public static final String UNDERFS_COS_MULTIPART_UPLOAD_THREADS =
+        "alluxio.underfs.cos.multipart.upload.threads";
+    public static final String UNDERFS_COS_MULTIPART_UPLOAD_PARTITION_SIZE =
+        "alluxio.underfs.cos.multipart.upload.part.size";
 
     //
     // UFS access control related properties

--- a/dora/core/common/src/main/java/alluxio/underfs/ObjectMultipartUploadOutputStream.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/ObjectMultipartUploadOutputStream.java
@@ -1,0 +1,391 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs;
+
+import alluxio.Constants;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.retry.CountingRetry;
+import alluxio.retry.RetryPolicy;
+import alluxio.retry.RetryUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Upload File to object storage in multiple parts.
+ * <p>
+ * The file is partitioned into multiple parts, each part is uploaded in a separate thread.
+ * The number of threads is determined by the configuration.
+ * The minimum part size is 5MB (s3) or 100KB (oss, obs) or 1MB(cos), except the last part.
+ * We choose 5MB to be the minimum part size for all object storage systems.
+ * The maximum part size is 5GB (s3, oss, cos, obs).
+ * The partition size is determined by the configuration.
+ * <p>
+ * In flush(), we wait for all uploads to finish.
+ * <p>
+ * In close() we complete the multipart upload.
+ * <p>
+ * close() will not be retried, but all the multipart upload
+ * related operations(init, upload, complete, and abort) will be retried.
+ * <p>
+ * If an error occurs, and we have no way to recover, we abort the multipart uploads.
+ * Some multipart uploads may not be completed/aborted in normal ways and need periodical cleanup
+ * by enabling the {@link PropertyKey#UNDERFS_CLEANUP_ENABLED}.
+ * When a leader master starts or a cleanup interval is reached, all the multipart uploads
+ * older than clean age will be cleaned.
+ */
+@NotThreadSafe
+public abstract class ObjectMultipartUploadOutputStream extends OutputStream
+    implements ContentHashable {
+  protected static final Logger LOG =
+      LoggerFactory.getLogger(ObjectMultipartUploadOutputStream.class);
+  /**
+   * Only parts bigger than 5MB could be uploaded through multipart upload,
+   * except the last part.
+   */
+  protected static final long MINIMUM_PART_SIZE = 5L * Constants.MB;
+
+  /**
+   * The maximum size of a single part is 5GB.
+   */
+  protected static final long MAXIMUM_PART_SIZE = 5L * Constants.GB;
+
+  /**
+   * Bucket name of the object storage bucket.
+   */
+  protected final String mBucketName;
+  /**
+   * Key of the file when it is uploaded to object storage.
+   */
+  protected final String mKey;
+  /**
+   * The retry policy of this multipart upload.
+   */
+  protected final Supplier<RetryPolicy> mRetryPolicy = () -> new CountingRetry(5);
+  /**
+   * Pre-allocated byte buffer for writing single characters.
+   */
+  protected final byte[] mSingleCharWrite = new byte[1];
+  /**
+   * The maximum allowed size of a partition.
+   */
+  protected final long mPartitionSize;
+  /**
+   * Give each upload request a unique and continuous id
+   * so that object storage knows the part sequence to concatenate the parts to a single object.
+   */
+  private final AtomicInteger mPartNumber;
+  /**
+   * Executing the upload tasks.
+   */
+  private final ListeningExecutorService mExecutor;
+  /**
+   * Store the future of tags.
+   */
+  private final List<ListenableFuture<?>> mFutures = new ArrayList<>();
+  /**
+   * Flag to indicate this stream has been closed, to ensure close is only done once.
+   */
+  protected boolean mClosed = false;
+  /**
+   * When the offset reaches the partition size, we upload mStream.
+   */
+  protected long mPartitionOffset;
+  /**
+   * upload part timeout, null means no timeout.
+   */
+  @Nullable
+  private Long mUploadPartTimeoutMills;
+  /**
+   * Whether the multi upload has been initialized.
+   */
+  private boolean mMultiPartUploadInitialized = false;
+
+  @Nullable
+  private byte[] mUploadPartArray;
+
+  /**
+   * Constructs a new stream for writing a file.
+   *
+   * @param bucketName                   the name of the bucket
+   * @param key                          the key of the file
+   * @param executor                     executor
+   * @param multipartUploadPartitionSize the size in bytes for partitions of multipart uploads
+   * @param ufsConf                      the object store under file system configuration
+   */
+  public ObjectMultipartUploadOutputStream(
+      String bucketName,
+      String key,
+      ListeningExecutorService executor,
+      long multipartUploadPartitionSize,
+      AlluxioConfiguration ufsConf) {
+    Preconditions.checkArgument(bucketName != null && !bucketName.isEmpty(),
+        "Bucket name must not be null or empty.");
+    mBucketName = bucketName;
+    mExecutor = executor;
+    mKey = key;
+    mPartNumber = new AtomicInteger(1);
+    mPartitionSize = Math.min(Math.max(
+        MINIMUM_PART_SIZE, multipartUploadPartitionSize), MAXIMUM_PART_SIZE);
+    if (ufsConf.isSet(PropertyKey.UNDERFS_OBJECT_STORE_MULTIPART_UPLOAD_TIMEOUT)) {
+      mUploadPartTimeoutMills =
+          ufsConf.getDuration(PropertyKey.UNDERFS_OBJECT_STORE_MULTIPART_UPLOAD_TIMEOUT)
+              .toMillis();
+    }
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    mSingleCharWrite[0] = (byte) b;
+    write(mSingleCharWrite);
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    write(b, 0, b.length);
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    if (b == null || len == 0) {
+      return;
+    }
+    Preconditions.checkNotNull(b);
+    Preconditions.checkArgument(off >= 0 && off <= b.length
+        && len >= 0 && off + len <= b.length);
+
+    if (mUploadPartArray == null) {
+      initNewUploadPartArray();
+    }
+    // If the current partition is not full, we write the data to the current partition.
+    if (mPartitionOffset + len <= mPartitionSize) {
+      // Since the original b array will be overwritten in other functions
+      // We can't just keep the reference of b array, but should keep a copy of b array.
+      System.arraycopy(b, off, mUploadPartArray, (int) mPartitionOffset, len);
+      mPartitionOffset += len;
+    } else {
+      // If the current partition cannot write all the data,
+      // write the excess data to the next partition after filling the current partition
+      int firstLen = (int) (mPartitionSize - mPartitionOffset);
+
+      // As described before, we keep a copy of b array.
+      System.arraycopy(b, off, mUploadPartArray, (int) mPartitionOffset, firstLen);
+      mPartitionOffset += firstLen;
+      uploadPart();
+      write(b, off + firstLen, len - firstLen);
+    }
+  }
+
+  @Override
+  public void flush() throws IOException {
+    if (!mMultiPartUploadInitialized) {
+      return;
+    }
+    // We try to minimize the time use to close()
+    // because Fuse release() method which calls close() is async.
+    // In flush(), we upload the current writing file if it is bigger than 5 MB,
+    // and wait for all current upload to complete.
+    if (mPartitionOffset > MINIMUM_PART_SIZE) {
+      uploadPart();
+    }
+    waitForAllPartsUpload();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (mClosed) {
+      return;
+    }
+
+    // Set the closed flag, we never retry close() even if exception occurs
+    mClosed = true;
+
+    // Multipart upload has not been initialized, use putObject to upload the file.
+    if (!mMultiPartUploadInitialized) {
+      if (mUploadPartArray == null) {
+        LOG.debug("Multipart upload output stream closed without uploading any data.");
+        RetryUtils.retry("put empty object for key" + mKey, () -> createEmptyObject(mKey),
+            mRetryPolicy.get());
+      } else {
+        byte[] buf = mUploadPartArray;
+        mUploadPartArray = null;
+        try {
+          RetryUtils.retry("put object for key" + mKey,
+              () -> putObject(mKey, buf, mPartitionOffset), mRetryPolicy.get());
+        } catch (Exception e) {
+          LOG.error("Failed to upload {}", mKey, e);
+          throw new IOException(e);
+        }
+      }
+      return;
+    }
+
+    // Multipart upload has been initialized, upload the last part and complete the multipart.
+    try {
+      if (mUploadPartArray != null) {
+        int partNumber = mPartNumber.getAndIncrement();
+        byte[] buf = mUploadPartArray;
+        uploadPart(buf, partNumber, true, mPartitionOffset);
+        mUploadPartArray = null;
+      }
+
+      // Wait for all parts to be uploaded.
+      waitForAllPartsUpload();
+      RetryUtils.retry("complete multipart upload",
+          this::completeMultipartUploadInternal, mRetryPolicy.get());
+    } catch (Exception e) {
+      LOG.error("Failed to upload {}", mKey, e);
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Creates a new temp file to write to.
+   */
+  private void initNewUploadPartArray() {
+    mUploadPartArray = new byte[(int) mPartitionSize];
+    mPartitionOffset = 0;
+    LOG.debug("Init new mUploadPartArray @ {}", mUploadPartArray);
+  }
+
+  /**
+   * Uploads part async.
+   */
+  protected void uploadPart() throws IOException {
+    if (mUploadPartArray == null) {
+      return;
+    }
+
+    if (!mMultiPartUploadInitialized) {
+      RetryUtils.retry("init multipart upload", this::initMultipartUploadInternal,
+          mRetryPolicy.get());
+      mMultiPartUploadInitialized = true;
+    }
+
+    int partNumber = mPartNumber.getAndIncrement();
+    byte[] buf = mUploadPartArray;
+    uploadPart(buf, partNumber, false, mPartitionOffset);
+    mUploadPartArray = null;
+  }
+
+  protected void uploadPart(byte[] buf, int partNumber,
+                            boolean isLastPart, long length) throws IOException {
+    Callable<?> callable = () -> {
+      try {
+        RetryUtils.retry("upload part for key " + mKey + " and part number " + partNumber,
+            () -> uploadPartInternal(buf, partNumber, isLastPart, length), mRetryPolicy.get());
+        return null;
+      } catch (Exception e) {
+        LOG.error("Failed to upload part {} for key {}", partNumber, mKey, e);
+        throw new IOException(e);
+      }
+    };
+    ListenableFuture<?> futureTag = mExecutor.submit(callable);
+    mFutures.add(futureTag);
+  }
+
+  protected void abortMultiPartUpload() throws IOException {
+    RetryUtils.retry("abort multipart upload for key " + mKey, this::abortMultipartUploadInternal,
+        mRetryPolicy.get());
+  }
+
+  protected void waitForAllPartsUpload() throws IOException {
+    try {
+      for (ListenableFuture<?> future : mFutures) {
+        if (mUploadPartTimeoutMills == null) {
+          future.get();
+        } else {
+          future.get(mUploadPartTimeoutMills, TimeUnit.MILLISECONDS);
+        }
+      }
+    } catch (ExecutionException e) {
+      // No recover ways so that we need to cancel all the upload tasks
+      // and abort the multipart upload
+      Futures.allAsList(mFutures).cancel(true);
+      abortMultiPartUpload();
+      throw new IOException(
+          "Part upload failed in multipart upload with to " + mKey, e);
+    } catch (InterruptedException e) {
+      LOG.warn("Interrupted object upload.", e);
+      Futures.allAsList(mFutures).cancel(true);
+      abortMultiPartUpload();
+      Thread.currentThread().interrupt();
+    } catch (TimeoutException e) {
+      LOG.error("timeout when upload part");
+      Futures.allAsList(mFutures).cancel(true);
+      abortMultiPartUpload();
+      throw new IOException("timeout when upload part " + mKey, e);
+    }
+    mFutures.clear();
+  }
+
+  /**
+   * @param buf              the byte buf
+   * @param partNumber       the part number
+   * @param isLastPart       whether this is the last part
+   * @param length           the length of the part to be uploaded
+   * @throws IOException
+   */
+  protected abstract void uploadPartInternal(
+      byte[] buf,
+      int partNumber,
+      boolean isLastPart,
+      long length)
+      throws IOException;
+
+  /**
+   * @throws IOException
+   */
+  protected abstract void initMultipartUploadInternal() throws IOException;
+
+  /**
+   * @throws IOException
+   */
+  protected abstract void completeMultipartUploadInternal() throws IOException;
+
+  /**
+   * @throws IOException
+   */
+  protected abstract void abortMultipartUploadInternal() throws IOException;
+
+  /**
+   * @param key the key
+   * @throws IOException
+   */
+  protected abstract void createEmptyObject(String key) throws IOException;
+
+  /**
+   * @param key     the key
+   * @param buf     the byte buf
+   * @param length  the length of the file to be uploaded
+   * @throws IOException
+   */
+  protected abstract void putObject(String key, byte[] buf, long length) throws IOException;
+}

--- a/dora/underfs/cos/src/main/java/alluxio/underfs/cos/COSMultipartUploadOutputStream.java
+++ b/dora/underfs/cos/src/main/java/alluxio/underfs/cos/COSMultipartUploadOutputStream.java
@@ -1,0 +1,217 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.cos;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.underfs.ObjectMultipartUploadOutputStream;
+
+import com.amazonaws.SdkClientException;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.qcloud.cos.COS;
+import com.qcloud.cos.model.AbortMultipartUploadRequest;
+import com.qcloud.cos.model.CompleteMultipartUploadRequest;
+import com.qcloud.cos.model.InitiateMultipartUploadRequest;
+import com.qcloud.cos.model.ObjectMetadata;
+import com.qcloud.cos.model.PartETag;
+import com.qcloud.cos.model.PutObjectRequest;
+import com.qcloud.cos.model.UploadPartRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Object storage multipart upload for COS.
+ */
+@NotThreadSafe
+public class COSMultipartUploadOutputStream extends ObjectMultipartUploadOutputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(COSMultipartUploadOutputStream.class);
+
+  /**
+   * The COS client to interact with COS.
+   */
+  private final COS mClient;
+  /**
+   * Tags for the uploaded part, provided by COS after uploading.
+   */
+  private final List<PartETag> mTags = Collections.synchronizedList(new ArrayList<>());
+
+  /**
+   * The upload id of this multipart upload.
+   */
+  protected volatile String mUploadId;
+
+  private String mContentHash;
+
+  /**
+   * Constructs a new stream for writing a file.
+   *
+   * @param bucketName the name of the bucket
+   * @param key        the key of the file
+   * @param COSClient   the COS client to upload the file with
+   * @param executor   a thread pool executor
+   * @param ufsConf    the object store under file system configuration
+   */
+  public COSMultipartUploadOutputStream(
+      String bucketName,
+      String key,
+      COS COSClient,
+      ListeningExecutorService executor,
+      AlluxioConfiguration ufsConf) {
+    super(bucketName, key, executor,
+        ufsConf.getBytes(PropertyKey.UNDERFS_COS_MULTIPART_UPLOAD_PARTITION_SIZE), ufsConf);
+    mClient = Preconditions.checkNotNull(COSClient);
+  }
+
+  @Override
+  protected void uploadPartInternal(
+      byte[] buf,
+      int partNumber,
+      boolean isLastPart,
+      long length)
+      throws IOException {
+    try {
+      InputStream inputStream = new BufferedInputStream(
+          new ByteArrayInputStream(buf, 0, (int) length));
+
+      final UploadPartRequest uploadRequest = new UploadPartRequest()
+          .withBucketName(mBucketName)
+          .withKey(mKey)
+          .withUploadId(mUploadId)
+          .withPartNumber(partNumber)
+          .withInputStream(inputStream)
+          .withPartSize(length);
+
+      // calculate md5 digest
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      md.update(buf, 0, (int) length);
+
+      // set parameter of md5 digest
+      uploadRequest.setMd5Digest(Base64.getEncoder().encodeToString(md.digest()));
+
+      // set parameter of isLastPart
+      uploadRequest.setLastPart(isLastPart);
+
+      // Upload this part
+      PartETag partETag = getClient().uploadPart(uploadRequest).getPartETag();
+      mTags.add(partETag);
+    } catch (SdkClientException e) {
+      LOG.debug("failed to upload part.", e);
+      throw new IOException(String.format(
+          "failed to upload part. key: %s part number: %s uploadId: %s",
+          mKey, partNumber, mUploadId), e);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected void initMultipartUploadInternal() throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+      mUploadId = getClient()
+          .initiateMultipartUpload(new InitiateMultipartUploadRequest(mBucketName, mKey, meta))
+          .getUploadId();
+    } catch (SdkClientException e) {
+      LOG.debug("failed to init multi part upload", e);
+      throw new IOException("failed to init multi part upload", e);
+    }
+  }
+
+  @Override
+  protected void completeMultipartUploadInternal() throws IOException {
+    try {
+      LOG.debug("complete multi part {}", mUploadId);
+      mContentHash = getClient().completeMultipartUpload(new CompleteMultipartUploadRequest(
+          mBucketName, mKey, mUploadId, mTags)).getETag();
+    } catch (SdkClientException e) {
+      LOG.debug("failed to complete multi part upload", e);
+      throw new IOException(
+          String.format("failed to complete multi part upload, key: %s, upload id: %s",
+              mKey, mUploadId), e);
+    }
+  }
+
+  @Override
+  protected void abortMultipartUploadInternal() throws IOException {
+    try {
+      getClient().abortMultipartUpload(
+          new AbortMultipartUploadRequest(mBucketName, mKey, mUploadId));
+    } catch (SdkClientException e) {
+      LOG.debug("failed to abort multi part upload", e);
+      throw new IOException(
+          String.format("failed to abort multi part upload, key: %s, upload id: %s", mKey,
+              mUploadId), e);
+    }
+  }
+
+  @Override
+  protected void createEmptyObject(String key) throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+      meta.setContentLength(0);
+      mContentHash = getClient().putObject(
+              new PutObjectRequest(mBucketName, key, new ByteArrayInputStream(new byte[0]), meta))
+          .getETag();
+    } catch (SdkClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected void putObject(String key, byte[] buf, long length) throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+
+      InputStream inputStream = new BufferedInputStream(
+          new ByteArrayInputStream(buf, 0, (int) length));
+
+      // calculate md5 digest
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      md.update(buf, 0, (int) length);
+
+      // set parameter of md5 digest
+      meta.setContentMD5(Base64.getEncoder().encodeToString(md.digest()));
+
+      // set other parameters
+      meta.setContentLength(length);
+
+      // upload this file whose data is in the array buf.
+      PutObjectRequest putReq = new PutObjectRequest(mBucketName, key, inputStream, meta);
+      mContentHash = getClient().putObject(putReq).getETag();
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  protected COS getClient() {
+    return mClient;
+  }
+
+  @Override
+  public Optional<String> getContentHash() {
+    return Optional.ofNullable(mContentHash);
+  }
+}

--- a/dora/underfs/obs/src/main/java/alluxio/underfs/obs/OBSMultipartUploadOutputStream.java
+++ b/dora/underfs/obs/src/main/java/alluxio/underfs/obs/OBSMultipartUploadOutputStream.java
@@ -1,0 +1,224 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.obs;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.underfs.ObjectMultipartUploadOutputStream;
+
+import com.amazonaws.SdkClientException;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.obs.services.ObsClient;
+import com.obs.services.internal.utils.Mimetypes;
+import com.obs.services.model.AbortMultipartUploadRequest;
+import com.obs.services.model.CompleteMultipartUploadRequest;
+import com.obs.services.model.InitiateMultipartUploadRequest;
+import com.obs.services.model.ObjectMetadata;
+import com.obs.services.model.PartEtag;
+import com.obs.services.model.PutObjectRequest;
+import com.obs.services.model.UploadPartRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Object storage multipart upload for obs.
+ */
+@NotThreadSafe
+public class OBSMultipartUploadOutputStream extends ObjectMultipartUploadOutputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(OBSMultipartUploadOutputStream.class);
+
+  /**
+   * The Amazon OBS client to interact with OBS.
+   */
+  private final ObsClient mClient;
+  /**
+   * Tags for the uploaded part, provided by OBS after uploading.
+   */
+  private final List<PartEtag> mTags = Collections.synchronizedList(new ArrayList<>());
+
+  /**
+   * The upload id of this multipart upload.
+   */
+  protected volatile String mUploadId;
+
+  private String mContentHash;
+
+  /**
+   * Constructs a new stream for writing a file.
+   *
+   * @param bucketName the name of the bucket
+   * @param key        the key of the file
+   * @param OBSClient   the OBS client to upload the file with
+   * @param executor   a thread pool executor
+   * @param ufsConf    the object store under file system configuration
+   */
+  public OBSMultipartUploadOutputStream(
+      String bucketName,
+      String key,
+      ObsClient OBSClient,
+      ListeningExecutorService executor,
+      AlluxioConfiguration ufsConf) {
+    super(bucketName, key, executor,
+        ufsConf.getBytes(PropertyKey.UNDERFS_OBS_MULTIPART_UPLOAD_PARTITION_SIZE), ufsConf);
+    mClient = Preconditions.checkNotNull(OBSClient);
+  }
+
+  @Override
+  protected void uploadPartInternal(
+      byte[] buf,
+      int partNumber,
+      boolean isLastPart,
+      long length)
+      throws IOException {
+    try {
+      InputStream inputStream = new BufferedInputStream(
+          new ByteArrayInputStream(buf, 0, (int) length));
+
+      final UploadPartRequest uploadRequest = new UploadPartRequest();
+      uploadRequest.setBucketName(mBucketName);
+      uploadRequest.setObjectKey(mKey);
+      uploadRequest.setUploadId(mUploadId);
+      uploadRequest.setPartNumber(partNumber);
+      uploadRequest.setInput(inputStream);
+      uploadRequest.setPartSize(length);
+
+      // calculate md5 digest
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      md.update(buf, 0, (int) length);
+
+      // set parameter of md5 digest
+      uploadRequest.setContentMd5(Base64.getEncoder().encodeToString(md.digest()));
+
+      // Upload this part
+      PartEtag partEtag = new PartEtag(getClient().uploadPart(uploadRequest).getEtag(), partNumber);
+      mTags.add(partEtag);
+    } catch (SdkClientException e) {
+      LOG.debug("failed to upload part.", e);
+      throw new IOException(String.format(
+          "failed to upload part. key: %s part number: %s uploadId: %s",
+          mKey, partNumber, mUploadId), e);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected void initMultipartUploadInternal() throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+      meta.setContentType(Mimetypes.MIMETYPE_OCTET_STREAM);
+      InitiateMultipartUploadRequest request =
+          new InitiateMultipartUploadRequest(mBucketName, mKey);
+      request.setMetadata(meta);
+
+      mUploadId = getClient()
+          .initiateMultipartUpload(request)
+          .getUploadId();
+    } catch (SdkClientException e) {
+      LOG.debug("failed to init multi part upload", e);
+      throw new IOException("failed to init multi part upload", e);
+    }
+  }
+
+  @Override
+  protected void completeMultipartUploadInternal() throws IOException {
+    try {
+      LOG.debug("complete multi part {}", mUploadId);
+      mContentHash = getClient().completeMultipartUpload(new CompleteMultipartUploadRequest(
+          mBucketName, mKey, mUploadId, mTags)).getEtag();
+    } catch (SdkClientException e) {
+      LOG.debug("failed to complete multi part upload", e);
+      throw new IOException(
+          String.format("failed to complete multi part upload, key: %s, upload id: %s",
+              mKey, mUploadId), e);
+    }
+  }
+
+  @Override
+  protected void abortMultipartUploadInternal() throws IOException {
+    try {
+      getClient().abortMultipartUpload(
+          new AbortMultipartUploadRequest(mBucketName, mKey, mUploadId));
+    } catch (SdkClientException e) {
+      LOG.debug("failed to abort multi part upload", e);
+      throw new IOException(
+          String.format("failed to abort multi part upload, key: %s, upload id: %s", mKey,
+              mUploadId), e);
+    }
+  }
+
+  @Override
+  protected void createEmptyObject(String key) throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+      meta.setContentLength(0L);
+      meta.setContentType(Mimetypes.MIMETYPE_OCTET_STREAM);
+      PutObjectRequest request = new PutObjectRequest(
+          mBucketName, key, new ByteArrayInputStream(new byte[0]));
+      request.setMetadata(meta);
+      mContentHash = getClient().putObject(request).getEtag();
+    } catch (SdkClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected void putObject(String key, byte[] buf, long length) throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+
+      InputStream inputStream = new BufferedInputStream(
+          new ByteArrayInputStream(buf, 0, (int) length));
+
+      // calculate md5 digest
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      md.update(buf, 0, (int) length);
+
+      // set parameter of md5 digest
+      meta.setContentMd5(Base64.getEncoder().encodeToString(md.digest()));
+
+      // set other parameters
+      meta.setContentLength(length);
+      meta.setContentType(Mimetypes.MIMETYPE_OCTET_STREAM);
+
+      // upload this file whose data is in the array buf.
+      PutObjectRequest putReq = new PutObjectRequest(mBucketName, key, inputStream);
+      putReq.setMetadata(meta);
+      mContentHash = getClient().putObject(putReq).getEtag();
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  protected ObsClient getClient() {
+    return mClient;
+  }
+
+  @Override
+  public Optional<String> getContentHash() {
+    return Optional.ofNullable(mContentHash);
+  }
+}

--- a/dora/underfs/obs/src/main/java/alluxio/underfs/obs/OBSUnderFileSystem.java
+++ b/dora/underfs/obs/src/main/java/alluxio/underfs/obs/OBSUnderFileSystem.java
@@ -82,7 +82,12 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
   private final String mBucketName;
 
   private final String mBucketType;
+
+  /** The executor service for the streaming upload. */
   private final Supplier<ListeningExecutorService> mStreamingUploadExecutor;
+
+  /** The executor service for the multipart upload. */
+  private final Supplier<ListeningExecutorService> mMultipartUploadExecutor;
 
   /**
    * Constructs a new instance of {@link OBSUnderFileSystem}.
@@ -126,11 +131,23 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
     mClient = obsClient;
     mBucketName = bucketName;
     mBucketType = bucketType;
+
+    // Initialize the executor service for the streaming upload.
     mStreamingUploadExecutor = Suppliers.memoize(() -> {
       int numTransferThreads =
           conf.getInt(PropertyKey.UNDERFS_OBS_STREAMING_UPLOAD_THREADS);
       ExecutorService service = ExecutorServiceFactories
           .fixedThreadPool("alluxio-obs-streaming-upload-worker",
+              numTransferThreads).create();
+      return MoreExecutors.listeningDecorator(service);
+    });
+
+    // Initialize the executor service for the multipart upload.
+    mMultipartUploadExecutor = Suppliers.memoize(() -> {
+      int numTransferThreads =
+          conf.getInt(PropertyKey.UNDERFS_OBS_MULTIPART_UPLOAD_THREADS);
+      ExecutorService service = ExecutorServiceFactories
+          .fixedThreadPool("alluxio-obs-multipart-upload-worker",
               numTransferThreads).create();
       return MoreExecutors.listeningDecorator(service);
     });
@@ -207,6 +224,10 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
     if (mUfsConf.getBoolean(PropertyKey.UNDERFS_OBS_STREAMING_UPLOAD_ENABLED)) {
       return new OBSLowLevelOutputStream(mBucketName, key, mClient,
           mStreamingUploadExecutor.get(), mUfsConf);
+    }
+    else if (mUfsConf.getBoolean(PropertyKey.UNDERFS_OBS_MULTIPART_UPLOAD_ENABLED)) {
+      return new OBSMultipartUploadOutputStream(mBucketName, key, mClient,
+          mMultipartUploadExecutor.get(), mUfsConf);
     }
     return new OBSOutputStream(mBucketName, key, mClient,
         mUfsConf.getList(PropertyKey.TMP_DIRS));

--- a/dora/underfs/oss/src/main/java/alluxio/underfs/oss/OSSMultipartUploadOutputStream.java
+++ b/dora/underfs/oss/src/main/java/alluxio/underfs/oss/OSSMultipartUploadOutputStream.java
@@ -1,0 +1,218 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.oss;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.underfs.ObjectMultipartUploadOutputStream;
+
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.internal.Mimetypes;
+import com.aliyun.oss.model.AbortMultipartUploadRequest;
+import com.aliyun.oss.model.CompleteMultipartUploadRequest;
+import com.aliyun.oss.model.InitiateMultipartUploadRequest;
+import com.aliyun.oss.model.ObjectMetadata;
+import com.aliyun.oss.model.PartETag;
+import com.aliyun.oss.model.PutObjectRequest;
+import com.aliyun.oss.model.UploadPartRequest;
+import com.amazonaws.SdkClientException;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Object storage multipart upload for oss.
+ */
+@NotThreadSafe
+public class OSSMultipartUploadOutputStream extends ObjectMultipartUploadOutputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(OSSMultipartUploadOutputStream.class);
+
+  /**
+   * The OSS client to interact with OSS.
+   */
+  private final OSS mClient;
+  /**
+   * Tags for the uploaded part, provided by OSS after uploading.
+   */
+  private final List<PartETag> mTags = Collections.synchronizedList(new ArrayList<>());
+
+  /**
+   * The upload id of this multipart upload.
+   */
+  protected volatile String mUploadId;
+
+  private String mContentHash;
+
+  /**
+   * Constructs a new stream for writing a file.
+   *
+   * @param bucketName the name of the bucket
+   * @param key        the key of the file
+   * @param OSSClient   the OSS client to upload the file with
+   * @param executor   a thread pool executor
+   * @param ufsConf    the object store under file system configuration
+   */
+  public OSSMultipartUploadOutputStream(
+      String bucketName,
+      String key,
+      OSS OSSClient,
+      ListeningExecutorService executor,
+      AlluxioConfiguration ufsConf) {
+    super(bucketName, key, executor,
+        ufsConf.getBytes(PropertyKey.UNDERFS_OSS_MULTIPART_UPLOAD_PARTITION_SIZE), ufsConf);
+    mClient = Preconditions.checkNotNull(OSSClient);
+  }
+
+  @Override
+  protected void uploadPartInternal(
+      byte[] buf,
+      int partNumber,
+      boolean isLastPart,
+      long length)
+      throws IOException {
+    try {
+      InputStream inputStream = new BufferedInputStream(
+          new ByteArrayInputStream(buf, 0, (int) length));
+
+      final UploadPartRequest uploadRequest = new UploadPartRequest();
+      uploadRequest.setBucketName(mBucketName);
+      uploadRequest.setKey(mKey);
+      uploadRequest.setUploadId(mUploadId);
+      uploadRequest.setPartNumber(partNumber);
+      uploadRequest.setInputStream(inputStream);
+      uploadRequest.setPartSize(length);
+
+      // calculate md5 digest
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      md.update(buf, 0, (int) length);
+
+      // set parameter of md5 digest
+      uploadRequest.setMd5Digest(Base64.getEncoder().encodeToString(md.digest()));
+
+      // Upload this part
+      PartETag partETag = getClient().uploadPart(uploadRequest).getPartETag();
+      mTags.add(partETag);
+    } catch (SdkClientException e) {
+      LOG.debug("failed to upload part.", e);
+      throw new IOException(String.format(
+          "failed to upload part. key: %s part number: %s uploadId: %s",
+          mKey, partNumber, mUploadId), e);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected void initMultipartUploadInternal() throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+      meta.setContentType(Mimetypes.DEFAULT_MIMETYPE);
+      mUploadId = getClient()
+          .initiateMultipartUpload(new InitiateMultipartUploadRequest(mBucketName, mKey, meta))
+          .getUploadId();
+    } catch (SdkClientException e) {
+      LOG.debug("failed to init multi part upload", e);
+      throw new IOException("failed to init multi part upload", e);
+    }
+  }
+
+  @Override
+  protected void completeMultipartUploadInternal() throws IOException {
+    try {
+      LOG.debug("complete multi part {}", mUploadId);
+      mContentHash = getClient().completeMultipartUpload(new CompleteMultipartUploadRequest(
+          mBucketName, mKey, mUploadId, mTags)).getETag();
+    } catch (SdkClientException e) {
+      LOG.debug("failed to complete multi part upload", e);
+      throw new IOException(
+          String.format("failed to complete multi part upload, key: %s, upload id: %s",
+              mKey, mUploadId), e);
+    }
+  }
+
+  @Override
+  protected void abortMultipartUploadInternal() throws IOException {
+    try {
+      getClient().abortMultipartUpload(
+          new AbortMultipartUploadRequest(mBucketName, mKey, mUploadId));
+    } catch (SdkClientException e) {
+      LOG.debug("failed to abort multi part upload", e);
+      throw new IOException(
+          String.format("failed to abort multi part upload, key: %s, upload id: %s", mKey,
+              mUploadId), e);
+    }
+  }
+
+  @Override
+  protected void createEmptyObject(String key) throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+      meta.setContentLength(0);
+      meta.setContentType(Mimetypes.DEFAULT_MIMETYPE);
+      mContentHash = getClient().putObject(
+              new PutObjectRequest(mBucketName, key, new ByteArrayInputStream(new byte[0]), meta))
+          .getETag();
+    } catch (SdkClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected void putObject(String key, byte[] buf, long length) throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+
+      InputStream inputStream = new BufferedInputStream(
+          new ByteArrayInputStream(buf, 0, (int) length));
+
+      // calculate md5 digest
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      md.update(buf, 0, (int) length);
+
+      // set parameter of md5 digest
+      meta.setContentMD5(Base64.getEncoder().encodeToString(md.digest()));
+
+      // set other parameters
+      meta.setContentLength(length);
+      meta.setContentType(Mimetypes.DEFAULT_MIMETYPE);
+
+      // upload this file whose data is in the array buf.
+      PutObjectRequest putReq = new PutObjectRequest(mBucketName, key, inputStream, meta);
+      mContentHash = getClient().putObject(putReq).getETag();
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  protected OSS getClient() {
+    return mClient;
+  }
+
+  @Override
+  public Optional<String> getContentHash() {
+    return Optional.ofNullable(mContentHash);
+  }
+}

--- a/dora/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AMultipartUploadOutputStream.java
+++ b/dora/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AMultipartUploadOutputStream.java
@@ -1,0 +1,232 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.s3a;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.underfs.ObjectMultipartUploadOutputStream;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.internal.Mimetypes;
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Object storage multipart upload for aws s3.
+ */
+@NotThreadSafe
+public class S3AMultipartUploadOutputStream extends ObjectMultipartUploadOutputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(S3AMultipartUploadOutputStream.class);
+
+  /**
+   * Server side encrypt enabled.
+   */
+  private final boolean mSseEnabled;
+  /**
+   * The Amazon S3 client to interact with S3.
+   */
+  private final AmazonS3 mClient;
+  /**
+   * Tags for the uploaded part, provided by S3 after uploading.
+   */
+  private final List<PartETag> mTags = Collections.synchronizedList(new ArrayList<>());
+
+  /**
+   * The upload id of this multipart upload.
+   */
+  protected volatile String mUploadId;
+
+  private String mContentHash;
+
+  /**
+   * Constructs a new stream for writing a file.
+   *
+   * @param bucketName the name of the bucket
+   * @param key        the key of the file
+   * @param s3Client   the Amazon S3 client to upload the file with
+   * @param executor   a thread pool executor
+   * @param ufsConf    the object store under file system configuration
+   */
+  public S3AMultipartUploadOutputStream(
+      String bucketName,
+      String key,
+      AmazonS3 s3Client,
+      ListeningExecutorService executor,
+      AlluxioConfiguration ufsConf) {
+    super(bucketName, key, executor,
+        ufsConf.getBytes(PropertyKey.UNDERFS_S3_MULTIPART_UPLOAD_PARTITION_SIZE), ufsConf);
+    mClient = Preconditions.checkNotNull(s3Client);
+    mSseEnabled = ufsConf.getBoolean(PropertyKey.UNDERFS_S3_SERVER_SIDE_ENCRYPTION_ENABLED);
+  }
+
+  @Override
+  protected void uploadPartInternal(
+      byte[] buf,
+      int partNumber,
+      boolean isLastPart,
+      long length)
+      throws IOException {
+    try {
+      InputStream inputStream = new BufferedInputStream(
+          new ByteArrayInputStream(buf, 0, (int) length));
+
+      final UploadPartRequest uploadRequest = new UploadPartRequest()
+          .withBucketName(mBucketName)
+          .withKey(mKey)
+          .withUploadId(mUploadId)
+          .withPartNumber(partNumber)
+          .withInputStream(inputStream)
+          .withPartSize(length);
+
+      // calculate md5 digest
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      md.update(buf, 0, (int) length);
+
+      // set parameter of md5 digest
+      uploadRequest.setMd5Digest(Base64.getEncoder().encodeToString(md.digest()));
+
+      // set parameter of isLastPart
+      uploadRequest.setLastPart(isLastPart);
+
+      // Upload this part
+      PartETag partETag = getClient().uploadPart(uploadRequest).getPartETag();
+      mTags.add(partETag);
+    } catch (SdkClientException e) {
+      LOG.debug("failed to upload part.", e);
+      throw new IOException(String.format(
+          "failed to upload part. key: %s part number: %s uploadId: %s",
+          mKey, partNumber, mUploadId), e);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected void initMultipartUploadInternal() throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+      if (mSseEnabled) {
+        meta.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+      }
+      meta.setContentType(Mimetypes.MIMETYPE_OCTET_STREAM);
+      mUploadId = getClient()
+          .initiateMultipartUpload(new InitiateMultipartUploadRequest(mBucketName, mKey, meta))
+          .getUploadId();
+    } catch (SdkClientException e) {
+      LOG.debug("failed to init multi part upload", e);
+      throw new IOException("failed to init multi part upload", e);
+    }
+  }
+
+  @Override
+  protected void completeMultipartUploadInternal() throws IOException {
+    try {
+      LOG.debug("complete multi part {}", mUploadId);
+      mContentHash = getClient().completeMultipartUpload(new CompleteMultipartUploadRequest(
+          mBucketName, mKey, mUploadId, mTags)).getETag();
+    } catch (SdkClientException e) {
+      LOG.debug("failed to complete multi part upload", e);
+      throw new IOException(
+          String.format("failed to complete multi part upload, key: %s, upload id: %s",
+              mKey, mUploadId), e);
+    }
+  }
+
+  @Override
+  protected void abortMultipartUploadInternal() throws IOException {
+    try {
+      getClient().abortMultipartUpload(
+          new AbortMultipartUploadRequest(mBucketName, mKey, mUploadId));
+    } catch (SdkClientException e) {
+      LOG.debug("failed to abort multi part upload", e);
+      throw new IOException(
+          String.format("failed to abort multi part upload, key: %s, upload id: %s", mKey,
+              mUploadId), e);
+    }
+  }
+
+  @Override
+  protected void createEmptyObject(String key) throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+      meta.setContentLength(0);
+      meta.setContentType(Mimetypes.MIMETYPE_OCTET_STREAM);
+      mContentHash = getClient().putObject(
+              new PutObjectRequest(mBucketName, key, new ByteArrayInputStream(new byte[0]), meta))
+          .getETag();
+    } catch (SdkClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected void putObject(String key, byte[] buf, long length) throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+      if (mSseEnabled) {
+        meta.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+      }
+
+      InputStream inputStream = new BufferedInputStream(
+          new ByteArrayInputStream(buf, 0, (int) length));
+
+      // calculate md5 digest
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      md.update(buf, 0, (int) length);
+
+      // set parameter of md5 digest
+      meta.setContentMD5(Base64.getEncoder().encodeToString(md.digest()));
+
+      // set other parameters
+      meta.setContentLength(length);
+      meta.setContentType(Mimetypes.MIMETYPE_OCTET_STREAM);
+
+      // upload this file whose data is in the array buf.
+      PutObjectRequest putReq = new PutObjectRequest(mBucketName, key, inputStream, meta);
+      mContentHash = getClient().putObject(putReq).getETag();
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  protected AmazonS3 getClient() {
+    return mClient;
+  }
+
+  @Override
+  public Optional<String> getContentHash() {
+    return Optional.ofNullable(mContentHash);
+  }
+}

--- a/dora/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/dora/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -147,6 +147,9 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   /** Whether the streaming upload is enabled. */
   private final boolean mStreamingUploadEnabled;
 
+  /** Whether the multipart upload is enabled. */
+  private final boolean mMultipartUploadEnabled;
+
   /** The permissions associated with the bucket. Fetched once and assumed to be immutable. */
   private final Supplier<ObjectPermissions> mPermissions
       = CommonUtils.memoize(this::getPermissionsInternal);
@@ -238,6 +241,9 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
     boolean streamingUploadEnabled =
         conf.getBoolean(PropertyKey.UNDERFS_S3_STREAMING_UPLOAD_ENABLED);
 
+    boolean multipartUploadEnabled =
+        conf.getBoolean(PropertyKey.UNDERFS_S3_MULTIPART_UPLOAD_ENABLED);
+
     // Signer algorithm
     if (conf.isSet(PropertyKey.UNDERFS_S3_SIGNER_ALGORITHM)) {
       clientConf.setSignerOverride(conf.getString(PropertyKey.UNDERFS_S3_SIGNER_ALGORITHM));
@@ -261,7 +267,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
         .build();
 
     return new S3AUnderFileSystem(uri, amazonS3Client, asyncClient, bucketName,
-        service, transferManager, conf, streamingUploadEnabled);
+        service, transferManager, conf, streamingUploadEnabled, multipartUploadEnabled);
   }
 
   /**
@@ -405,7 +411,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   /**
    * Creates an endpoint configuration.
    *
-   * @param conf the aluxio conf
+   * @param conf the alluxio conf
    * @param clientConf the aws conf
    * @return the endpoint configuration
    */
@@ -449,11 +455,12 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
    * @param transferManager Transfer Manager for efficient I/O to S3
    * @param conf configuration for this S3A ufs
    * @param streamingUploadEnabled whether streaming upload is enabled
+   * @param multipartUploadEnabled whether multipart upload is enabled
    */
   protected S3AUnderFileSystem(
       AlluxioURI uri, AmazonS3 amazonS3Client, S3AsyncClient asyncClient, String bucketName,
       ExecutorService executor, TransferManager transferManager, UnderFileSystemConfiguration conf,
-      boolean streamingUploadEnabled) {
+      boolean streamingUploadEnabled, boolean multipartUploadEnabled) {
     super(uri, conf);
     mClient = amazonS3Client;
     mAsyncClient = asyncClient;
@@ -461,6 +468,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
     mExecutor = MoreExecutors.listeningDecorator(executor);
     mManager = transferManager;
     mStreamingUploadEnabled = streamingUploadEnabled;
+    mMultipartUploadEnabled = multipartUploadEnabled;
   }
 
   @Override
@@ -565,11 +573,19 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected OutputStream createObject(String key) throws IOException {
     if (mStreamingUploadEnabled) {
+      LOG.debug("S3AUnderFileSystem, createObject, Streaming Upload enabled");
       return new S3ALowLevelOutputStream(mBucketName, key, mClient, mExecutor, mUfsConf);
     }
-    return new S3AOutputStream(mBucketName, key, mManager,
-        mUfsConf.getList(PropertyKey.TMP_DIRS),
-        mUfsConf.getBoolean(PropertyKey.UNDERFS_S3_SERVER_SIDE_ENCRYPTION_ENABLED));
+    else if (mMultipartUploadEnabled) {
+      LOG.debug("S3AUnderFileSystem, createObject, Multipart upload enabled");
+      return new S3AMultipartUploadOutputStream(mBucketName, key, mClient, mExecutor, mUfsConf);
+    }
+    else {
+      LOG.debug("S3AUnderFileSystem, createObject, Simple Upload enabled");
+      return new S3AOutputStream(mBucketName, key, mManager,
+          mUfsConf.getList(PropertyKey.TMP_DIRS),
+          mUfsConf.getBoolean(PropertyKey.UNDERFS_S3_SERVER_SIDE_ENCRYPTION_ENABLED));
+    }
   }
 
   @Override

--- a/dora/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemMockServerTest.java
+++ b/dora/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemMockServerTest.java
@@ -105,7 +105,7 @@ public class S3AUnderFileSystemMockServerTest {
         new S3AUnderFileSystem(new AlluxioURI("s3://" + TEST_BUCKET), mClient,
             asyncClient, TEST_BUCKET,
             Executors.newSingleThreadExecutor(), new TransferManager(),
-            UnderFileSystemConfiguration.defaults(CONF), false);
+            UnderFileSystemConfiguration.defaults(CONF), false, false);
   }
 
   @After

--- a/dora/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/dora/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -79,7 +79,7 @@ public class S3AUnderFileSystemTest {
     mS3UnderFileSystem =
         new S3AUnderFileSystem(new AlluxioURI("s3a://" + BUCKET_NAME),
             mClient, mAsyncClient, BUCKET_NAME,
-            mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false);
+            mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false, false);
   }
 
   @Test
@@ -189,7 +189,7 @@ public class S3AUnderFileSystemTest {
       S3AUnderFileSystem s3UnderFileSystem =
           new S3AUnderFileSystem(
               new AlluxioURI("s3a://" + BUCKET_NAME), mClient, mAsyncClient, BUCKET_NAME,
-              mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false);
+              mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false, false);
 
       Mockito.when(mClient.getS3AccountOwner()).thenReturn(new Owner("111", "test"));
       Mockito.when(mClient.getBucketAcl(Mockito.anyString())).thenReturn(new AccessControlList());
@@ -209,7 +209,7 @@ public class S3AUnderFileSystemTest {
       S3AUnderFileSystem s3UnderFileSystem =
           new S3AUnderFileSystem(new AlluxioURI("s3a://" + BUCKET_NAME), mClient,
               mAsyncClient, BUCKET_NAME,
-              mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false);
+              mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false, false);
 
       Mockito.when(mClient.getS3AccountOwner()).thenReturn(new Owner("0", "test"));
       Mockito.when(mClient.getBucketAcl(Mockito.anyString())).thenReturn(new AccessControlList());


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support multipart upload of S3, OSS, COS and OBS.

### Why are the changes needed?

1. support multipart upload mode of s3. Simple upload refers to [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html). Multipart upload refer to [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html)
2. Multipart upload improve streaming upload mode. Multipart upload remove temp file, that optimizes three read and write disk operations into one. Upload each time the input data reaches the `partition size`, and use Netty zero-copy technology for splicing.
3. OSS, COS and OBS are similar as described to the above.

**There are some experiments conducted on Mac Laptop and AWS instance. Simple upload (default) and streaming upload are two original upload methods of alluxio.**

File Size: 4.8GB

MinIO (Mac Laptop): 
Simple Upload: 28 seconds
Streaming Upload: 20 seconds
Multipart Upload: 12 seconds

AWS same region (r6a.xlarge):
Simple Upload:  25 seconds
Streaming Upload: 18 seconds
Multipart Upload:  12 seconds

In an environment with sufficient bandwidth (or an intranet environment), the speed increase is obvious.

### Does this PR introduce any user facing changes?

`alluxio.underfs.object.store.multipart.upload.timeout`: Timeout for uploading part when using multipart upload.

S3: 
`alluxio.underfs.s3.multipart.upload.enabled`: Whether to enable multipart upload for S3. If it is `true`, then multipart upload of S3 will be enabled. Defult value is `false`.
`alluxio.underfs.s3.multipart.upload.partition.size`: Multipart upload partition size for S3. The default partition size is `64MB`.

OSS: 
`alluxio.underfs.oss.multipart.upload.enabled`: Whether to enable multipart upload for OSS.
`alluxio.underfs.oss.multipart.upload.threads`: Thread pool size for OSS multipart upload.
`alluxio.underfs.oss.multipart.upload.partition.size`: Multipart upload partition size for OSS. The default partition size is 64MB.


COS: 
`alluxio.underfs.cos.multipart.upload.enabled`: Whether to enable multipart upload for COS.
`alluxio.underfs.cos.multipart.upload.threads`: Thread pool size for COS multipart upload.
`alluxio.underfs.cos.multipart.upload.partition.size`: Multipart upload partition size for COS. The default partition size is 64MB.


OBS: 
`alluxio.underfs.obs.multipart.upload.enabled`: Whether to enable multipart upload for OBS.
`alluxio.underfs.obs.multipart.upload.threads`: Thread pool size for OBS multipart upload.
`alluxio.underfs.obs.multipart.upload.partition.size`: Multipart upload partition size for OBS. The default partition size is 64MB.


