### PR TITLE
Implement HTTP server for providing the get page RESTful API

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -252,6 +252,20 @@ public interface CacheManager extends AutoCloseable, CacheStatus {
    *
    * @param pageId page identifier
    * @param pageOffset offset into the page
+   * @param buffer destination buffer to write
+   * @param cacheContext cache related context
+   * @return number of bytes read, 0 if page is not found, -1 on errors
+   */
+  default int get(PageId pageId, int pageOffset, ReadTargetBuffer buffer,
+          CacheContext cacheContext) {
+    throw new UnsupportedOperationException("This method is unsupported. ");
+  }
+
+  /**
+   * Reads a part of a page if the queried page is found in the cache, stores the result in buffer.
+   *
+   * @param pageId page identifier
+   * @param pageOffset offset into the page
    * @param bytesToRead number of bytes to read in this page
    * @param buffer destination buffer to write
    * @param offsetInBuffer offset in the destination buffer to write

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -563,6 +563,24 @@ public class LocalCacheManager implements CacheManager {
   }
 
   @Override
+  public int get(PageId pageId, int pageOffset, ReadTargetBuffer buffer,
+                 CacheContext cacheContext) {
+    ReadWriteLock pageLock = getPageLock(pageId);
+    long pageSize = -1L;
+    try (LockResource r = new LockResource(pageLock.readLock())) {
+      PageInfo pageInfo;
+      try (LockResource r2 = new LockResource(mPageMetaStore.getLock().readLock())) {
+        pageInfo = mPageMetaStore.getPageInfo(pageId); //check if page exists and refresh LRU items
+      } catch (PageNotFoundException e) {
+        LOG.debug("get({},pageOffset={}) fails due to page not found", pageId, pageOffset);
+        return 0;
+      }
+      pageSize = pageInfo.getPageSize();
+    }
+    return get(pageId, pageOffset, (int) pageSize, buffer, cacheContext);
+  }
+
+  @Override
   public int get(PageId pageId, int pageOffset, int bytesToRead, ReadTargetBuffer buffer,
                  CacheContext cacheContext) {
     Preconditions.checkArgument(pageOffset <= mOptions.getPageSize(),

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
@@ -74,6 +74,18 @@ public class NoExceptionCacheManager implements CacheManager {
   }
 
   @Override
+  public int get(PageId pageId, int pageOffset, ReadTargetBuffer buffer,
+                 CacheContext cacheContext) {
+    try {
+      return mCacheManager.get(pageId, pageOffset, buffer, cacheContext);
+    } catch (Exception e) {
+      LOG.error("Failed to get page {}", pageId, e);
+      Metrics.GET_ERRORS.inc();
+      return -1;
+    }
+  }
+
+  @Override
   public int get(PageId pageId, int bytesToRead, byte[] buffer, int offsetInBuffer) {
     try {
       return mCacheManager.get(pageId, bytesToRead, buffer, offsetInBuffer);

--- a/dora/core/common/src/main/java/alluxio/file/NettyBufTargetBuffer.java
+++ b/dora/core/common/src/main/java/alluxio/file/NettyBufTargetBuffer.java
@@ -109,4 +109,12 @@ public class NettyBufTargetBuffer implements ReadTargetBuffer {
     }
     return bytesRead;
   }
+
+  /**
+   * Get the internal Bytebuf object
+   * @return the internal Bytebuf object
+   */
+  public ByteBuf getTargetBuffer() {
+    return mTarget;
+  }
 }

