### PR TITLE
Modify shell of bin/alluxio-common.sh

### DIFF
--- a/bin/alluxio-common.sh
+++ b/bin/alluxio-common.sh
@@ -37,12 +37,9 @@ function get_alluxio_property() {
 }
 
 # Generates an array of ramdisk paths in global variable RAMDISKARRAY
-# - Only examines level0 of the tiered store for "MEM"-type paths
 function get_ramdisk_array() {
-  local tier_path=$(get_alluxio_property "alluxio.worker.tieredstore.level0.dirs.path")
-  local medium_type=$(get_alluxio_property "alluxio.worker.tieredstore.level0.dirs.mediumtype")
+  local tier_path=$(get_alluxio_property "alluxio.worker.page.store.dirs")
   local patharray
-  local mediumtypearray
 
   # Use "Internal Field Separator (IFS)" variable to split strings on a
   # delimeter and parse into an array
@@ -50,21 +47,18 @@ function get_ramdisk_array() {
   local oldifs=$IFS
   IFS=','
   read -ra patharray <<< "$tier_path"
-  read -ra mediumtypearray <<< "$medium_type"
 
   # iterate over the array elements using indices
   # - https://stackoverflow.com/a/6723516
   RAMDISKARRAY=()
-  for i in "${!patharray[@]}"; do 
-    if [ "${mediumtypearray[$i]}" = "MEM" ]; then
-      local dir=${patharray[$i]}
-      if [[ -z "${dir}" ]]; then
-        echo "Alluxio has a configured ramcache with an empty path"
-        exit 1
-      fi
-
-      RAMDISKARRAY+=(${patharray[$i]})
+  for i in "${!patharray[@]}"; do
+    local dir=${patharray[$i]}
+    if [[ -z "${dir}" ]]; then
+      echo "Alluxio has a configured ramcache with an empty path"
+      exit 1
     fi
+
+    RAMDISKARRAY+=(${patharray[$i]})
   done
   IFS=$oldifs
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Modify shell of `bin/alluxio-common.sh`

### Why are the changes needed?

Alluxio's original tier path is set by `alluxio.worker.tieredstore.level0.dirs.path`. However, in branch main, this property is removed. So I modify `bin/alluxio-common.sh` and let the value of `tier_path` be equal to `worker.page.store.dirs`.

### Does this PR introduce any user facing changes?

No.
