### PR TITLE
Fix corrupted block causing reads to fail

### DIFF
--- a/core/common/src/main/java/alluxio/exception/runtime/BlockDoesNotExistRuntimeException.java
+++ b/core/common/src/main/java/alluxio/exception/runtime/BlockDoesNotExistRuntimeException.java
@@ -19,11 +19,21 @@ import java.text.MessageFormat;
 public class BlockDoesNotExistRuntimeException extends NotFoundRuntimeException {
 
   /**
-   * Constructs a new exception with the specified detail message and cause.
+   * Constructs a new exception with the specified block ID.
    *
    * @param blockId block id
    */
   public BlockDoesNotExistRuntimeException(long blockId) {
     super(MessageFormat.format("BlockMeta not found for blockId {0,number,#}", blockId));
+  }
+
+  /**
+   * Constructs a new exception with the specified block ID and cause.
+   *
+   * @param blockId block id
+   * @param cause why the block is not found
+   */
+  public BlockDoesNotExistRuntimeException(long blockId, Throwable cause) {
+    super(MessageFormat.format("Block {0,number,#} not found", blockId), cause);
   }
 }

--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -270,6 +270,25 @@ public final class FileUtils {
   }
 
   /**
+   * Deletes the file or directory, if it exists.
+   *
+   * @param path pathname string of file or directory
+   */
+  public static void deleteIfExists(String path) {
+    try {
+      Files.deleteIfExists(Paths.get(path));
+    } catch (java.nio.file.InvalidPathException e) {
+      throw new InvalidArgumentRuntimeException(e);
+    } catch (DirectoryNotEmptyException e) {
+      throw new FailedPreconditionRuntimeException(e);
+    } catch (SecurityException e) {
+      throw new PermissionDeniedRuntimeException(e);
+    } catch (IOException e) {
+      throw new UnknownRuntimeException(e);
+    }
+  }
+
+  /**
    * Deletes a file or a directory, recursively if it is a directory.
    *
    * If the path does not exist, nothing happens.

--- a/core/server/worker/src/main/java/alluxio/worker/block/MonoBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/MonoBlockStore.java
@@ -159,18 +159,21 @@ public class MonoBlockStore implements BlockStore {
       boolean positionShort, Protocol.OpenUfsBlockOptions options)
       throws IOException {
     BlockReader reader;
-    Optional<? extends BlockMeta> blockMeta = mLocalBlockStore.getVolatileBlockMeta(blockId);
-    if (blockMeta.isPresent()) {
+    // first try reading from Alluxio cache
+    try {
       reader = mLocalBlockStore.createBlockReader(sessionId, blockId, offset);
       DefaultBlockWorker.Metrics.WORKER_ACTIVE_CLIENTS.inc();
-    } else {
-      boolean checkUfs = options != null && (options.hasUfsPath() || options.getBlockInUfsTier());
-      if (!checkUfs) {
-        throw new BlockDoesNotExistRuntimeException(blockId);
-      }
-      // When the block does not exist in Alluxio but exists in UFS, try to open the UFS block.
-      reader = createUfsBlockReader(sessionId, blockId, offset, positionShort, options);
+      return reader;
+    } catch (BlockDoesNotExistRuntimeException e) {
+      // the block does not exist in Alluxio, try loading from UFS
     }
+    boolean checkUfs = options != null && (options.hasUfsPath() || options.getBlockInUfsTier());
+    if (!checkUfs) {
+      throw new BlockDoesNotExistRuntimeException(blockId);
+    }
+    // When the block does not exist in Alluxio but exists in UFS, try to open the UFS block.
+    reader = createUfsBlockReader(sessionId, blockId, offset, positionShort, options);
+    DefaultBlockWorker.Metrics.WORKER_ACTIVE_CLIENTS.inc();
     return reader;
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -243,7 +243,8 @@ public class TieredBlockStore implements LocalBlockStore {
    * @param blockMeta the block meta acquired from meta data manager
    * @throws IllegalStateException if the block is deemed corrupted
    */
