### PR TITLE
Add fs subcommand to CLI

### DIFF
--- a/cli/src/alluxio.org/cli/cmd/fs/cat.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/cat.go
@@ -1,0 +1,52 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Cat = &CatCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "cat",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"cat"},
+	},
+}
+
+type CatCommand struct {
+	*env.BaseJavaCommand
+}
+
+func (c *CatCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *CatCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path]", Cat.CommandName),
+		Short: "Print specified file's content",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	return cmd
+}
+
+func (c *CatCommand) Run(args []string) error {
+	return c.Base().Run(args)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/checksum.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/checksum.go
@@ -1,0 +1,52 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Checksum = &ChecksumCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "checksum",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"checksum"},
+	},
+}
+
+type ChecksumCommand struct {
+	*env.BaseJavaCommand
+}
+
+func (c *ChecksumCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *ChecksumCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path]", Checksum.CommandName),
+		Short: "Calculates the md5 checksum of a specified file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	return cmd
+}
+
+func (c *ChecksumCommand) Run(args []string) error {
+	return c.Base().Run(args)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/count.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/count.go
@@ -1,0 +1,63 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Count = &CountCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "count",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"count"},
+	},
+}
+
+type CountCommand struct {
+	*env.BaseJavaCommand
+
+	isHumanReadable bool
+}
+
+func (c *CountCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *CountCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path]", Count.CommandName),
+		Short: "Displays the number of files and directories matching the specified path",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	// special case to overwrite the -h shorthand for --help flag for --human-readable
+	cmd.PersistentFlags().BoolP("help", "", false, "help for this command")
+
+	cmd.Flags().BoolVarP(&c.isHumanReadable, "human-readable", "h", false, "Print sizes in human readable format")
+	return cmd
+}
+
+func (c *CountCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.isHumanReadable {
+		javaArgs = append(javaArgs, "-h")
+	}
+	javaArgs = append(javaArgs, args...)
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/cp.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/cp.go
@@ -1,0 +1,65 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Cp = &CopyCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "cp",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"cp"},
+	},
+}
+
+type CopyCommand struct {
+	*env.BaseJavaCommand
+
+	isRecursive bool
+}
+
+func (c *CopyCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *CopyCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [srcPath] [dstPath]", Cp.CommandName),
+		Short: "Copy a file or directory",
+		Long: `Copies a file or directory in the Alluxio filesystem or between local and Alluxio filesystems
+Use the file:// schema to indicate a local filesystem path (ex. file:///absolute/path/to/file) and
+use the recursive flag to copy directories`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	cmd.Flags().BoolVarP(&c.isRecursive, "recursive", "R", false, "True to copy the directory subtree to the destination directory")
+	// TODO: the java class also exposes flags for preserve, and threads
+	//  buffersize is also declared and mentioned in the usage text, but it's not added as an option in java code so it was never working
+	return cmd
+}
+
+func (c *CopyCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.isRecursive {
+		javaArgs = append(javaArgs, "-r")
+	}
+	javaArgs = append(javaArgs, args...)
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/du.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/du.go
@@ -1,0 +1,78 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Du = &DuCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "du",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"du"},
+	},
+}
+
+type DuCommand struct {
+	*env.BaseJavaCommand
+
+	groupByWorker   bool
+	isHumanReadable bool
+	showMemoryInfo  bool
+	summarize       bool
+}
+
+func (c *DuCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *DuCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path]", Du.CommandName),
+		Short: "Print specified file's content",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	// special case to overwrite the -h shorthand for --help flag for --human-readable
+	cmd.PersistentFlags().BoolP("help", "", false, "help for this command")
+
+	cmd.Flags().BoolVarP(&c.groupByWorker, "group-worker", "g", false, "Display distribution of data store in Alluxio grouped by worker")
+	cmd.Flags().BoolVarP(&c.isHumanReadable, "human-readable", "h", false, "Print sizes in human readable format")
+	cmd.Flags().BoolVarP(&c.showMemoryInfo, "memory", "m", false, "Show in memory size and percentage")
+	cmd.Flags().BoolVarP(&c.summarize, "summary", "s", false, "Summarize listed files by aggregating their sizes")
+	return cmd
+}
+
+func (c *DuCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.groupByWorker {
+		javaArgs = append(javaArgs, "-g")
+	}
+	if c.isHumanReadable {
+		javaArgs = append(javaArgs, "-h")
+	}
+	if c.showMemoryInfo {
+		javaArgs = append(javaArgs, "-m")
+	}
+	if c.summarize {
+		javaArgs = append(javaArgs, "-s")
+	}
+	javaArgs = append(javaArgs, args...)
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/fs.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/fs.go
@@ -1,0 +1,38 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"alluxio.org/cli/env"
+)
+
+var Service = &env.Service{
+	Name:        "fs",
+	Description: "Operations to interface with the Alluxio filesystem",
+	Commands: []env.Command{
+		Cat,
+		Checksum,
+		Count,
+		Cp,
+		Du,
+		Head,
+		Location,
+		Ls,
+		Mkdir,
+		Mv,
+		Rm,
+		Stat,
+		Tail,
+		Test,
+		Touch,
+	},
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/head.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/head.go
@@ -1,0 +1,60 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Head = &HeadCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "head",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"head"},
+	},
+}
+
+type HeadCommand struct {
+	*env.BaseJavaCommand
+
+	bytes string
+}
+
+func (c *HeadCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *HeadCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path]", Head.CommandName),
+		Short: "Print the leading bytes from the specified file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	cmd.Flags().StringVar(&c.bytes, "bytes", "", "Byte size to print")
+	return cmd
+}
+
+func (c *HeadCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.bytes != "" {
+		javaArgs = append(javaArgs, "-c", c.bytes)
+	}
+	javaArgs = append(javaArgs, args...)
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/location.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/location.go
@@ -1,0 +1,52 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Location = &LocationCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "location",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"location"},
+	},
+}
+
+type LocationCommand struct {
+	*env.BaseJavaCommand
+}
+
+func (c *LocationCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *LocationCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path]", Location.CommandName),
+		Short: "Displays the list of hosts storing the specified file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	return cmd
+}
+
+func (c *LocationCommand) Run(args []string) error {
+	return c.Base().Run(args)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/ls.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/ls.go
@@ -1,0 +1,138 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Ls = &LsCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "ls",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"ls"},
+	},
+}
+
+type LsCommand struct {
+	*env.BaseJavaCommand
+
+	listDirAsFile     bool
+	forceLoadMetadata bool
+	isHumanReadable   bool
+	omitMountInfo     bool
+	pinnedFileOnly    bool
+	isRecursive       bool
+	isReverse         bool
+	sortBy            string
+	timestamp         string
+}
+
+func (c *LsCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+var (
+	sortOptions = []string{
+		"creationTime",
+		"inMemoryPercentage",
+		"lastAccessTime",
+		"lastModificationTime",
+		"name",
+		"path",
+		"size",
+	}
+	timestampOptions = []string{
+		"createdTime",
+		"lastAccessTime",
+		"lastModifiedTime",
+	}
+)
+
+func (c *LsCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path]", Ls.CommandName),
+		Short: "Prints information for files and directories at the given path",
+		Long:  `Displays information for all files and directories directly under the specified paths, including permission, owner, group, size (bytes for files or the number of children for directories), persistence state, last modified time, the percentage of content already in Alluxio, and the path`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	// special case to overwrite the -h shorthand for --help flag for --human-readable
+	cmd.PersistentFlags().BoolP("help", "", false, "help for this command")
+
+	cmd.Flags().BoolVarP(&c.listDirAsFile, "list-dir-as-file", "d", false, "List directories as files")
+	cmd.Flags().BoolVarP(&c.forceLoadMetadata, "load-metadata", "f", false, "Force load metadata for immediate children in a directory")
+	cmd.Flags().BoolVarP(&c.isHumanReadable, "human-readable", "h", false, "Print sizes in human readable format")
+	cmd.Flags().BoolVarP(&c.omitMountInfo, "omit-mount-info", "m", false, "Omit mount point related information such as the UFS path")
+	cmd.Flags().BoolVarP(&c.pinnedFileOnly, "pinned-files", "p", false, "Only show pinned files")
+	cmd.Flags().BoolVarP(&c.isRecursive, "recursive", "R", false, "List subdirectories recursively")
+	cmd.Flags().BoolVarP(&c.isReverse, "reverse", "r", false, "Reverse sorted order")
+	cmd.Flags().StringVar(&c.sortBy, "sort", "", fmt.Sprintf("Sort entries by column, one of {%v}", strings.Join(sortOptions, "|")))
+	cmd.Flags().StringVar(&c.timestamp, "timestamp", "", fmt.Sprintf("Display specified timestamp of entry, one of {%v}", strings.Join(timestampOptions, "|")))
+	return cmd
+}
+
+func (c *LsCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.listDirAsFile {
+		javaArgs = append(javaArgs, "-d")
+	}
+	if c.forceLoadMetadata {
+		javaArgs = append(javaArgs, "-f")
+	}
+	if c.isHumanReadable {
+		javaArgs = append(javaArgs, "-h")
+	}
+	if c.omitMountInfo {
+		javaArgs = append(javaArgs, "-m")
+	}
+	if c.pinnedFileOnly {
+		javaArgs = append(javaArgs, "-p")
+	}
+	if c.isRecursive {
+		javaArgs = append(javaArgs, "-R")
+	}
+	if c.isReverse {
+		javaArgs = append(javaArgs, "-r")
+	}
+	if c.sortBy != "" {
+		if err := checkAllowed(c.sortBy, sortOptions...); err != nil {
+			return stacktrace.Propagate(err, "error validating sort options")
+		}
+		javaArgs = append(javaArgs, "--sort", c.sortBy)
+	}
+	if c.timestamp != "" {
+		if err := checkAllowed(c.timestamp, timestampOptions...); err != nil {
+			return stacktrace.Propagate(err, "error validating timestamp options")
+		}
+		javaArgs = append(javaArgs, "--timestamp", c.timestamp)
+	}
+	javaArgs = append(javaArgs, args...)
+	return c.Base().Run(javaArgs)
+}
+
+func checkAllowed(val string, allowed ...string) error {
+	for _, i := range allowed {
+		if val == i {
+			return nil
+		}
+	}
+	return stacktrace.NewError("value %v must be one of %v", val, strings.Join(allowed, ","))
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/mkdir.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/mkdir.go
@@ -1,0 +1,52 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Mkdir = &MkdirCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "mkdir",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"mkdir"},
+	},
+}
+
+type MkdirCommand struct {
+	*env.BaseJavaCommand
+}
+
+func (c *MkdirCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *MkdirCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path1 path2 ...]", Mkdir.CommandName),
+		Short: "Create directories at the specified paths, creating the parent directory if not exists",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	return cmd
+}
+
+func (c *MkdirCommand) Run(args []string) error {
+	return c.Base().Run(args)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/mv.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/mv.go
@@ -1,0 +1,52 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Mv = &MoveCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "mv",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"mv"},
+	},
+}
+
+type MoveCommand struct {
+	*env.BaseJavaCommand
+}
+
+func (c *MoveCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *MoveCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [srcPath] [dstPath]", Mv.CommandName),
+		Short: "Rename a file or directory",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	return cmd
+}
+
+func (c *MoveCommand) Run(args []string) error {
+	return c.Base().Run(args)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/rm.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/rm.go
@@ -1,0 +1,75 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Rm = &RmCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "rm",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"rm"},
+	},
+}
+
+type RmCommand struct {
+	*env.BaseJavaCommand
+
+	alluxioOnly  bool
+	deleteMount  bool
+	isRecursive  bool
+	skipUfsCheck bool
+}
+
+func (c *RmCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *RmCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path]", Rm.CommandName),
+		Short: "Remove the specified file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	cmd.Flags().BoolVar(&c.alluxioOnly, "alluxio-only", false, "True to only remove data and metadata from Alluxio cache")
+	cmd.Flags().BoolVarP(&c.deleteMount, "delete-mount", "m", false, "True to remove mount points within the specified directory subtree, which would otherwise cause failures")
+	cmd.Flags().BoolVarP(&c.isRecursive, "recursive", "R", false, "True to recursively remove files within the specified directory subtree")
+	cmd.Flags().BoolVarP(&c.skipUfsCheck, "skip-ufs-check", "U", false, "True to skip checking if corresponding UFS contents are in sync")
+	return cmd
+}
+
+func (c *RmCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.alluxioOnly {
+		javaArgs = append(javaArgs, "--alluxioOnly")
+	}
+	if c.deleteMount {
+		javaArgs = append(javaArgs, "--deleteMountPoint")
+	}
+	if c.isRecursive {
+		javaArgs = append(javaArgs, "-R")
+	}
+	if c.skipUfsCheck {
+		javaArgs = append(javaArgs, "-U")
+	}
+	javaArgs = append(javaArgs, args...)
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/stat.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/stat.go
@@ -1,0 +1,82 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Stat = &StatCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "stat",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"stat"},
+	},
+}
+
+type StatCommand struct {
+	*env.BaseJavaCommand
+
+	Path   string
+	FileId string
+	Format string
+}
+
+func (c *StatCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *StatCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   Stat.CommandName,
+		Short: "Displays info for the specified file or directory",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(nil)
+		},
+	})
+	const path, fileId = "path", "file-id"
+	cmd.Flags().StringVar(&c.Path, path, "", "Path to file or directory")
+	cmd.Flags().StringVar(&c.FileId, fileId, "", "File id of file")
+	cmd.Flags().StringVarP(&c.Format, "format", "f", "", `Display info in the given format:
+  "%N": name of the file
+  "%z": size of file in bytes
+  "%u": owner
+  "%g": group name of owner
+  "%i": file id of the file
+  "%y": modification time in UTC in 'yyyy-MM-dd HH:mm:ss' format
+  "%Y": modification time as Unix timestamp in milliseconds
+  "%b": Number of blocks allocated for file
+`)
+	cmd.MarkFlagsMutuallyExclusive(path, fileId)
+	return cmd
+}
+
+func (c *StatCommand) Run(_ []string) error {
+	if c.Path == "" && c.FileId == "" {
+		return stacktrace.NewError("must set one of --path or --file-id flags")
+	}
+
+	var javaArgs []string
+	if c.Format != "" {
+		javaArgs = append(javaArgs, "-f", c.Format)
+	}
+	if c.Path != "" {
+		javaArgs = append(javaArgs, c.Path)
+	} else if c.FileId != "" {
+		javaArgs = append(javaArgs, "--file-id", c.FileId)
+	}
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/tail.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/tail.go
@@ -1,0 +1,60 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Tail = &TailCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "tail",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"tail"},
+	},
+}
+
+type TailCommand struct {
+	*env.BaseJavaCommand
+
+	bytes string
+}
+
+func (c *TailCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *TailCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path]", Tail.CommandName),
+		Short: "Print the trailing bytes from the specified file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	cmd.Flags().StringVar(&c.bytes, "bytes", "", "Byte size to print")
+	return cmd
+}
+
+func (c *TailCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.bytes != "" {
+		javaArgs = append(javaArgs, "-c", c.bytes)
+	}
+	javaArgs = append(javaArgs, args...)
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/test.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/test.go
@@ -1,0 +1,80 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Test = &TestCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "test",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"test"},
+	},
+}
+
+type TestCommand struct {
+	*env.BaseJavaCommand
+
+	isDirectory  bool
+	isExists     bool
+	isFile       bool
+	isNotEmpty   bool
+	isZeroLength bool
+}
+
+func (c *TestCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *TestCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path]", Test.CommandName),
+		Short: "Test a property of a path, returning 0 if the property is true, or 1 otherwise",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	cmd.Flags().BoolVarP(&c.isDirectory, "dir", "d", false, "Test if path is a directory")
+	cmd.Flags().BoolVarP(&c.isExists, "exists", "e", false, "Test if path exists")
+	cmd.Flags().BoolVarP(&c.isFile, "file", "f", false, "Test if path is a file")
+	cmd.Flags().BoolVarP(&c.isFile, "not-empty", "s", false, "Test if path is not empty")
+	cmd.Flags().BoolVarP(&c.isFile, "zero", "z", false, "Test if path is zero length")
+	return cmd
+}
+
+func (c *TestCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.isDirectory {
+		javaArgs = append(javaArgs, "-d")
+	}
+	if c.isExists {
+		javaArgs = append(javaArgs, "-e")
+	}
+	if c.isFile {
+		javaArgs = append(javaArgs, "-f")
+	}
+	if c.isNotEmpty {
+		javaArgs = append(javaArgs, "-s")
+	}
+	if c.isZeroLength {
+		javaArgs = append(javaArgs, "-z")
+	}
+	javaArgs = append(javaArgs, args...)
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/fs/touch.go
+++ b/cli/src/alluxio.org/cli/cmd/fs/touch.go
@@ -1,0 +1,52 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Touch = &TouchCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "touch",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		Parameters:    []string{"touch"},
+	},
+}
+
+type TouchCommand struct {
+	*env.BaseJavaCommand
+}
+
+func (c *TouchCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *TouchCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v [path]", Touch.CommandName),
+		Short: "Create a 0 byte file at the specified path, which will also be created in the under file system",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	return cmd
+}
+
+func (c *TouchCommand) Run(args []string) error {
+	return c.Base().Run(args)
+}

