### PR TITLE
Call needsCache in LocalCacheFileSystem

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
@@ -16,6 +16,7 @@ import alluxio.client.file.DelegatingFileSystem;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
+import alluxio.client.file.cache.filter.CacheFilter;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.OpenFilePOptions;
@@ -32,6 +33,7 @@ import java.io.IOException;
 public class LocalCacheFileSystem extends DelegatingFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(LocalCacheFileSystem.class);
   private final CacheManager mCacheManager;
+  private final CacheFilter mCacheFilter;
   private final AlluxioConfiguration mConf;
 
   /**
@@ -43,6 +45,7 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
     super(fs);
     mCacheManager = Preconditions.checkNotNull(cacheManage, "cacheManager");
     mConf = Preconditions.checkNotNull(conf, "conf");
+    mCacheFilter = CacheFilter.create(conf);
   }
 
   @Override
@@ -62,7 +65,8 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
   @Override
   public FileInStream openFile(URIStatus status, OpenFilePOptions options)
       throws IOException, AlluxioException {
-    if (mCacheManager == null || mCacheManager.state() == CacheManager.State.NOT_IN_USE) {
+    if (mCacheManager == null || mCacheManager.state() == CacheManager.State.NOT_IN_USE
+        || !mCacheFilter.needsCache(status)) {
       return mDelegatedFileSystem.openFile(status, options);
     }
     return new LocalCacheFileInStream(status,


### PR DESCRIPTION
### What changes are proposed in this pull request?

Check if the `uri` needs cache in `alluxio.client.file.cache.LocalCacheFileSystem`

### Why are the changes needed?

`needsCache` is checked in `alluxio.hadoop.LocalCacheFileSystem` but not `alluxio.client.file.cache.LocalCacheFileSystem`. However, it is `alluxio.client.file.cache.LocalCacheFileSystem` used by local cache.

I also checked the code and cannot find a place is using `alluxio.hadoop.LocalCacheFileSystem` in Alluxio. Should it be deleted from code or it may be used by some clients?

### Does this PR introduce any user facing changes?

NO
