### PR TITLE
Fix fuse position read bug

### DIFF
--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReader.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReader.java
@@ -92,6 +92,9 @@ public class FusePositionReader implements FuseFileStream {
     if (mClosed) {
       throw new FailedPreconditionRuntimeException("Position reader is closed");
     }
+    if (offset >= mFileStatus.getFileLength()) {
+      return 0;
+    }
     try {
       return mPositionReader.read(offset, buf, (int) size);
     } catch (IOException e) {

--- a/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsPositionedUnderFileInputStream.java
+++ b/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsPositionedUnderFileInputStream.java
@@ -166,7 +166,7 @@ public class HdfsPositionedUnderFileInputStream
       totalRead += currentRead;
     }
     if (totalRead == 0) {
-      return totalRead;
+      return currentRead;
     }
     if (targetIsByteArray) {
       buffer.offset(arrayPosition);

--- a/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsPositionedUnderFileInputStream.java
+++ b/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsPositionedUnderFileInputStream.java
@@ -166,7 +166,7 @@ public class HdfsPositionedUnderFileInputStream
       totalRead += currentRead;
     }
     if (totalRead == 0) {
-      return currentRead;
+      return totalRead;
     }
     if (targetIsByteArray) {
       buffer.offset(arrayPosition);


### PR DESCRIPTION
### What changes are proposed in this pull request?
The position read will return -1 when position >= filesize, then the fuse will throw an error.
<img width="693" alt="image" src="https://github.com/Alluxio/alluxio/assets/42070967/58f808ab-aefc-4597-8e28-cf858fbac576">
/tmp/alluxio-fuse/f1 is a 1mb file.
### Why are the changes needed?
Fix the fuse position read bug.
### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
