### PR TITLE
Fix deadlock in LocalCacheManager

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -537,31 +537,28 @@ public class LocalCacheManager implements CacheManager {
     if (bytesRead > 0) {
       return bytesRead;
     }
-    ReadWriteLock pageLock = getPageLock(pageId);
-    try (LockResource r = new LockResource(pageLock.writeLock())) {
-      bytesRead = get(pageId, pageOffset, bytesToRead,
-          buffer, cacheContext);
-      if (bytesRead > 0) {
-        return bytesRead;
-      }
-      // on local cache miss, read a complete page from external storage. This will always make
-      // progress or throw an exception
-      long startTime = System.nanoTime();
-      byte[] page = externalDataSupplier.get();
-      long timeElapse = System.nanoTime() - startTime;
-      // cache misses
-      buffer.writeBytes(page, pageOffset, bytesToRead);
-      MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getName())
-          .mark(bytesToRead);
-      cacheContext.incrementCounter(
-          MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getMetricName(), BYTE,
-          bytesToRead);
-      cacheContext.incrementCounter(
-          MetricKey.CLIENT_CACHE_PAGE_READ_EXTERNAL_TIME_NS.getMetricName(), NANO,
-          timeElapse);
-      put(pageId, page, cacheContext);
-      return bytesToRead;
-    }
+    // on local cache miss, read a complete page from external storage. This will always make
+    // progress or throw an exception
+    // Note that we cannot synchronize on the new page, as this will cause deadlock due to
+    // incompatible lock order within putAttempt
+    // Not synchronizing may cause the same page to be read multiple times from UFS by two or more
+    // concurrent requests,
+    // but this is acceptable, and is expected to be rare as long as the number of striping locks
+    // is big enough
+    long startTime = System.nanoTime();
+    byte[] page = externalDataSupplier.get();
+    long timeElapse = System.nanoTime() - startTime;
+    buffer.writeBytes(page, pageOffset, bytesToRead);
+    MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getName())
+        .mark(bytesToRead);
+    cacheContext.incrementCounter(
+        MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getMetricName(), BYTE,
+        bytesToRead);
+    cacheContext.incrementCounter(
+        MetricKey.CLIENT_CACHE_PAGE_READ_EXTERNAL_TIME_NS.getMetricName(), NANO,
+        timeElapse);
+    put(pageId, page, cacheContext);
+    return bytesToRead;
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix a deadlock in `LocalCacheManager.getAndLoad`.

To reproduce the deadlock: https://github.com/dbw9580/alluxio/commit/ff87c7334e2576d3bd936dd3a1c2ced4803da5b6