-  private void validateBlockIntegrityForRead(BlockMeta blockMeta) throws IllegalStateException {
+  public static void validateBlockIntegrityForRead(BlockMeta blockMeta)
+      throws IllegalStateException {
     final long blockId = blockMeta.getBlockId();
     final Path blockPath = Paths.get(blockMeta.getPath());
     final BasicFileAttributes blockFileAttrs;

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -903,7 +903,7 @@ public class TieredBlockStore implements LocalBlockStore {
    * @param blockMeta block metadata
    */
   private void removeBlockFileAndMeta(BlockMeta blockMeta) {
-    FileUtils.delete(blockMeta.getPath());
+    FileUtils.deleteIfExists(blockMeta.getPath());
     mMetaManager.removeBlockMeta(blockMeta);
   }
 

--- a/tests/src/test/java/alluxio/server/tieredstore/TieredStoreBlockCorruptionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/TieredStoreBlockCorruptionIntegrationTest.java
@@ -24,6 +24,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.ReadPType;
 import alluxio.grpc.WritePType;
+import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.io.BufferUtils;
@@ -55,7 +56,7 @@ import java.util.Optional;
  * 1. its block meta exists in memory, but no physical block file exist in the cache directory, or
  * 2. its length in block meta is non-zero, but the physical block file is 0-sized.
  */
-public class TieredStoreBlockCorruptionIntegrationTest {
+public class TieredStoreBlockCorruptionIntegrationTest extends BaseIntegrationTest {
   private static final int MEM_CAPACITY_BYTES = 1000;
   private static final int BLOCK_SIZE = 100;
   private final AlluxioURI mFile = new AlluxioURI("/file1");

--- a/tests/src/test/java/alluxio/server/tieredstore/TieredStoreBlockCorruptionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/TieredStoreBlockCorruptionIntegrationTest.java
@@ -1,0 +1,267 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.server.tieredstore;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.client.block.stream.LocalFileDataReader;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
+import alluxio.client.file.FileSystemTestUtils;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.options.InStreamOptions;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.status.NotFoundException;
+import alluxio.grpc.ReadPType;
+import alluxio.grpc.WritePType;
+import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.util.FileSystemOptionsUtils;
+import alluxio.util.io.BufferUtils;
+import alluxio.wire.BlockInfo;
+import alluxio.wire.FileBlockInfo;
+import alluxio.worker.block.BlockWorker;
+import alluxio.worker.block.meta.BlockMeta;
+
+import com.google.common.io.ByteStreams;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Tests that when a corrupt block is being read, tiered store will remove this block
+ * from both block meta and the physical block file, and falls back to read it from the UFS.
+ * A corrupt block is defined as:
+ * 1. its block meta exists in memory, but no physical block file exist in the cache directory, or
+ * 2. its length in block meta is non-zero, but the physical block file is 0-sized.
+ */
+public class TieredStoreBlockCorruptionIntegrationTest {
+  private static final int MEM_CAPACITY_BYTES = 1000;
+  private static final int BLOCK_SIZE = 100;
+  private final AlluxioURI mFile = new AlluxioURI("/file1");
+  private final int mFileLength = 3 * 100; // 3 blocks, 100 bytes each
+  private BlockWorker mWorker;
+  private FileSystem mFileSystem;
+
+  @Rule
+  public TemporaryFolder mTempFolder = new TemporaryFolder();
+
+  @Rule
+  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
+      new LocalAlluxioClusterResource.Builder()
+          .setProperty(PropertyKey.WORKER_RAMDISK_SIZE, MEM_CAPACITY_BYTES)
+          .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE)
+          .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, 100)
+          .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVEL0_HIGH_WATERMARK_RATIO, 0.8)
+          .setProperty(PropertyKey.USER_FILE_RESERVED_BYTES, 100)
+          .setProperty(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false)
+          .setProperty(PropertyKey.WORKER_REVIEWER_CLASS,
+              "alluxio.worker.block.reviewer.AcceptingReviewer")
+          .build();
+
+  @Before
+  public final void before() throws Exception {
+    mFileSystem = mLocalAlluxioClusterResource.get().getClient();
+    mWorker = mLocalAlluxioClusterResource.get()
+        .getWorkerProcess()
+        .getWorker(BlockWorker.class);
+    prepareFileWithCorruptBlocks();
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {
+      PropertyKey.Name.USER_SHORT_CIRCUIT_ENABLED, "false",
+  })
+  public void sequentialRead() throws Exception {
+    verifySequentialReadable();
+    verifyBlockMetadata();
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {
+      PropertyKey.Name.USER_SHORT_CIRCUIT_ENABLED, "false",
+  })
+  public void positionedRead() throws Exception {
+    verifyPositionedReadable();
+    verifyBlockMetadata();
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {
+      PropertyKey.Name.USER_SHORT_CIRCUIT_ENABLED, "true",
+  })
+  public void shortCircuitRead() throws Exception {
+    // verify that the block cannot be read via short-circuit
+    try (FileSystemContext fsContext = FileSystemContext.create()) {
+      URIStatus fileStatus = mFileSystem.getStatus(mFile);
+      List<FileBlockInfo> blocks = fileStatus.getFileBlockInfos();
+      InStreamOptions inStreamOptions = new InStreamOptions(fileStatus,
+          fsContext.getClusterConf());
+      Assert.assertThrows(NotFoundException.class, () -> new LocalFileDataReader.Factory(
+          fsContext, mWorker.getWorkerAddress(), blocks.get(0).getBlockInfo().getBlockId(),
+          Constants.KB, inStreamOptions));
+    }
+
+    verifySequentialReadable();
+    verifyBlockMetadata();
+  }
+
+  /**
+   * Prepares a 3-block file, truncates the first block to 0 size, removes the second block, and
+   * leaves the third block intact.
+   */
+  private void prepareFileWithCorruptBlocks() throws Exception {
+    BlockWorker worker = mLocalAlluxioClusterResource.get()
+        .getWorkerProcess()
+        .getWorker(BlockWorker.class);
+    FileSystemTestUtils.createByteFile(mFileSystem, mFile, WritePType.CACHE_THROUGH, mFileLength);
+    URIStatus fileStatus = mFileSystem.getStatus(mFile);
+    Path ufsFilePath = Paths.get(fileStatus.getFileInfo().getUfsPath());
+    Assert.assertTrue(Files.exists(ufsFilePath));
+    Assert.assertEquals(mFileLength, Files.size(ufsFilePath));
+
+    List<FileBlockInfo> blocks = fileStatus.getFileBlockInfos();
+    Assert.assertEquals(3, blocks.size());
+    Assert.assertTrue(blocks.get(0).getBlockInfo().getLocations().size() >= 1);
+    Assert.assertTrue(blocks.get(1).getBlockInfo().getLocations().size() >= 1);
+    Assert.assertTrue(blocks.get(2).getBlockInfo().getLocations().size() >= 1);
+
+    // truncate the first block on disk, bypassing worker management to simulate block corruption
+    Optional<BlockMeta> firstBlockMeta =
+        worker.getBlockStore().getVolatileBlockMeta(blocks.get(0).getBlockInfo().getBlockId());
+    Assert.assertTrue(
+        String.format("Block meta of first block does not exist on worker %s",
+            worker.getWorkerAddress()), firstBlockMeta.isPresent());
+    Path blockFilePath = Paths.get(firstBlockMeta.get().getPath());
+    Files.write(blockFilePath, new byte[0], StandardOpenOption.TRUNCATE_EXISTING);
+    Assert.assertTrue(Files.exists(blockFilePath));
+    Assert.assertEquals(0, Files.size(blockFilePath));
+
+    // remove the second block file
+    Optional<BlockMeta> secondBlockMeta =
+        worker.getBlockStore().getVolatileBlockMeta(blocks.get(1).getBlockInfo().getBlockId());
+    Assert.assertTrue(
+        String.format("Block meta of second block does not exist on worker %s",
+            worker.getWorkerAddress()), secondBlockMeta.isPresent());
+    blockFilePath = Paths.get(secondBlockMeta.get().getPath());
+    Files.deleteIfExists(blockFilePath);
+    Assert.assertFalse(Files.exists(blockFilePath));
+
+    Optional<BlockMeta> thirdBlockMeta =
+        worker.getBlockStore().getVolatileBlockMeta(blocks.get(2).getBlockInfo().getBlockId());
+    Assert.assertTrue(
+        String.format("Block meta of third block does not exist on worker %s",
+            worker.getWorkerAddress()), thirdBlockMeta.isPresent());
+    blockFilePath = Paths.get(thirdBlockMeta.get().getPath());
+    Assert.assertTrue(Files.exists(blockFilePath));
+    Assert.assertEquals(thirdBlockMeta.get().getBlockSize(), Files.size(blockFilePath));
+  }
+
+  private void verifySequentialReadable() throws Exception {
+    URIStatus fileStatus = mFileSystem.getStatus(mFile);
+    try (FileInStream is = mFileSystem.openFile(
+        fileStatus,
+        FileSystemOptionsUtils.openFileDefaults(
+            mLocalAlluxioClusterResource.get().getClient().getConf())
+        .toBuilder()
+        .setReadType(ReadPType.NO_CACHE) // don't cache the corrupt block
+        .build())) {
+      byte[] fileContent = ByteStreams.toByteArray(is);
+      Assert.assertTrue(
+          BufferUtils.equalIncreasingByteArray(mFileLength, fileContent));
+    }
+  }
+
+  private void verifyPositionedReadable() throws Exception {
+    URIStatus fileStatus = mFileSystem.getStatus(mFile);
+    try (FileInStream is = mFileSystem.openFile(
+        fileStatus,
+        FileSystemOptionsUtils.openFileDefaults(
+            mLocalAlluxioClusterResource.get().getClient().getConf())
+        .toBuilder()
+        .setReadType(ReadPType.NO_CACHE) // don't cache the corrupt block
+        .build())) {
+      final long startPos = 0;
+      int totalBytesRead = 0;
+      byte[] buffer = new byte[Constants.KB];
+      int bytesRead = is.positionedRead(startPos, buffer, totalBytesRead, buffer.length);
+      while (bytesRead != -1) {
+        totalBytesRead += bytesRead;
+        Assert.assertTrue(totalBytesRead <= mFileLength);
+        bytesRead = is.positionedRead(
+            startPos + totalBytesRead, buffer, totalBytesRead, buffer.length);
+      }
+      byte[] fileContent = Arrays.copyOfRange(buffer, 0, totalBytesRead);
+      Assert.assertTrue(
+          BufferUtils.equalIncreasingByteArray((int) startPos, totalBytesRead, fileContent));
+    }
+  }
+
+  /**
+   * Verifies that after corrupt blocks are detected and removed by tiered store, the first
+   * two blocks are not cached by the worker, and their block location info from master does not
+   * contain the worker.
+   */
+  private void verifyBlockMetadata() throws Exception {
+    URIStatus fileStatus = mFileSystem.getStatus(mFile);
+    List<FileBlockInfo> blocks = fileStatus.getFileBlockInfos();
+    Assert.assertEquals(3, blocks.size());
+    // verify that block meta are correct in block worker
+    Assert.assertFalse(mWorker
+        .getBlockStore()
+        .getVolatileBlockMeta(blocks.get(0).getBlockInfo().getBlockId())
+        .isPresent());
+    Assert.assertFalse(mWorker
+        .getBlockStore()
+        .getVolatileBlockMeta(blocks.get(1).getBlockInfo().getBlockId())
+        .isPresent());
+    Assert.assertTrue(mWorker
+        .getBlockStore()
+        .getVolatileBlockMeta(blocks.get(2).getBlockInfo().getBlockId())
+        .isPresent());
+
+    // verify that the block location info has been updated in master after worker-master sync
+    Thread.sleep(mLocalAlluxioClusterResource.get()
+        .getClient()
+        .getConf()
+        .getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS) * 2);
+    // retrieve latest block location info
+    fileStatus = mFileSystem.getStatus(mFile);
+    blocks = fileStatus.getFileBlockInfos();
+    Assert.assertEquals(3, blocks.size());
+    Assert.assertTrue(blocks
+        .stream()
+        .limit(2)
+        .map(FileBlockInfo::getBlockInfo)
+        .map(BlockInfo::getLocations)
+        .flatMap(Collection::stream)
+        .noneMatch(loc -> loc.getWorkerAddress().equals(mWorker.getWorkerAddress())));
+    Assert.assertTrue(blocks
+        .stream()
+        .skip(2)
+        .map(FileBlockInfo::getBlockInfo)
+        .map(BlockInfo::getLocations)
+        .flatMap(Collection::stream)
+        .anyMatch(loc -> loc.getWorkerAddress().equals(mWorker.getWorkerAddress())));
+  }
+}

--- a/tests/src/test/java/alluxio/server/tieredstore/TieredStoreIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/TieredStoreIntegrationTest.java
@@ -13,16 +13,12 @@ package alluxio.server.tieredstore;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
-import alluxio.client.block.stream.LocalFileDataReader;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
-import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
-import alluxio.client.file.options.InStreamOptions;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
 import alluxio.grpc.SetAttributePOptions;
@@ -31,29 +27,17 @@ import alluxio.master.block.BlockMaster;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.BufferUtils;
-import alluxio.wire.FileBlockInfo;
-import alluxio.worker.block.BlockWorker;
 import alluxio.worker.block.allocator.GreedyAllocator;
-import alluxio.worker.block.meta.BlockMeta;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.ByteStreams;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Integration tests for {@link alluxio.worker.block.meta.StorageTier}.
@@ -292,167 +276,5 @@ public class TieredStoreIntegrationTest extends BaseIntegrationTest {
         return false;
       }
     }, WAIT_OPTIONS);
