### PR TITLE
Improve monitor script printout

### DIFF
--- a/bin/alluxio-monitor.sh
+++ b/bin/alluxio-monitor.sh
@@ -125,7 +125,7 @@ run_monitor() {
   else
     "${JAVA}" -cp ${CLASSPATH} ${alluxio_config} ${monitor_exec}
     if [[ $? -ne 0 ]]; then
-      echo -e "${WHITE}---${NC} ${RED}[ FAILED ]${NC} The ${CYAN}${node_type}${NC} @ ${PURPLE}$(hostname -f)${NC} is not serving requests.${NC}"
+      echo -e "${WHITE}---${NC} ${RED}[ FAILED ]${NC} The ${CYAN}${node_type}${NC} @ ${PURPLE}$(hostname -f)${NC} is not serving requests after 120s. Please check if the process is running and the logs/ if necessary.${NC}"
       print_node_logs "${node_type}"
       return 1
     fi


### PR DESCRIPTION
### What changes are proposed in this pull request?

Given that the startup time is unpredictable and there is always chance that the process is simply not serving and may just start to serve eventually, mention that a double check is needed when the monitor shows the master/worker start "[FAILED]".
<img width="1307" alt="Screen Shot 2023-05-25 at 3 28 09 PM" src="https://github.com/Alluxio/alluxio/assets/14806853/674895ca-04a7-41cc-97c6-d636232fff88">

