### PR TITLE
Print Auth method to auditlog

### DIFF
--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedClientUser.java
@@ -166,5 +166,22 @@ public final class AuthenticatedClientUser {
     sUserThreadLocal.remove();
   }
 
+  /**
+   * Gets the user group information.
+   *
+   * @param conf Alluxio configuration
+   * @return the user group information
+   * @throws AccessControlException if the authentication is not enabled
+   */
+  public static String getUgi(AlluxioConfiguration conf) throws AccessControlException {
+    StringBuilder sb = new StringBuilder(getClientUser(conf));
+    sb.append(" (auth:" + getAuthMethod(conf) + ")");
+    String realUser = getConnectionUser(conf);
+    if (realUser != null) {
+      sb.append(" via ").append(realUser);
+    }
+    return sb.toString();
+  }
+
   private AuthenticatedClientUser() {} // prevent instantiation
 }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -5483,13 +5483,14 @@ public class DefaultFileSystemMaster extends CoreMaster
       String ugi = "";
       try {
         user = AuthenticatedClientUser.getClientUser(Configuration.global());
+        ugi = AuthenticatedClientUser.getUgi(Configuration.global());
       } catch (AccessControlException e) {
         ugi = "N/A";
       }
       if (user != null) {
         try {
           String primaryGroup = CommonUtils.getPrimaryGroupName(user, Configuration.global());
-          ugi = user + "," + primaryGroup;
+          ugi += "," + primaryGroup;
         } catch (IOException e) {
           LOG.debug("Failed to get primary group for user {}.", user);
           ugi = user + ",N/A";


### PR DESCRIPTION
### What changes are proposed in this pull request?

Print Auth method to auditlog, rather than auth type

### Why are the changes needed?

We can clear get what auth method the client use.

### Does this PR introduce any user facing changes?

Get more usefully information from auditlog
