### PR TITLE
Support dynamic enable/disable audit log

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -780,14 +780,12 @@ public class DefaultFileSystemMaster extends CoreMaster
               () -> new FixedIntervalSupplier(
                   Configuration.getMs(PropertyKey.MASTER_METRICS_TIME_SERIES_INTERVAL)),
               Configuration.global(), mMasterContext.getUserState()));
-      if (Configuration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
-        mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("AUDIT_LOG");
-        mAsyncAuditLogWriter.start();
-        MetricsSystem.registerGaugeIfAbsent(
-            MetricKey.MASTER_AUDIT_LOG_ENTRIES_SIZE.getName(),
-            () -> mAsyncAuditLogWriter != null
-                    ? mAsyncAuditLogWriter.getAuditLogEntriesSize() : -1);
-      }
+      mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("AUDIT_LOG");
+      mAsyncAuditLogWriter.start();
+      MetricsSystem.registerGaugeIfAbsent(
+          MetricKey.MASTER_AUDIT_LOG_ENTRIES_SIZE.getName(),
+          () -> mAsyncAuditLogWriter != null
+              ? mAsyncAuditLogWriter.getAuditLogEntriesSize() : -1);
       if (Configuration.getBoolean(PropertyKey.UNDERFS_CLEANUP_ENABLED)) {
         getExecutorService().submit(
             new HeartbeatThread(HeartbeatContext.MASTER_UFS_CLEANUP, new UfsCleaner(this),

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -535,6 +535,8 @@ public class DefaultFileSystemMaster extends CoreMaster
     mDefaultSyncProcess =  createSyncProcess(
         mInodeStore, mMountTable, mInodeTree, getSyncPathCache());
 
+    // As we can determine whether enable the audit log through update the config,
+    // So we need this audit log writer thread all the time.
     mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("AUDIT_LOG");
     mAsyncAuditLogWriter.start();
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -798,9 +798,9 @@ public class DefaultFileSystemMaster extends CoreMaster
       mScheduler.start();
     }
     /**
-     * As we can determine whether enable the audit log through update the config,
-     * and check it in {@link #createAuditContext},
-     * so we need this audit log writer thread all the time.
+     * The audit logger will be running all the time, and an operation checks whether
+     * to enable audit logs in {@link #createAuditContext}. So audit log can be turned on/off
+     * at runtime by updating the property key.
      */
     mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("AUDIT_LOG");
     mAsyncAuditLogWriter.start();

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -411,7 +411,7 @@ public class DefaultFileSystemMaster extends CoreMaster
   private final ActiveSyncManager mSyncManager;
 
   /** Log writer for user access audit log. */
-  protected AsyncUserAccessAuditLogWriter mAsyncAuditLogWriter;
+  protected volatile AsyncUserAccessAuditLogWriter mAsyncAuditLogWriter;
 
   /** Stores the time series for various metrics which are exposed in the UI. */
   private final TimeSeriesStore mTimeSeriesStore;

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -111,10 +111,10 @@ public final class ProxyWebServer extends WebServer {
     mGlobalRateLimiter = S3RestUtils.createRateLimiter(rate).orElse(null);
 
     /**
-     * As we can determine whether enable the audit log through update the config,
-     * and check it in {@link alluxio.proxy.s3.S3RestServiceHandler#createAuditContext} and
-     * {@link alluxio.proxy.s3.S3Handler#createAuditContext},
-     * so we need this audit log writer thread all the time.
+     * The audit logger will be running all the time, and an operation checks whether
+     * to enable audit logs in {@link alluxio.proxy.s3.S3RestServiceHandler#createAuditContext} and
+     * {@link alluxio.proxy.s3.S3Handler#createAuditContext}. So audit log can be turned on/off
+     * at runtime by updating the property key.
      */
     mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("PROXY_AUDIT_LOG");
     mAsyncAuditLogWriter.start();

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -110,14 +110,12 @@ public final class ProxyWebServer extends WebServer {
         (long) Configuration.getInt(PropertyKey.PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB) * Constants.MB;
     mGlobalRateLimiter = S3RestUtils.createRateLimiter(rate).orElse(null);
 
-    if (Configuration.getBoolean(PropertyKey.PROXY_AUDIT_LOGGING_ENABLED)) {
-      mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("PROXY_AUDIT_LOG");
-      mAsyncAuditLogWriter.start();
-      MetricsSystem.registerGaugeIfAbsent(
-          MetricKey.PROXY_AUDIT_LOG_ENTRIES_SIZE.getName(),
-              () -> mAsyncAuditLogWriter != null
-                  ? mAsyncAuditLogWriter.getAuditLogEntriesSize() : -1);
-    }
+    mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("PROXY_AUDIT_LOG");
+    mAsyncAuditLogWriter.start();
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.PROXY_AUDIT_LOG_ENTRIES_SIZE.getName(),
+        () -> mAsyncAuditLogWriter != null
+            ? mAsyncAuditLogWriter.getAuditLogEntriesSize() : -1);
 
     ServletContainer servlet = new ServletContainer(config) {
       private static final long serialVersionUID = 7756010860672831556L;

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -110,6 +110,8 @@ public final class ProxyWebServer extends WebServer {
         (long) Configuration.getInt(PropertyKey.PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB) * Constants.MB;
     mGlobalRateLimiter = S3RestUtils.createRateLimiter(rate).orElse(null);
 
+    // As we can determine whether enable the audit log through update the config,
+    // So we need this audit log writer thread all the time.
     mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("PROXY_AUDIT_LOG");
     mAsyncAuditLogWriter.start();
     MetricsSystem.registerGaugeIfAbsent(

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -259,14 +259,12 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
               () -> new FixedIntervalSupplier(
                   Configuration.getMs(PropertyKey.JOB_MASTER_LOST_MASTER_INTERVAL)),
               Configuration.global(), mMasterContext.getUserState()));
-      if (Configuration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
-        mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("JOB_MASTER_AUDIT_LOG");
-        mAsyncAuditLogWriter.start();
-        MetricsSystem.registerGaugeIfAbsent(
-            MetricKey.MASTER_AUDIT_LOG_ENTRIES_SIZE.getName(),
-            () -> mAsyncAuditLogWriter != null
-                ? mAsyncAuditLogWriter.getAuditLogEntriesSize() : -1);
-      }
+      mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("JOB_MASTER_AUDIT_LOG");
+      mAsyncAuditLogWriter.start();
+      MetricsSystem.registerGaugeIfAbsent(
+          MetricKey.MASTER_AUDIT_LOG_ENTRIES_SIZE.getName(),
+          () -> mAsyncAuditLogWriter != null
+              ? mAsyncAuditLogWriter.getAuditLogEntriesSize() : -1);
     } else {
       LOG.info("Starting job master as standby");
       if (ConfigurationUtils.isHaMode(Configuration.global())) {

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -260,9 +260,9 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
                   Configuration.getMs(PropertyKey.JOB_MASTER_LOST_MASTER_INTERVAL)),
               Configuration.global(), mMasterContext.getUserState()));
       /**
-       * As we can determine whether enable the audit log through update the config,
-       * and check it in {@link #createAuditContext},
-       * so we need this audit log writer thread all the time.
+       * The audit logger will be running all the time, and an operation checks whether
+       * to enable audit logs in {@link #createAuditContext}. So audit log can be turned on/off
+       * at runtime by updating the property key.
        */
       mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("JOB_MASTER_AUDIT_LOG");
       mAsyncAuditLogWriter.start();

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -259,6 +259,8 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
               () -> new FixedIntervalSupplier(
                   Configuration.getMs(PropertyKey.JOB_MASTER_LOST_MASTER_INTERVAL)),
               Configuration.global(), mMasterContext.getUserState()));
+      // As we can determine whether enable the audit log through update the config,
+      // So we need this audit log writer thread all the time.
       mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("JOB_MASTER_AUDIT_LOG");
       mAsyncAuditLogWriter.start();
       MetricsSystem.registerGaugeIfAbsent(


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support dynamic enable/disable audit log

### Why are the changes needed?

Now, if we disable auditlog before master startup, we cannot support enable it dynamically, but it can be disable if it is enabled at startup time, it is tricky.

And it is not expensive to start an object.

<img width="842" alt="image" src="https://github.com/Alluxio/alluxio/assets/17329931/df16dbfd-7307-4542-8fff-9f1fa556b66c">


### Does this PR introduce any user facing changes?

No