### PR TITLE
Add command to build docker images

### DIFF
--- a/dev/scripts/src/alluxio.org/build/artifact/artifact.go
+++ b/dev/scripts/src/alluxio.org/build/artifact/artifact.go
@@ -15,6 +15,7 @@ type ArtifactType string
 
 const (
 	TarballArtifact = ArtifactType("tarball")
+	DockerArtifact  = ArtifactType("docker")
 )
 
 type RepoMetadata struct {

--- a/dev/scripts/src/alluxio.org/build/cmd/docker.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/docker.go
@@ -1,0 +1,162 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/palantir/stacktrace"
+	"gopkg.in/yaml.v3"
+
+	"alluxio.org/build/artifact"
+	"alluxio.org/command"
+)
+
+const (
+	dockerYmlFile = "src/alluxio.org/build/docker.yml"
+
+	tempAlluxioTarballName        = "alluxio-tmp.tar.gz"
+	tempAlluxioTarballPlaceholder = "${ALLUXIO_TEMP_TARBALL}"
+)
+
+type DockerImage struct {
+	BuildArgs  []string `yaml:"buildArgs,omitempty"`
+	BuildDir   string   `yaml:"buildDir"`
+	Dockerfile string   `yaml:"dockerfile"`
+	Tag        string   `yaml:"tag"`
+	TargetName string   `yaml:"targetName,omitempty"`
+	Dependency string   `yaml:"dependency,omitempty"`
+
+	outputTarball string `yaml:"-"`
+}
+
+type dockerBuildOpts struct {
+	*buildOpts
+
+	image       string
+	tarballPath string
+}
+
+var (
+	dockerImages = map[string]*DockerImage{}
+)
+
+func init() {
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(stacktrace.Propagate(err, "error getting current working directory"))
+	}
+	dockerYmlPath := filepath.Join(wd, dockerYmlFile)
+	content, err := ioutil.ReadFile(dockerYmlPath)
+	if err != nil {
+		panic(stacktrace.Propagate(err, "error reading file at %v", dockerYmlPath))
+	}
+	if err := yaml.Unmarshal(content, &dockerImages); err != nil {
+		panic(stacktrace.Propagate(err, "error unmarshalling docker images from:\n%v", string(content)))
+	}
+}
+
+func DockerF(args []string) error {
+	cmd := flag.NewFlagSet(Docker, flag.ExitOnError)
+	opts := &dockerBuildOpts{}
+	// docker flags
+	cmd.StringVar(&opts.image, "image", "", fmt.Sprintf("Choose the docker image to build. See available images at %v", dockerYmlFile))
+	cmd.StringVar(&opts.tarballPath, "tarballPath", "", "Set to use existing tarball for building docker image")
+	// parse flags
+	tOpts, err := parseTarballFlags(cmd, args)
+	if err != nil {
+		return stacktrace.Propagate(err, "error parsing build flags")
+	}
+	image, ok := dockerImages[opts.image]
+	if !ok {
+		return stacktrace.NewError("must provide valid 'image' arg")
+	}
+	alluxioVersion, err := alluxioVersionFromPom()
+	if err != nil {
+		return stacktrace.Propagate(err, "error parsing version string")
+	}
+	opts.buildOpts = tOpts
+	if opts.artifactOutput != "" {
+		artifact, err := artifact.NewArtifact(
+			artifact.DockerArtifact,
+			opts.outputDir,
+			strings.ReplaceAll(dockerImages[opts.image].TargetName, versionPlaceholder, alluxioVersion),
+			alluxioVersion,
+			map[string]string{"image": opts.image})
+		if err != nil {
+			return stacktrace.Propagate(err, "error adding artifact")
+		}
+		return artifact.WriteToFile(opts.artifactOutput)
+	}
+
+	if opts.tarballPath == "" {
+		if err := buildTarball(tOpts); err != nil {
+			return stacktrace.Propagate(err, "error building tarball")
+		}
+		opts.tarballPath = filepath.Join(opts.outputDir,
+			strings.ReplaceAll(opts.targetName, versionPlaceholder, alluxioVersion))
+	}
+
+	// docker logic
+	if err != nil {
+		return stacktrace.Propagate(err, "error finding repo root")
+	}
+	dockerWs := filepath.Join(findRepoRoot(), "integration", "docker")
+	if err := command.RunF("cp %v %v", opts.tarballPath, filepath.Join(dockerWs, tempAlluxioTarballName)); err != nil {
+		return stacktrace.Propagate(err, "error copying tarball to docker workspace")
+	}
+	defer os.RemoveAll(filepath.Join(dockerWs, tempAlluxioTarballName))
+
+	if err := image.build(alluxioVersion, opts.outputDir, true); err != nil {
+		return stacktrace.Propagate(err, "error building image %v", opts.image)
+	}
+
+	return nil
+}
+
+func (i *DockerImage) build(alluxioVersion, outputDir string, save bool) error {
+	dockerWs := filepath.Join(findRepoRoot(), i.BuildDir)
+	if i.Dependency != "" {
+		if err := dockerImages[i.Dependency].build(alluxioVersion, outputDir, false); err != nil {
+			return stacktrace.Propagate(err, "error building dep %v", i.Dependency)
+		}
+	}
+	i.Tag = strings.ReplaceAll(i.Tag, versionPlaceholder, alluxioVersion)
+	i.TargetName = strings.ReplaceAll(i.TargetName, versionPlaceholder, alluxioVersion)
+	i.outputTarball = fmt.Sprintf("%v/%v",
+		outputDir, strings.ReplaceAll(i.TargetName, versionPlaceholder, alluxioVersion))
+	var buildArgs []string
+	for _, a := range i.BuildArgs {
+		buildArgs = append(buildArgs, fmt.Sprintf("--build-arg %v",
+			strings.ReplaceAll(a, tempAlluxioTarballPlaceholder, tempAlluxioTarballName)))
+	}
+	cmds := []string{
+		fmt.Sprintf("docker build -f %v -t %v %v %v",
+			i.Dockerfile, i.Tag, strings.Join(buildArgs, ""), dockerWs),
+	}
+	if i.TargetName != "" && save {
+		cmds = append(cmds, fmt.Sprintf("docker save %v -o %v", i.Tag, i.outputTarball))
+	}
+	for _, c := range cmds {
+		log.Printf("Running: %v", c)
+		if out, err := command.New(c).WithDir(findRepoRoot()).CombinedOutput(); err != nil {
+			return stacktrace.Propagate(err, "error from running cmd: %v", string(out))
+		}
+	}
+	return nil
+}