--- a/dora/core/common/src/main/java/alluxio/file/NettyBufTargetBuffer.java
+++ b/dora/core/common/src/main/java/alluxio/file/NettyBufTargetBuffer.java
@@ -111,7 +111,7 @@ public class NettyBufTargetBuffer implements ReadTargetBuffer {
   }
 
   /**
-   * Get the internal Bytebuf object
+   * Get the internal Bytebuf object.
    * @return the internal Bytebuf object
    */
   public ByteBuf getTargetBuffer() {

--- a/dora/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -250,7 +250,9 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
     mWebServer.start();
 
     // Start HTTP Server
-    mHttpServer.start();
+    if (mHttpServer != null) {
+      mHttpServer.start();
+    }
 
     // Start monitor jvm
     if (Configuration.getBoolean(PropertyKey.WORKER_JVM_MONITOR_ENABLED)) {

--- a/dora/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -32,6 +32,7 @@ import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.block.BlockWorker;
 import alluxio.worker.dora.DoraWorker;
 import alluxio.worker.netty.NettyDataServer;
+import alluxio.worker.http.HttpServer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
@@ -55,6 +56,11 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
   private static final Logger LOG = LoggerFactory.getLogger(AlluxioWorkerProcess.class);
 
   private final TieredIdentity mTieredIdentitiy;
+
+  /**
+   * Server for http restful api
+   */
+  private HttpServer mHttpServer;
 
   /**
    * Server for data requests and responses.
@@ -159,6 +165,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
       } else {
         mNettyDataServer = null;
       }
+
+      mHttpServer = new HttpServer();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -75,6 +75,11 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
   private DataServer mDomainSocketDataServer;
 
   /**
+   * HTTP Server provides RESTful API to get/put/append/delete page.
+   */
+  private HttpServer httpServer;
+
+  /**
    * The worker registry.
    */
   private final WorkerRegistry mRegistry;
@@ -121,7 +126,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
       UfsManager ufsManager,
       Worker worker,
       DataServerFactory dataServerFactory,
-      @Nullable NettyDataServer nettyDataServer) {
+      @Nullable NettyDataServer nettyDataServer,
+      @Nullable HttpServer httpServer) {
     try {
       mTieredIdentitiy = requireNonNull(tieredIdentity);
       mUfsManager = requireNonNull(ufsManager);
@@ -166,7 +172,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
         mNettyDataServer = null;
       }
 
-      mHttpServer = new HttpServer();
+      mHttpServer = httpServer;
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -247,6 +253,9 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
 
     // Start serving the web server, this will not block.
     mWebServer.start();
+
+    // Start HTTP Server
+    mHttpServer.start();
 
     // Start monitor jvm
     if (Configuration.getBoolean(PropertyKey.WORKER_JVM_MONITOR_ENABLED)) {

--- a/dora/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -31,8 +31,8 @@ import alluxio.wire.TieredIdentity;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.block.BlockWorker;
 import alluxio.worker.dora.DoraWorker;
-import alluxio.worker.netty.NettyDataServer;
 import alluxio.worker.http.HttpServer;
+import alluxio.worker.netty.NettyDataServer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
@@ -58,11 +58,6 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
   private final TieredIdentity mTieredIdentitiy;
 
   /**
-   * Server for http restful api
-   */
-  private HttpServer mHttpServer;
-
-  /**
    * Server for data requests and responses.
    */
   private DataServer mDataServer;
@@ -77,7 +72,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
   /**
    * HTTP Server provides RESTful API to get/put/append/delete page.
    */
-  private HttpServer httpServer;
+  private HttpServer mHttpServer;
 
   /**
    * The worker registry.

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServer.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServer.java
@@ -1,0 +1,42 @@
+package alluxio.worker.http;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import com.google.common.base.Throwables;
+
+public final class HttpServer {
+    static final boolean SSL = false;
+    static final int PORT = 28080;
+
+    public HttpServer() {
+        // Configure the server.
+        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.option(ChannelOption.SO_BACKLOG, 1024);
+            b.group(bossGroup, workerGroup)
+             .channel(NioServerSocketChannel.class)
+             .handler(new LoggingHandler(LogLevel.INFO))
+             .childHandler(new HttpServerInitializer());
+
+            Channel ch = b.bind(PORT).sync().channel();
+
+            System.err.println("Open your web browser and navigate to " +
+                    (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');
+
+            ch.closeFuture().sync();
+        } catch (InterruptedException e) {
+            throw Throwables.propagate(e);
+        } finally {
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+        }
+    }
+}

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
@@ -59,6 +59,7 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
       HttpRequest req = (HttpRequest) msg;
       String requestUri = req.uri();
       // parse the request uri to get the parameters
+      // TODO(JiamingMai): parse the URI and dispatch it to different methods
       requestUri = requestUri.substring(requestUri.indexOf("?") + 1);
       String[] params = requestUri.split("&");
       Map<String, String> parametersMap = new HashMap<>();

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
@@ -1,0 +1,64 @@
+package alluxio.worker.http;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpUtil;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderValues.CLOSE;
+import static io.netty.handler.codec.http.HttpHeaderValues.KEEP_ALIVE;
+import static io.netty.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+
+public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
+    private static final byte[] CONTENT = { 'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd' };
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) {
+        if (msg instanceof HttpRequest) {
+            HttpRequest req = (HttpRequest) msg;
+
+            boolean keepAlive = HttpUtil.isKeepAlive(req);
+            FullHttpResponse response = new DefaultFullHttpResponse(req.protocolVersion(), OK,
+                                                                    Unpooled.wrappedBuffer(CONTENT));
+            response.headers()
+                    .set(CONTENT_TYPE, TEXT_PLAIN)
+                    .setInt(CONTENT_LENGTH, response.content().readableBytes());
+
+            if (keepAlive) {
+                if (!req.protocolVersion().isKeepAliveDefault()) {
+                    response.headers().set(CONNECTION, KEEP_ALIVE);
+                }
+            } else {
+                // Tell the client we're going to close the connection.
+                response.headers().set(CONNECTION, CLOSE);
+            }
+
+            ChannelFuture f = ctx.write(response);
+
+            if (!keepAlive) {
+                f.addListener(ChannelFutureListener.CLOSE);
+            }
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        ctx.close();
+    }
+}

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
@@ -1,5 +1,18 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.worker.http;
 
+import com.google.inject.Inject;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -18,9 +31,17 @@ import static io.netty.handler.codec.http.HttpHeaderValues.CLOSE;
 import static io.netty.handler.codec.http.HttpHeaderValues.KEEP_ALIVE;
 import static io.netty.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import alluxio.client.file.cache.CacheManager;
+import java.util.HashMap;
+import java.util.Map;
 
 public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
-    private static final byte[] CONTENT = { 'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd' };
+
+    private final PagedService mPagedService;
+
+    public HttpServerHandler(PagedService pagedService) {
+        mPagedService = pagedService;
+    }
 
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) {
@@ -31,10 +52,22 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
     public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) {
         if (msg instanceof HttpRequest) {
             HttpRequest req = (HttpRequest) msg;
+            String requestUri = req.uri();
+            // parse the request uri to get the parameters
+            requestUri = requestUri.substring(requestUri.indexOf("?") + 1);
+            String[] params = requestUri.split("&");
+            Map<String, String> parametersMap = new HashMap<>();
+            for (String param : params) {
+                String[] keyValue = param.split("=");
+                parametersMap.put(keyValue[0], keyValue[1]);
+            }
+            String fileId = parametersMap.get("fileId");
+            long pageIndex = Long.parseLong(parametersMap.get("pageIndex"));
 
             boolean keepAlive = HttpUtil.isKeepAlive(req);
+            ByteBuf byteBuf = mPagedService.getPage(fileId, pageIndex, ctx.channel());
             FullHttpResponse response = new DefaultFullHttpResponse(req.protocolVersion(), OK,
-                                                                    Unpooled.wrappedBuffer(CONTENT));
+                byteBuf);
             response.headers()
                     .set(CONTENT_TYPE, TEXT_PLAIN)
                     .setInt(CONTENT_LENGTH, response.content().readableBytes());

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
@@ -1,5 +1,17 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.worker.http;
 
+import com.google.inject.Inject;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
@@ -10,21 +22,19 @@ import io.netty.handler.codec.http.HttpServerExpectContinueHandler;
 
 public class HttpServerInitializer extends ChannelInitializer<SocketChannel> {
 
-    //private final SslContext sslCtx;
+    private final PagedService mPagedService;
 
-    public HttpServerInitializer() {
-        //this.sslCtx = sslCtx;
+    @Inject
+    public HttpServerInitializer(PagedService pagedService) {
+        mPagedService = pagedService;
     }
 
     @Override
     public void initChannel(SocketChannel ch) {
         ChannelPipeline p = ch.pipeline();
-        //if (sslCtx != null) {
-        //    p.addLast(sslCtx.newHandler(ch.alloc()));
-        //}
         p.addLast(new HttpServerCodec());
         p.addLast(new HttpContentCompressor((CompressionOptions[]) null));
         p.addLast(new HttpServerExpectContinueHandler());
-        p.addLast(new HttpServerHandler());
+        p.addLast(new HttpServerHandler(mPagedService));
     }
 }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
@@ -17,6 +17,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.compression.CompressionOptions;
 import io.netty.handler.codec.http.HttpContentCompressor;
+import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerExpectContinueHandler;
 
@@ -40,6 +41,7 @@ public class HttpServerInitializer extends ChannelInitializer<SocketChannel> {
   public void initChannel(SocketChannel ch) {
     ChannelPipeline p = ch.pipeline();
     p.addLast(new HttpServerCodec());
+    p.addLast(new HttpObjectAggregator(1024 * 10));
     p.addLast(new HttpContentCompressor((CompressionOptions[]) null));
     p.addLast(new HttpServerExpectContinueHandler());
     p.addLast(new HttpServerHandler(mPagedService));

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
@@ -1,0 +1,30 @@
+package alluxio.worker.http;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.compression.CompressionOptions;
+import io.netty.handler.codec.http.HttpContentCompressor;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpServerExpectContinueHandler;
+
+public class HttpServerInitializer extends ChannelInitializer<SocketChannel> {
+
+    //private final SslContext sslCtx;
+
+    public HttpServerInitializer() {
+        //this.sslCtx = sslCtx;
+    }
+
+    @Override
+    public void initChannel(SocketChannel ch) {
+        ChannelPipeline p = ch.pipeline();
+        //if (sslCtx != null) {
+        //    p.addLast(sslCtx.newHandler(ch.alloc()));
+        //}
+        p.addLast(new HttpServerCodec());
+        p.addLast(new HttpContentCompressor((CompressionOptions[]) null));
+        p.addLast(new HttpServerExpectContinueHandler());
+        p.addLast(new HttpServerHandler());
+    }
+}

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
@@ -20,21 +20,28 @@ import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerExpectContinueHandler;
 
+/**
+ * {@link HttpServerInitializer} is used for initializing the Netty pipeline of HTTP Server.
+ */
 public class HttpServerInitializer extends ChannelInitializer<SocketChannel> {
 
-    private final PagedService mPagedService;
+  private final PagedService mPagedService;
 
-    @Inject
-    public HttpServerInitializer(PagedService pagedService) {
-        mPagedService = pagedService;
-    }
+  /**
+   * {@link HttpServerInitializer} is used for initializing the Netty pipeline of HTTP Server.
+   * @param pagedService the {@link PagedService} object provides page related RESTful API
+   */
+  @Inject
+  public HttpServerInitializer(PagedService pagedService) {
+    mPagedService = pagedService;
+  }
 
-    @Override
-    public void initChannel(SocketChannel ch) {
-        ChannelPipeline p = ch.pipeline();
-        p.addLast(new HttpServerCodec());
-        p.addLast(new HttpContentCompressor((CompressionOptions[]) null));
-        p.addLast(new HttpServerExpectContinueHandler());
-        p.addLast(new HttpServerHandler(mPagedService));
-    }
+  @Override
+  public void initChannel(SocketChannel ch) {
+    ChannelPipeline p = ch.pipeline();
+    p.addLast(new HttpServerCodec());
+    p.addLast(new HttpContentCompressor((CompressionOptions[]) null));
+    p.addLast(new HttpServerExpectContinueHandler());
+    p.addLast(new HttpServerHandler(mPagedService));
+  }
 }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
@@ -52,7 +52,10 @@ public class PagedService {
     ByteBuf byteBuf = channel.alloc().buffer((int) mPageSize);
     NettyBufTargetBuffer targetBuffer = new NettyBufTargetBuffer(byteBuf);
     PageId pageId = new PageId(fileId, pageIndex);
+    // TODO(JiamingMai): load the page from UFS if it doesn't exist, but this requires AlluxioURI
+    // instead of the given fileId
     int bytesRead = mCacheManager.get(pageId, 0, targetBuffer, CacheContext.defaults());
     return targetBuffer.getTargetBuffer();
   }
+  // TODO(JiamingMai): do we need to implement a method for reading file directly?
 }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
@@ -17,23 +17,37 @@ import alluxio.client.file.cache.PageId;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.file.NettyBufTargetBuffer;
-import alluxio.file.ReadTargetBuffer;
+
 import com.google.inject.Inject;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 
+/**
+ * {@link PagedService} is used for providing page related RESTful API service.
+ */
 public class PagedService {
 
   private final CacheManager mCacheManager;
 
   private final long mPageSize;
 
+  /**
+   * {@link PagedService} is used for providing page related RESTful API service.
+   * @param cacheManager The interface for managing cached pages
+   */
   @Inject
   public PagedService(CacheManager cacheManager) {
     mCacheManager = cacheManager;
     mPageSize = Configuration.global().getBytes(PropertyKey.WORKER_PAGE_STORE_PAGE_SIZE);
   }
 
+  /**
+   * Get page bytes given fileId, pageIndex, and channel which is used for allocating ByteBuf.
+   * @param fileId the file ID
+   * @param pageIndex the page index
+   * @param channel the Netty channel which is used for allocating ByteBuf
+   * @return the ByteBuf object that wraps page bytes
+   */
   public ByteBuf getPage(String fileId, long pageIndex, Channel channel) {
     ByteBuf byteBuf = channel.alloc().buffer((int) mPageSize);
     NettyBufTargetBuffer targetBuffer = new NettyBufTargetBuffer(byteBuf);
@@ -41,5 +55,4 @@ public class PagedService {
     int bytesRead = mCacheManager.get(pageId, 0, targetBuffer, CacheContext.defaults());
     return targetBuffer.getTargetBuffer();
   }
-
 }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
@@ -1,0 +1,45 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.http;
+
+import alluxio.client.file.CacheContext;
+import alluxio.client.file.cache.CacheManager;
+import alluxio.client.file.cache.PageId;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.file.NettyBufTargetBuffer;
+import alluxio.file.ReadTargetBuffer;
+import com.google.inject.Inject;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+
+public class PagedService {
+
+  private final CacheManager mCacheManager;
+
+  private final long mPageSize;
+
+  @Inject
+  public PagedService(CacheManager cacheManager) {
+    mCacheManager = cacheManager;
+    mPageSize = Configuration.global().getBytes(PropertyKey.WORKER_PAGE_STORE_PAGE_SIZE);
+  }
+
+  public ByteBuf getPage(String fileId, long pageIndex, Channel channel) {
+    ByteBuf byteBuf = channel.alloc().buffer((int) mPageSize);
+    NettyBufTargetBuffer targetBuffer = new NettyBufTargetBuffer(byteBuf);
+    PageId pageId = new PageId(fileId, pageIndex);
+    int bytesRead = mCacheManager.get(pageId, 0, targetBuffer, CacheContext.defaults());
+    return targetBuffer.getTargetBuffer();
+  }
+
+}

--- a/dora/core/server/worker/src/main/java/alluxio/worker/modules/BlockWorkerModule.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/modules/BlockWorkerModule.java
@@ -38,6 +38,8 @@ import alluxio.worker.block.TieredBlockStore;
 import alluxio.worker.block.TieredBlockWriterFactory;
 import alluxio.worker.block.TieredTempBlockMetaFactory;
 import alluxio.worker.file.FileSystemMasterClient;
+import alluxio.worker.http.HttpServer;
+import alluxio.worker.netty.NettyDataServer;
 import alluxio.worker.page.PagedBlockMetaStore;
 import alluxio.worker.page.PagedBlockStore;
 import alluxio.worker.page.PagedBlockStoreDir;
@@ -105,5 +107,7 @@ public class BlockWorkerModule extends AbstractModule {
     } else {
       bind(Worker.class).to(AllMasterRegistrationBlockWorker.class).in(Scopes.SINGLETON);
     }
+
+    bind(HttpServer.class).toProvider(() -> null);
   }
 }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/modules/BlockWorkerModule.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/modules/BlockWorkerModule.java
@@ -39,7 +39,6 @@ import alluxio.worker.block.TieredBlockWriterFactory;
 import alluxio.worker.block.TieredTempBlockMetaFactory;
 import alluxio.worker.file.FileSystemMasterClient;
 import alluxio.worker.http.HttpServer;
-import alluxio.worker.netty.NettyDataServer;
 import alluxio.worker.page.PagedBlockMetaStore;
 import alluxio.worker.page.PagedBlockStore;
 import alluxio.worker.page.PagedBlockStoreDir;

--- a/dora/core/server/worker/src/main/java/alluxio/worker/modules/DoraWorkerModule.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/modules/DoraWorkerModule.java
@@ -27,6 +27,10 @@ import alluxio.worker.dora.DoraUfsManager;
 import alluxio.worker.dora.DoraWorker;
 import alluxio.worker.dora.PagedDoraWorker;
 import alluxio.worker.file.FileSystemMasterClient;
+import alluxio.worker.http.HttpServer;
+import alluxio.worker.http.HttpServerHandler;
+import alluxio.worker.http.HttpServerInitializer;
+import alluxio.worker.http.PagedService;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
@@ -60,9 +64,15 @@ public class DoraWorkerModule extends AbstractModule {
       PageMetaStore pageMetaStore = PageMetaStore.create(
           CacheManagerOptions.createForWorker(Configuration.global()));
       bind(PageMetaStore.class).toInstance(pageMetaStore);
-      bind(CacheManager.class).toInstance(
-          CacheManager.Factory.create(Configuration.global(),
-              cacheManagerOptions, pageMetaStore));
+      bind(CacheManager.class).toProvider(() ->
+      {
+        try {
+          return CacheManager.Factory.create(Configuration.global(),
+              cacheManagerOptions, pageMetaStore);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }).in(Scopes.SINGLETON);
 
       long pageSize = Configuration.global().getBytes(PropertyKey.WORKER_PAGE_STORE_PAGE_SIZE);
       bind(new TypeLiteral<Long>() {
@@ -70,6 +80,11 @@ public class DoraWorkerModule extends AbstractModule {
     } catch (IOException e) {
       throw new RuntimeException("Failed to create CacheManager", e);
     }
+
+    // HTTP Server
+    bind(PagedService.class).in(Scopes.SINGLETON);
+    bind(HttpServerInitializer.class).in(Scopes.SINGLETON);
+    bind(HttpServer.class).in(Scopes.SINGLETON);
 
     // the following objects are required when using dora
     bind(Worker.class).to(DoraWorker.class).in(Scopes.SINGLETON);

--- a/dora/core/server/worker/src/main/java/alluxio/worker/modules/DoraWorkerModule.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/modules/DoraWorkerModule.java
@@ -28,7 +28,6 @@ import alluxio.worker.dora.DoraWorker;
 import alluxio.worker.dora.PagedDoraWorker;
 import alluxio.worker.file.FileSystemMasterClient;
 import alluxio.worker.http.HttpServer;
-import alluxio.worker.http.HttpServerHandler;
 import alluxio.worker.http.HttpServerInitializer;
 import alluxio.worker.http.PagedService;
 

--- a/dora/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/dora/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -50,7 +50,6 @@ import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.hamcrest.Matchers;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/dora/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/dora/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -50,6 +50,7 @@ import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.hamcrest.Matchers;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Implement http server for providing the get page RESTful API. Now we can get the page by sending a HTTP request:
`http://<HOST>:<PORT>/page?fileId=<FILE_ID>&pageIndex=<PAGE_INDEX>`

An example snapshot is shown as follows:
<img width="985" alt="image" src="https://github.com/Alluxio/alluxio/assets/6129818/b079c763-cc86-4df7-b49d-5d6cd822a85b">

### Why are the changes needed?

It can provide a more convenient API for AI scenarios and improve reading performance.

### Does this PR introduce any user facing changes?

No, it doesn't.
