### PR TITLE
Fix fuse start binary path

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -102,7 +102,7 @@ function formatWorkerIfSpecified {
 }
 
 function mountAlluxioFSWithFuseOption {
-  exec integration/fuse/bin/alluxio-fuse mount "${@}" -f
+  exec dora/integration/fuse/bin/alluxio-fuse mount "${@}" -f
 }
 
 function mountFuseWithUFS {


### PR DESCRIPTION
fuse dir had been moved inside dora/integration/fuse. Fix the path in `entrypoint.sh` for docker and k8s.