![image](https://github.com/Alluxio/alluxio/assets/6999708/d604f39b-e409-4c24-8fb1-b55893825599)


### Why are the changes needed?

Deadlock detected by jstack:

<details>
  <summary>jstack output</summary>

  ```

  Found one Java-level deadlock:
  =============================
  "pool-4-thread-1":
    waiting for ownable synchronizer 0x000000070eb3b9f0, (a java.util.concurrent.locks.ReentrantReadWriteLock$FairSync),
    which is held by "pool-4-thread-6"
  "pool-4-thread-6":
    waiting for ownable synchronizer 0x000000070eb25728, (a java.util.concurrent.locks.ReentrantReadWriteLock$FairSync),
    which is held by "pool-4-thread-3"
  "pool-4-thread-3":
    waiting for ownable synchronizer 0x000000070eb3b9f0, (a java.util.concurrent.locks.ReentrantReadWriteLock$FairSync),
    which is held by "pool-4-thread-6"
  
  Java stack information for the threads listed above:
  ===================================================
  "pool-4-thread-1":
          at jdk.internal.misc.Unsafe.park(java.base@11.0.19/Native Method)
          - parking to wait for  <0x000000070eb3b9f0> (a java.util.concurrent.locks.ReentrantReadWriteLock$FairSync)
          at java.util.concurrent.locks.LockSupport.park(java.base@11.0.19/LockSupport.java:194)
          at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(java.base@11.0.19/AbstractQueuedSynchronizer.java:885)
          at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(java.base@11.0.19/AbstractQueuedSynchronizer.java:917)
          at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@11.0.19/AbstractQueuedSynchronizer.java:1240)
          at java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(java.base@11.0.19/ReentrantReadWriteLock.java:959)
          at alluxio.resource.LockResource.<init>(LockResource.java:102)
          at alluxio.resource.LockResource.<init>(LockResource.java:73)
          at alluxio.resource.LockResource.<init>(LockResource.java:57)
          at alluxio.client.file.cache.LocalCacheManager.getAndLoad(LocalCacheManager.java:525)
          at alluxio.client.file.cache.LocalCacheManagerTest.lambda$concurrentGetAndLoad$9(LocalCacheManagerTest.java:1133)
          at alluxio.client.file.cache.LocalCacheManagerTest$$Lambda$167/0x00000008001c8c40.call(Unknown Source)
          at java.util.concurrent.FutureTask.run(java.base@11.0.19/FutureTask.java:264)
          at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.19/ThreadPoolExecutor.java:1128)
          at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.19/ThreadPoolExecutor.java:628)
          at java.lang.Thread.run(java.base@11.0.19/Thread.java:829)
  "pool-4-thread-6":
          at jdk.internal.misc.Unsafe.park(java.base@11.0.19/Native Method)
          - parking to wait for  <0x000000070eb25728> (a java.util.concurrent.locks.ReentrantReadWriteLock$FairSync)
          at java.util.concurrent.locks.LockSupport.park(java.base@11.0.19/LockSupport.java:194)
          at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(java.base@11.0.19/AbstractQueuedSynchronizer.java:885)
          at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(java.base@11.0.19/AbstractQueuedSynchronizer.java:917)
          at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@11.0.19/AbstractQueuedSynchronizer.java:1240)
          at java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(java.base@11.0.19/ReentrantReadWriteLock.java:959)
          at alluxio.resource.LockResource.<init>(LockResource.java:102)
          at alluxio.resource.LockResource.<init>(LockResource.java:73)
          at alluxio.resource.LockResource.<init>(LockResource.java:57)
          at alluxio.client.file.cache.LocalCacheManager.putAttempt(LocalCacheManager.java:374)
          at alluxio.client.file.cache.LocalCacheManager.putInternal(LocalCacheManager.java:278)
          at alluxio.client.file.cache.LocalCacheManager.put(LocalCacheManager.java:238)
          at alluxio.client.file.cache.CacheManager.put(CacheManager.java:206)
          at alluxio.client.file.cache.LocalCacheManager.getAndLoad(LocalCacheManager.java:546)
          at alluxio.client.file.cache.LocalCacheManagerTest.lambda$concurrentGetAndLoad$9(LocalCacheManagerTest.java:1133)
          at alluxio.client.file.cache.LocalCacheManagerTest$$Lambda$167/0x00000008001c8c40.call(Unknown Source)
          at java.util.concurrent.FutureTask.run(java.base@11.0.19/FutureTask.java:264)
          at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.19/ThreadPoolExecutor.java:1128)
          at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.19/ThreadPoolExecutor.java:628)
          at java.lang.Thread.run(java.base@11.0.19/Thread.java:829)
  "pool-4-thread-3":
          at jdk.internal.misc.Unsafe.park(java.base@11.0.19/Native Method)
          - parking to wait for  <0x000000070eb3b9f0> (a java.util.concurrent.locks.ReentrantReadWriteLock$FairSync)
          at java.util.concurrent.locks.LockSupport.park(java.base@11.0.19/LockSupport.java:194)
          at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(java.base@11.0.19/AbstractQueuedSynchronizer.java:885)
          at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(java.base@11.0.19/AbstractQueuedSynchronizer.java:917)
          at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@11.0.19/AbstractQueuedSynchronizer.java:1240)
          at java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(java.base@11.0.19/ReentrantReadWriteLock.java:959)
          at alluxio.resource.LockResource.<init>(LockResource.java:102)
          at alluxio.resource.LockResource.<init>(LockResource.java:73)
          at alluxio.resource.LockResource.<init>(LockResource.java:57)
          at alluxio.client.file.cache.LocalCacheManager.putAttempt(LocalCacheManager.java:375)
          at alluxio.client.file.cache.LocalCacheManager.putInternal(LocalCacheManager.java:278)
          at alluxio.client.file.cache.LocalCacheManager.put(LocalCacheManager.java:238)
          at alluxio.client.file.cache.CacheManager.put(CacheManager.java:206)
          at alluxio.client.file.cache.LocalCacheManager.getAndLoad(LocalCacheManager.java:546)
          at alluxio.client.file.cache.LocalCacheManagerTest.lambda$concurrentGetAndLoad$9(LocalCacheManagerTest.java:1133)
          at alluxio.client.file.cache.LocalCacheManagerTest$$Lambda$167/0x00000008001c8c40.call(Unknown Source)
          at java.util.concurrent.FutureTask.run(java.base@11.0.19/FutureTask.java:264)
          at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.19/ThreadPoolExecutor.java:1128)
          at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.19/ThreadPoolExecutor.java:628)
          at java.lang.Thread.run(java.base@11.0.19/Thread.java:829)
  
  ```

</details>

### Does this PR introduce any user facing changes?

No.