--- a/dev/scripts/src/alluxio.org/build/cmd/docker.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/docker.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	dockerYmlFile = "src/alluxio.org/build/docker.yml"
+	defaultDockerYmlFilePath = "src/alluxio.org/build/docker.yml"
 
 	tempAlluxioTarballName        = "alluxio-tmp.tar.gz"
 	tempAlluxioTarballPlaceholder = "${ALLUXIO_TEMP_TARBALL}"
@@ -48,41 +48,42 @@ type DockerImage struct {
 type dockerBuildOpts struct {
 	*buildOpts
 
-	image       string
-	tarballPath string
-}
-
-var (
-	dockerImages = map[string]*DockerImage{}
-)
-
-func init() {
-	wd, err := os.Getwd()
-	if err != nil {
-		panic(stacktrace.Propagate(err, "error getting current working directory"))
-	}
-	dockerYmlPath := filepath.Join(wd, dockerYmlFile)
-	content, err := ioutil.ReadFile(dockerYmlPath)
-	if err != nil {
-		panic(stacktrace.Propagate(err, "error reading file at %v", dockerYmlPath))
-	}
-	if err := yaml.Unmarshal(content, &dockerImages); err != nil {
-		panic(stacktrace.Propagate(err, "error unmarshalling docker images from:\n%v", string(content)))
-	}
+	dockerImages  map[string]*DockerImage
+	dockerYmlFile string
+	image         string
+	tarballPath   string
 }
 
 func DockerF(args []string) error {
 	cmd := flag.NewFlagSet(Docker, flag.ExitOnError)
 	opts := &dockerBuildOpts{}
 	// docker flags
-	cmd.StringVar(&opts.image, "image", "", fmt.Sprintf("Choose the docker image to build. See available images at %v", dockerYmlFile))
+	cmd.StringVar(&opts.dockerYmlFile, "dockerYmlFile", defaultDockerYmlFilePath, "Path to docker.yml file")
+	cmd.StringVar(&opts.image, "image", "", "Choose the docker image to build. See available images in docker.yml")
 	cmd.StringVar(&opts.tarballPath, "tarballPath", "", "Set to use existing tarball for building docker image")
 	// parse flags
 	tOpts, err := parseTarballFlags(cmd, args)
 	if err != nil {
 		return stacktrace.Propagate(err, "error parsing build flags")
 	}
-	image, ok := dockerImages[opts.image]
+
+	// parse available docker images in docker.yml
+	{
+		wd, err := os.Getwd()
+		if err != nil {
+			return stacktrace.Propagate(err, "error getting current working directory")
+		}
+		dockerYmlPath := filepath.Join(wd, opts.dockerYmlFile)
+		content, err := ioutil.ReadFile(dockerYmlPath)
+		if err != nil {
+			return stacktrace.Propagate(err, "error reading file at %v", dockerYmlPath)
+		}
+		if err := yaml.Unmarshal(content, &opts.dockerImages); err != nil {
+			return stacktrace.Propagate(err, "error unmarshalling docker images from:\n%v", string(content))
+		}
+	}
+
+	image, ok := opts.dockerImages[opts.image]
 	if !ok {
 		return stacktrace.NewError("must provide valid 'image' arg")
 	}
@@ -95,7 +96,7 @@ func DockerF(args []string) error {
 		artifact, err := artifact.NewArtifact(
 			artifact.DockerArtifact,
 			opts.outputDir,
-			strings.ReplaceAll(dockerImages[opts.image].TargetName, versionPlaceholder, alluxioVersion),
+			strings.ReplaceAll(opts.dockerImages[opts.image].TargetName, versionPlaceholder, alluxioVersion),
 			alluxioVersion,
 			map[string]string{"image": opts.image})
 		if err != nil {
@@ -122,24 +123,28 @@ func DockerF(args []string) error {
 	}
 	defer os.RemoveAll(filepath.Join(dockerWs, tempAlluxioTarballName))
 
-	if err := image.build(alluxioVersion, opts.outputDir, true); err != nil {
+	if err := image.build(opts, alluxioVersion, true); err != nil {
 		return stacktrace.Propagate(err, "error building image %v", opts.image)
 	}
 
 	return nil
 }
 
-func (i *DockerImage) build(alluxioVersion, outputDir string, save bool) error {
+func (i *DockerImage) build(opts *dockerBuildOpts, alluxioVersion string, save bool) error {
 	dockerWs := filepath.Join(findRepoRoot(), i.BuildDir)
 	if i.Dependency != "" {
-		if err := dockerImages[i.Dependency].build(alluxioVersion, outputDir, false); err != nil {
+		dep, ok := opts.dockerImages[i.Dependency]
+		if !ok {
+			return stacktrace.NewError("%v not found in list of docker images", i.Dependency)
+		}
+		if err := dep.build(opts, alluxioVersion, false); err != nil {
 			return stacktrace.Propagate(err, "error building dep %v", i.Dependency)
 		}
 	}
 	i.Tag = strings.ReplaceAll(i.Tag, versionPlaceholder, alluxioVersion)
 	i.TargetName = strings.ReplaceAll(i.TargetName, versionPlaceholder, alluxioVersion)
 	i.outputTarball = fmt.Sprintf("%v/%v",
-		outputDir, strings.ReplaceAll(i.TargetName, versionPlaceholder, alluxioVersion))
+		opts.outputDir, strings.ReplaceAll(i.TargetName, versionPlaceholder, alluxioVersion))
 	var buildArgs []string
 	for _, a := range i.BuildArgs {
 		buildArgs = append(buildArgs, fmt.Sprintf("--build-arg %v",

--- a/dev/scripts/src/alluxio.org/build/cmd/flags.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/flags.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	Docker          = "docker"
 	Modules         = "modules"
 	Profiles        = "profiles"
 	Tarball         = "tarball"
@@ -29,6 +30,7 @@ const (
 )
 
 var SubCmdNames = []string{
+	Docker,
 	Modules,
 	Profiles,
 	Tarball,

--- a/dev/scripts/src/alluxio.org/build/docker.yml
+++ b/dev/scripts/src/alluxio.org/build/docker.yml
@@ -1,0 +1,29 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+alluxio-base:
+  buildDir: integration/docker
+  dockerfile: integration/docker/Dockerfile-base
+  tag: alluxio/alluxio-base:latest
+alluxio:
+  buildArgs:
+    - "ALLUXIO_TARBALL=${ALLUXIO_TEMP_TARBALL}"
+  buildDir: integration/docker
+  dockerfile: integration/docker/Dockerfile
+  tag: alluxio/alluxio:${VERSION}
+  targetName: alluxio-${VERSION}.tar
+  dependency: alluxio-base
+alluxio-dev:
+  buildDir: integration/docker
+  dockerfile: integration/docker/Dockerfile-dev
+  tag: alluxio/alluxio-dev:${VERSION}
+  targetName: alluxio-dev-${VERSION}.tar
+  dependency: alluxio

--- a/dev/scripts/src/alluxio.org/build/main.go
+++ b/dev/scripts/src/alluxio.org/build/main.go
@@ -32,6 +32,8 @@ func run(args []string) error {
 		return stacktrace.NewError("expected a subcommand argument. select one of the following: %v", cmd.SubCmdNames)
 	}
 	switch subCmd := args[1]; subCmd {
+	case cmd.Docker:
+		return cmd.DockerF(args[2:])
 	case cmd.Modules:
 		return cmd.PluginsF(args[2:])
 	case cmd.Profiles:


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add command to build docker images via artifact generation script. Docker images will be built and saved to tarballs (via `docker save`).

ex:
```
# will build dependent alluxio tarball since the alluxio docker image requires it
./build-artifact.sh docker --image alluxio <add same args as tarball cmd>

# uses an existing alluxio tarball
./build-artifact.sh docker --image alluxio --tarballPath ../../alluxio-296-SNAPSHOT-bin.tar.gz
```


### Why are the changes needed?

Enable generating docker 'artifacts' (tarballs)

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
