### PR TITLE
Fix LocalPageStore NPE

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -77,11 +77,11 @@ public class LocalPageStore implements PageStore {
       }
     } catch (Exception e) {
       Files.deleteIfExists(pagePath);
-      if (e.getMessage().contains(ERROR_NO_SPACE_LEFT)) {
+      if (e.getMessage() != null && e.getMessage().contains(ERROR_NO_SPACE_LEFT)) {
         throw new ResourceExhaustedException(
             String.format("%s is full, configured with %d bytes", mRoot, mCapacity), e);
       }
-      throw new IOException("Failed to write file " + pagePath + " for page " + pageId);
+      throw new IOException("Failed to write file " + pagePath + " for page " + pageId, e);
     }
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix LocalPageStore NPE.

### Why are the changes needed?

I encountered the following exception while using local cache

```
2023-05-31T17:25:13.453+0800    ERROR   20230531_092513_00010_uqx2a.1.0.0-7-153 alluxio.client.file.cache.NoExceptionCacheManager       Failed to put page PageId{FileId=76f9c79d5d43c725de31295c263291e0, PageIndex=534}, cacheContext CacheContext{cacheIdentifier=null, cacheQuota=alluxio.client.quota.CacheQuota$1@1f, cacheScope=CacheScope{id=.}, hiveCacheContext=null, isTemporary=false}
java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because the return value of "java.lang.Exception.getMessage()" is null
        at alluxio.client.file.cache.store.LocalPageStore.put(LocalPageStore.java:80)
        at alluxio.client.file.cache.LocalCacheManager.putAttempt(LocalCacheManager.java:345)
        at alluxio.client.file.cache.LocalCacheManager.putInternal(LocalCacheManager.java:274)
        at alluxio.client.file.cache.LocalCacheManager.put(LocalCacheManager.java:234)
        at alluxio.client.file.cache.CacheManagerWithShadowCache.put(CacheManagerWithShadowCache.java:52)
        at alluxio.client.file.cache.NoExceptionCacheManager.put(NoExceptionCacheManager.java:55)
        at alluxio.client.file.cache.CacheManager.put(CacheManager.java:196)
        at alluxio.client.file.cache.LocalCacheFileInStream.localCachedRead(LocalCacheFileInStream.java:218)
        at alluxio.client.file.cache.LocalCacheFileInStream.bufferedRead(LocalCacheFileInStream.java:144)
        at alluxio.client.file.cache.LocalCacheFileInStream.readInternal(LocalCacheFileInStream.java:242)
        at alluxio.client.file.cache.LocalCacheFileInStream.positionedRead(LocalCacheFileInStream.java:287)
        at alluxio.hadoop.HdfsFileInputStream.read(HdfsFileInputStream.java:153)
        at alluxio.hadoop.HdfsFileInputStream.readFully(HdfsFileInputStream.java:170)
        at org.apache.hadoop.fs.FSDataInputStream.readFully(FSDataInputStream.java:111)
        at io.trino.filesystem.hdfs.HdfsInput.readFully(HdfsInput.java:42)
        at io.trino.plugin.hive.parquet.TrinoParquetDataSource.readInternal(TrinoParquetDataSource.java:64)
        at io.trino.parquet.AbstractParquetDataSource.readFully(AbstractParquetDataSource.java:120)
        at io.trino.parquet.AbstractParquetDataSource$ReferenceCountedReader.read(AbstractParquetDataSource.java:330)
        at io.trino.parquet.ChunkReader.readUnchecked(ChunkReader.java:31)
        at io.trino.parquet.reader.ChunkedInputStream.readNextChunk(ChunkedInputStream.java:149)
        at io.trino.parquet.reader.ChunkedInputStream.read(ChunkedInputStream.java:93)
```

### Does this PR introduce any user facing changes?

NO
