### PR TITLE
Fix CCE for metric system

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/AlluxioExecutorService.java
+++ b/core/server/common/src/main/java/alluxio/master/AlluxioExecutorService.java
@@ -58,7 +58,7 @@ public class AlluxioExecutorService implements ExecutorService {
   /**
    * @return the current RPC queue size
    */
-  public int getRpcQueueLength() {
+  public long getRpcQueueLength() {
     if (mExecutor instanceof ThreadPoolExecutor) {
       return ((ThreadPoolExecutor) mExecutor).getQueue().size();
     } else if (mExecutor instanceof ForkJoinPool) {
@@ -72,7 +72,7 @@ public class AlluxioExecutorService implements ExecutorService {
   /**
    * @return the current RPC active thread count
    */
-  public int getActiveCount() {
+  public long getActiveCount() {
     if (mExecutor instanceof ThreadPoolExecutor) {
       return ((ThreadPoolExecutor) mExecutor).getActiveCount();
     } else if (mExecutor instanceof ForkJoinPool) {
@@ -86,7 +86,7 @@ public class AlluxioExecutorService implements ExecutorService {
   /**
    * @return the current RPC thread pool size
    */
-  public int getPoolSize() {
+  public long getPoolSize() {
     if (mExecutor instanceof ThreadPoolExecutor) {
       return ((ThreadPoolExecutor) mExecutor).getPoolSize();
     } else if (mExecutor instanceof ForkJoinPool) {


### PR DESCRIPTION
Fix CCE for metric system

Without this fix, start a single master will encountered the following CCE.

```
2023-05-21 21:41:27,422 INFO  [main](WebServer.java:211) - Alluxio Master Web service started @ /0.0.0.0:19999
2023-05-21 21:41:27,422 INFO  [main](PrimaryOnlyMetricsService.java:27) - Promoting PrimaryOnlyMetricsService
2023-05-21 21:41:27,422 INFO  [main](MetricsService.java:29) - Start metric sinks.
2023-05-21 21:41:27,425 INFO  [main](AlluxioMasterProcess.java:294) - Primary started
2023-05-21 21:41:28,244 ERROR [Master Throttle](HeartbeatThread.java:157) - Uncaught exception in heartbeat executor, Heartbeat Thread shutting down
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
	at alluxio.master.throttle.ServerIndicator.createFromMetrics(ServerIndicator.java:127)
	at alluxio.master.throttle.SystemMonitor.collectServerIndicators(SystemMonitor.java:260)
	at alluxio.master.throttle.SystemMonitor.collectIndicators(SystemMonitor.java:220)
	at alluxio.master.throttle.SystemMonitor.run(SystemMonitor.java:211)
	at alluxio.master.throttle.DefaultThrottleMaster$ThrottleExecutor.heartbeat(DefaultThrottleMaster.java:147)
	at alluxio.heartbeat.HeartbeatThread.run(HeartbeatThread.java:152)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:266)
	at java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```