--- a/cli/src/alluxio.org/cli/env/command.go
+++ b/cli/src/alluxio.org/cli/env/command.go
@@ -40,7 +40,7 @@ type BaseJavaCommand struct {
 }
 
 func (c *BaseJavaCommand) InitRunJavaClassCmd(cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().BoolVarP(&c.DebugMode, "attach-debug", "d", false, fmt.Sprintf("True to attach debug opts specified by $%v", ConfAlluxioUserAttachOpts.EnvVar))
+	cmd.Flags().BoolVar(&c.DebugMode, "attach-debug", false, fmt.Sprintf("True to attach debug opts specified by $%v", ConfAlluxioUserAttachOpts.EnvVar))
 	cmd.Flags().StringSliceVarP(&c.InlineJavaOpts, "java-opts", "D", nil, `Alluxio properties to apply, ex. -Dkey=value`)
 	return cmd
 }

--- a/cli/src/alluxio.org/cli/launch/launch.go
+++ b/cli/src/alluxio.org/cli/launch/launch.go
@@ -47,6 +47,5 @@ func Run() error {
 
 	env.InitServiceCommandTree(rootCmd)
 
-	rootCmd.SilenceUsage = true
 	return rootCmd.Execute()
 }

--- a/cli/src/alluxio.org/cli/main.go
+++ b/cli/src/alluxio.org/cli/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	"alluxio.org/cli/cmd/conf"
+	"alluxio.org/cli/cmd/fs"
 	"alluxio.org/cli/cmd/info"
 	"alluxio.org/cli/cmd/journal"
 	"alluxio.org/cli/cmd/process"
@@ -37,6 +38,7 @@ func main() {
 
 	for _, c := range []*env.Service{
 		conf.Service,
+		fs.Service,
 		info.Service,
 		journal.Service,
 		process.Service,


### PR DESCRIPTION
Add fs commands to golang CLI as part of https://github.com/Alluxio/alluxio/issues/17522

unlike other CLI commands, utilize arguments to maintain the existing structure of filesystem commands (ex. cp, du, ls, mv, rm, etc)
