### PR TITLE
fixed directory deletion failure when ufs is cos

### DIFF
--- a/dora/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -341,6 +341,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
           try {
             return operate(batch);
           } catch (IOException e) {
+            LOG.error("A batch operation failed. ", e);
             // Do not append to success list
             return Collections.emptyList();
           }

--- a/dora/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
+++ b/dora/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
@@ -170,7 +170,7 @@ public class COSUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected List<String> deleteObjects(List<String> keys) throws IOException {
     try {
-      DeleteObjectsRequest request = new DeleteObjectsRequest(mBucketName);
+      DeleteObjectsRequest request = new DeleteObjectsRequest(mBucketNameInternal);
       List<DeleteObjectsRequest.KeyVersion> keyVersions = keys.stream()
           .map(DeleteObjectsRequest.KeyVersion::new)
           .collect(Collectors.toList());


### PR DESCRIPTION
### What changes are proposed in this pull request?

fixed directory deletion failure when ufs is cos

### Why are the changes needed?

1. cos bucket name is bucket-appid
2. COSUnderFileSystem.deleteObjects request is not bucket-appid case  `Failed to delete 1 paths from the under file system: /xxx (UFS delete dir failed)`
3. ObjectUnderFileSystem.submitBatch exception should print


### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. when ufs is cos can normal exec alluxio rm -r xxx