-  }
-
-  /**
-   * Tests that when a corrupt block is being read, tiered store will remove this block
-   * from both block meta and the physical block file, and falls back to read it from the UFS.
-   * A corrupt block is defined as:
-   * 1. its block meta exists in memory, but no physical block file exist in the cache directory, or
-   * 2. its length in block meta is non-zero, but the physical block file is 0-sized.
-   */
-  @Test
-  @LocalAlluxioClusterResource.Config(confParams = {
-      PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "100",
-      // disable short circuit read to ensure blocks are read from worker block store
-      PropertyKey.Name.USER_SHORT_CIRCUIT_ENABLED, "false",
-  })
-  public void removesCorruptBlockAndFallbackToUfs() throws Exception {
-    BlockWorker worker = mLocalAlluxioClusterResource.get()
-        .getWorkerProcess()
-        .getWorker(BlockWorker.class);
-    AlluxioURI file = new AlluxioURI("/file1");
-    int fileLen = 3 * 100; // 3 blocks, 100 bytes each
-    prepareCorruptThreeBlockFile(file, fileLen);
-    URIStatus fileStatus = mFileSystem.getStatus(file);
-    List<FileBlockInfo> blocks = fileStatus.getFileBlockInfos();
-    // verify that the file can be read
-    FileInStream is = mFileSystem.openFile(fileStatus, FileSystemOptionsUtils.openFileDefaults(
-        mLocalAlluxioClusterResource.get().getClient().getConf())
-            .toBuilder()
-            .setReadType(ReadPType.NO_CACHE) // don't cache the corrupt block
-            .build());
-    byte[] fileContent = ByteStreams.toByteArray(is);
-    Assert.assertTrue(
-        BufferUtils.equalIncreasingByteArray(fileLen, fileContent));
-    Assert.assertFalse(worker
-        .getBlockStore()
-        .getVolatileBlockMeta(blocks.get(0).getBlockInfo().getBlockId())
-        .isPresent());
-    Assert.assertFalse(worker
-        .getBlockStore()
-        .getVolatileBlockMeta(blocks.get(1).getBlockInfo().getBlockId())
-        .isPresent());
-    Assert.assertTrue(worker
-        .getBlockStore()
-        .getVolatileBlockMeta(blocks.get(2).getBlockInfo().getBlockId())
-        .isPresent());
-    // verify that the block location info has been updated in master
-    Thread.sleep(mLocalAlluxioClusterResource.get().getClient().getConf()
-        .getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS) * 2);
-    URIStatus newStatus = mFileSystem.getStatus(file);
-    Assert.assertEquals(0,
-        newStatus.getFileBlockInfos().get(0).getBlockInfo().getLocations().size());
-    Assert.assertEquals(0,
-        newStatus.getFileBlockInfos().get(1).getBlockInfo().getLocations().size());
-    Assert.assertEquals(1,
-        newStatus.getFileBlockInfos().get(2).getBlockInfo().getLocations().size());
-  }
-
-  @Test
-  @LocalAlluxioClusterResource.Config(confParams = {
-      PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "100",
-      PropertyKey.Name.USER_SHORT_CIRCUIT_ENABLED, "true",
-  })
-  public void removesCorruptBlockAndFallbackToUfsShortCircuit() throws Exception {
-    BlockWorker worker = mLocalAlluxioClusterResource.get()
-        .getWorkerProcess()
-        .getWorker(BlockWorker.class);
-    AlluxioURI file = new AlluxioURI("/file1");
-    int fileLen = 3 * 100; // 3 blocks, 100 bytes each
-    prepareCorruptThreeBlockFile(file, fileLen);
-    URIStatus fileStatus = mFileSystem.getStatus(file);
-    List<FileBlockInfo> blocks = fileStatus.getFileBlockInfos();
-
-    // verify that the block cannot be read via short-circuit
-    FileSystemContext fsContext = FileSystemContext.create();
-    InStreamOptions inStreamOptions = new InStreamOptions(fileStatus, fsContext.getClusterConf());
-    Assert.assertThrows(NotFoundException.class, () -> new LocalFileDataReader.Factory(
-        fsContext, worker.getWorkerAddress(), blocks.get(0).getBlockInfo().getBlockId(),
-        Constants.KB, inStreamOptions));
-
-    // verify that the file is readable
-    FileInStream is = mFileSystem.openFile(fileStatus, FileSystemOptionsUtils.openFileDefaults(
-            fsContext.getClusterConf())
-        .toBuilder()
-        .setReadType(ReadPType.NO_CACHE) // don't cache the corrupt block
-        .build());
-    byte[] fileContent = ByteStreams.toByteArray(is);
-    Assert.assertTrue(
-        BufferUtils.equalIncreasingByteArray(fileLen, fileContent));
-    Assert.assertFalse(worker
-        .getBlockStore()
-        .getVolatileBlockMeta(blocks.get(0).getBlockInfo().getBlockId())
-        .isPresent());
-    Assert.assertFalse(worker
-        .getBlockStore()
-        .getVolatileBlockMeta(blocks.get(1).getBlockInfo().getBlockId())
-        .isPresent());
-    Assert.assertTrue(worker
-        .getBlockStore()
-        .getVolatileBlockMeta(blocks.get(2).getBlockInfo().getBlockId())
-        .isPresent());
-    // verify that the block location info has been updated in master
-    Thread.sleep(fsContext
-        .getClusterConf()
-        .getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS) * 2);
-    URIStatus newStatus = mFileSystem.getStatus(file);
-    Assert.assertEquals(0,
-        newStatus.getFileBlockInfos().get(0).getBlockInfo().getLocations().size());
-    Assert.assertEquals(0,
-        newStatus.getFileBlockInfos().get(1).getBlockInfo().getLocations().size());
-    Assert.assertEquals(1,
-        newStatus.getFileBlockInfos().get(2).getBlockInfo().getLocations().size());
-  }
-
-  /**
-   * Prepares a 3-block file, truncates the first block to 0 size, removes the second block, and
-   * leaves the third block intact.
-   */
-  private void prepareCorruptThreeBlockFile(AlluxioURI fileName, int fileLen) throws Exception {
-    BlockWorker worker = mLocalAlluxioClusterResource.get()
-        .getWorkerProcess()
-        .getWorker(BlockWorker.class);
-    FileSystemTestUtils.createByteFile(mFileSystem, fileName, WritePType.CACHE_THROUGH, fileLen);
-    URIStatus fileStatus = mFileSystem.getStatus(fileName);
-    Path ufsFilePath = Paths.get(fileStatus.getFileInfo().getUfsPath());
-    Assert.assertTrue(Files.exists(ufsFilePath));
-    Assert.assertEquals(fileLen, Files.size(ufsFilePath));
-
-    List<FileBlockInfo> blocks = fileStatus.getFileBlockInfos();
-    Assert.assertEquals(3, blocks.size());
-    Assert.assertTrue(blocks.get(0).getBlockInfo().getLocations().size() >= 1);
-    Assert.assertTrue(blocks.get(1).getBlockInfo().getLocations().size() >= 1);
-    Assert.assertTrue(blocks.get(2).getBlockInfo().getLocations().size() >= 1);
-
-    // truncate the first block on disk, bypassing worker management to simulate block corruption
-    Optional<BlockMeta> firstBlockMeta =
-        worker.getBlockStore().getVolatileBlockMeta(blocks.get(0).getBlockInfo().getBlockId());
-    Assert.assertTrue(
-        String.format("Block meta of first block does not exist on worker %s",
-            worker.getWorkerAddress()), firstBlockMeta.isPresent());
-    Path blockFilePath = Paths.get(firstBlockMeta.get().getPath());
-    Files.write(blockFilePath, new byte[0], StandardOpenOption.TRUNCATE_EXISTING);
-    Assert.assertTrue(Files.exists(blockFilePath));
-    Assert.assertEquals(0, Files.size(blockFilePath));
-
-    // remove the second block file
-    Optional<BlockMeta> secondBlockMeta =
-        worker.getBlockStore().getVolatileBlockMeta(blocks.get(1).getBlockInfo().getBlockId());
-    Assert.assertTrue(
-        String.format("Block meta of second block does not exist on worker %s",
-            worker.getWorkerAddress()), secondBlockMeta.isPresent());
-    blockFilePath = Paths.get(secondBlockMeta.get().getPath());
-    Files.deleteIfExists(blockFilePath);
-    Assert.assertFalse(Files.exists(blockFilePath));
-
-    Optional<BlockMeta> thirdBlockMeta =
-        worker.getBlockStore().getVolatileBlockMeta(blocks.get(2).getBlockInfo().getBlockId());
-    Assert.assertTrue(
-        String.format("Block meta of third block does not exist on worker %s",
-            worker.getWorkerAddress()), thirdBlockMeta.isPresent());
-    blockFilePath = Paths.get(thirdBlockMeta.get().getPath());
-    Assert.assertTrue(Files.exists(blockFilePath));
-    Assert.assertEquals(thirdBlockMeta.get().getBlockSize(), Files.size(blockFilePath));
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix read failure when a mismatch occurs between the block size recorded in memory by `BlockMeta` and the length of the actual physical block file. When such a mismatch is detected, the block is removed from worker storage, and worker falls back to reading from UFS.

### Why are the changes needed?

This causes reading the block to fail.

### Does this PR introduce any user facing changes?

No.
