### PR TITLE
Add config check for alluxio.master.ttl.checker.interval at start time

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -391,6 +391,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     checkTieredStorage();
     checkMasterThrottleThresholds();
     checkCheckpointZipConfig();
+    checkMasterTTLInterval();
   }
 
   @Override
@@ -480,6 +481,17 @@ public class InstancedConfiguration implements AlluxioConfiguration {
       checkState(System.getProperty(PropertyKey.Name.WORKER_WEB_PORT) == null,
           message, PropertyKey.WORKER_WEB_PORT);
     }
+  }
+
+  /**
+   * Checks that master TTL checker interval.
+   * @throws IllegalStateException if the TTL check interval <= 0
+   */
+  private void checkMasterTTLInterval() {
+    long interval = getMs(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS);
+    checkState(interval > 0,
+        "invalid value of " + PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS + "=%s, "
+        + "it must be greater than 0", interval);
   }
 
   /**

--- a/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
@@ -680,6 +680,13 @@ public class InstancedConfigurationTest {
   }
 
   @Test
+  public void setMasterTTLIntervalZero() {
+    mConfiguration.set(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, "0");
+    mThrown.expect(IllegalStateException.class);
+    mConfiguration.validate();
+  }
+
+  @Test
   public void setUserFileBufferBytesMaxInteger() {
     mConfiguration.set(PropertyKey.USER_FILE_BUFFER_BYTES, Integer.MAX_VALUE + "B");
     assertEquals(Integer.MAX_VALUE,


### PR DESCRIPTION
### What changes are proposed in this pull request?

#17405
this pr is from #17408 

### Why are the changes needed?
Add pre-check for alluxio.master.ttl.checker.interval, to avoid resources waste when starting alluxio.
