### PR TITLE
[DOCFIX] Improve desc on write type THROUGH

### DIFF
--- a/docs/en/overview/Architecture.md
+++ b/docs/en/overview/Architecture.md
@@ -309,7 +309,7 @@ If you are writing replica with `ASYNC_THROUGH` and all worker with the copies c
 ### Write to UFS Only (`THROUGH`)
 
 With `THROUGH`, data is written to under storage synchronously without being cached to Alluxio
-workers. This write type ensures that data will be persisted after the write completes, but the
+workers. This write type ensures that data will be persisted before the write completes, but the
 speed is limited by the under storage throughput.
 
 ### Data consistency


### PR DESCRIPTION
### Summary
In Section 6.4 Write to UFS Only (THROUGH), write completion and persistence are described in the wrong order. In the case of using UFS only, write should be completed after persistence to ensure that the written data will not be lost.

Suggest to update the sentence
”This write type ensures that data will be persisted after the write completes“

to

”This write type ensures that data will be persisted before the write completes“
