### PR TITLE
Fix the issue of not being able to display third level files when ufs is OBS

### DIFF
--- a/dora/underfs/obs/src/main/java/alluxio/underfs/obs/OBSUnderFileSystem.java
+++ b/dora/underfs/obs/src/main/java/alluxio/underfs/obs/OBSUnderFileSystem.java
@@ -347,6 +347,18 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
+  public UfsStatus getStatus(String path) throws IOException {
+    ObjectStatus status = getObjectStatus(stripPrefixIfPresent(path));
+    if (!isDirectory(path)) {
+      ObjectPermissions permissions = getPermissions();
+      return new UfsFileStatus(path, status.getContentHash(), status.getContentLength(), status.getLastModifiedTimeMs(),
+              permissions.getOwner(), permissions.getGroup(), permissions.getMode(), mUfsConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT));
+    }
+    // Return directory status.
+    return getDirectoryStatus(path);
+  }
+  
+  @Override
   public boolean isDirectory(String path) throws IOException {
     if (!isEnvironmentPFS()) {
       return super.isDirectory(path);


### PR DESCRIPTION
### What changes are proposed in this pull request?
Determine whether it is a file or directory based on the path to obtain the correct file status

### Why are the changes needed?
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.
Fix the issue of not being able to display third level files when ufs is OBS

### Does this PR introduce any user facing changes?
No
Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  4. webui
