### PR TITLE
Invalidate cached pages from PagingStore by fileId

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -303,12 +303,11 @@ public interface CacheManager extends AutoCloseable, CacheStatus {
   }
 
   /**
-   * Invalidates all pages by its file id.
+   * Deletes all pages of the given file.
+   *
    * @param fileId the file id of the target file
    */
-  default void invalidateAllPagesByFileId(String fileId) {
-    // Do nothing;
-  }
+  void deleteFile(String fileId);
 
   /**
    * Deletes a page from the cache.

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -303,6 +303,14 @@ public interface CacheManager extends AutoCloseable, CacheStatus {
   }
 
   /**
+   * Invalidates all pages by its file id.
+   * @param fileId the file id of the target file
+   */
+  default void invalidateAllPagesByFileId(String fileId) {
+    // Do nothing;
+  }
+
+  /**
    * Deletes a page from the cache.
    *
    * @param pageId page identifier

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerWithShadowCache.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerWithShadowCache.java
@@ -164,6 +164,11 @@ public class CacheManagerWithShadowCache implements CacheManager {
   }
 
   @Override
+  public void deleteFile(String fileId) {
+    mCacheManager.deleteFile(fileId);
+  }
+
+  @Override
   public Optional<CacheUsage> getUsage() {
     return mCacheManager.getUsage();
   }

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/DefaultPageMetaStore.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/DefaultPageMetaStore.java
@@ -228,7 +228,7 @@ public class DefaultPageMetaStore implements PageMetaStore {
   }
 
   @Override
-  @GuardedBy("getLock()")
+  @GuardedBy("getLock().readLock()")
   public Set<PageInfo> getAllPagesByFileId(String fileId) {
     Set<PageInfo> pages = mPages.getByField(INDEX_FILE_ID, fileId);
     return pages;

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/DefaultPageMetaStore.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/DefaultPageMetaStore.java
@@ -228,6 +228,13 @@ public class DefaultPageMetaStore implements PageMetaStore {
   }
 
   @Override
+  @GuardedBy("getLock()")
+  public Set<PageInfo> getAllPagesByFileId(String fileId) {
+    Set<PageInfo> pages = mPages.getByField(INDEX_FILE_ID, fileId);
+    return pages;
+  }
+
+  @Override
   public Optional<CacheUsage> getUsage() {
     return Optional.of(new Usage());
   }

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -47,6 +47,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -799,6 +800,15 @@ public class LocalCacheManager implements CacheManager {
       }
     }
     return pageIds;
+  }
+
+  @Override
+  public void invalidateAllPagesByFileId(String fileId) {
+    Set<PageInfo> pages;
+    try (LockResource r = new LockResource(mPageMetaStore.getLock().readLock())) {
+      pages = mPageMetaStore.getAllPagesByFileId(fileId);
+    }
+    pages.forEach(page -> delete(page.getPageId()));
   }
 
   @Override

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -803,7 +803,7 @@ public class LocalCacheManager implements CacheManager {
   }
 
   @Override
-  public void invalidateAllPagesByFileId(String fileId) {
+  public void deleteFile(String fileId) {
     Set<PageInfo> pages;
     try (LockResource r = new LockResource(mPageMetaStore.getLock().readLock())) {
       pages = mPageMetaStore.getAllPagesByFileId(fileId);

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
@@ -192,6 +192,15 @@ public class NoExceptionCacheManager implements CacheManager {
   }
 
   @Override
+  public void invalidateAllPagesByFileId(String fileId) {
+    try {
+      mCacheManager.invalidateAllPagesByFileId(fileId);
+    } catch (Exception e) {
+      LOG.error("Failed to invalidateAllPages for {}", fileId, e);
+    }
+  }
+
+  @Override
   public Optional<CacheUsage> getUsage() {
     return mCacheManager.getUsage();
   }

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
@@ -192,11 +192,11 @@ public class NoExceptionCacheManager implements CacheManager {
   }
 
   @Override
-  public void invalidateAllPagesByFileId(String fileId) {
+  public void deleteFile(String fileId) {
     try {
-      mCacheManager.invalidateAllPagesByFileId(fileId);
+      mCacheManager.deleteFile(fileId);
     } catch (Exception e) {
-      LOG.error("Failed to invalidateAllPages for {}", fileId, e);
+      LOG.error("Failed to deleteFile for {}", fileId, e);
     }
   }
 

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/PageMetaStore.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/PageMetaStore.java
@@ -17,7 +17,9 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.PageNotFoundException;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 
 /**
@@ -134,6 +136,15 @@ public interface PageMetaStore extends CacheStatus {
    * Resets the meta store.
    */
   void reset();
+
+  /**
+   * Gets all pages by the specified File ID.
+   * @param fileId the target file id
+   * @return a set of PageInfo's of this file, otherwise an empty set if not found
+   */
+  default Set<PageInfo> getAllPagesByFileId(String fileId) {
+    return Collections.emptySet();
+  }
 
   /**
    * @param pageStoreDir

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/PageMetaStore.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/PageMetaStore.java
@@ -17,7 +17,6 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.PageNotFoundException;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -142,9 +141,7 @@ public interface PageMetaStore extends CacheStatus {
    * @param fileId the target file id
    * @return a set of PageInfo's of this file, otherwise an empty set if not found
    */
-  default Set<PageInfo> getAllPagesByFileId(String fileId) {
-    return Collections.emptySet();
-  }
+  Set<PageInfo> getAllPagesByFileId(String fileId);
 
   /**
    * @param pageStoreDir

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
@@ -287,6 +287,11 @@ public final class CacheManagerWithShadowCacheTest {
     }
 
     @Override
+    public void deleteFile(String fileId) {
+      // no-op
+    }
+
+    @Override
     public Optional<CacheUsage> getUsage() {
       return Optional.empty();
     }

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -723,6 +723,11 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
+    public void deleteFile(String fileId) {
+      // no-op
+    }
+
+    @Override
     public Optional<CacheUsage> getUsage() {
       return Optional.of(new Usage());
     }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -355,7 +355,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
 
   private boolean invalidateCachedFile(String path) {
     FileId file = FileId.of(new AlluxioURI(path).hash());
-    mCacheManager.invalidateAllPagesByFileId(file.toString());
+    mCacheManager.deleteFile(file.toString());
     return true;
   }
 

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -22,7 +22,6 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.cache.CacheManager;
 import alluxio.client.file.cache.CacheUsage;
-import alluxio.client.file.cache.PageId;
 import alluxio.client.file.options.UfsFileSystemOptions;
 import alluxio.client.file.ufs.UfsBaseFileSystem;
 import alluxio.conf.AlluxioConfiguration;
@@ -340,23 +339,12 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
   }
 
   /**
-   * @param fileInfo the FileInfo of this file. Cached pages are identified by PageId
-   * @return true at this moment
+   * Invalidate the given cached File by deleting it from local cache.
+   * @param path the full path of this file
    */
-  public boolean invalidateCachedFile(FileInfo fileInfo) {
-    FileId fileId = FileId.of(new AlluxioURI(fileInfo.getUfsPath()).hash());
-
-    for (PageId page: mCacheManager.getCachedPageIdsByFileId(
-        fileId.toString(), fileInfo.getLength())) {
-      mCacheManager.delete(page);
-    }
-    return true;
-  }
-
-  private boolean invalidateCachedFile(String path) {
+  private void invalidateCachedFile(String path) {
     FileId file = FileId.of(new AlluxioURI(path).hash());
     mCacheManager.deleteFile(file.toString());
-    return true;
   }
 
   @Override

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -354,25 +354,8 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
   }
 
   private boolean invalidateCachedFile(String path) {
-    long pages = 0;
-    try {
-      UfsStatus existingFileStatus = mUfs.getStatus(path);
-      if (existingFileStatus instanceof UfsFileStatus) {
-        pages =
-            (((UfsFileStatus) existingFileStatus).getContentLength() + mPageSize - 1) / mPageSize;
-      }
-    } catch (Exception e) {
-      // It's possible that this file is not found in UFS.
-      // FIXME: If the file is not found in UFS, we need a new API to remove all cached pages
-      // of that file, not based on the pageId. This needs a new API. See below.
-      pages = 10_000L; // 1MB * 10_000 = 10GB
-    }
-    // TODO(bowen) we need a new API to remove all cached pages of a file, not based on the pages.
     FileId file = FileId.of(new AlluxioURI(path).hash());
-    for (long i = 0; i < pages; i++) {
-      PageId page = new PageId(file.toString(), i);
-      mCacheManager.delete(page);
-    }
+    mCacheManager.invalidateAllPagesByFileId(file.toString());
     return true;
   }
 

--- a/dora/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockMetaStore.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockMetaStore.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -467,6 +468,11 @@ public class PagedBlockMetaStore implements PageMetaStore {
   public Optional<CacheUsage> getUsage() {
     // TODO(bowen): implement partition by block
     return mDelegate.getUsage();
+  }
+
+  @Override
+  public Set<PageInfo> getAllPagesByFileId(String fileId) {
+    return Collections.emptySet();
   }
 
   private static PagedBlockStoreDir downcast(PageStoreDir pageStoreDir) {

--- a/dora/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockMetaStore.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockMetaStore.java
@@ -472,6 +472,14 @@ public class PagedBlockMetaStore implements PageMetaStore {
 
   @Override
   public Set<PageInfo> getAllPagesByFileId(String fileId) {
+    long blockId = BlockPageId.parseBlockId(fileId);
+    PagedBlockMeta blockMeta = mBlocks.getFirstByField(INDEX_BLOCK_ID, blockId);
+    if (blockMeta == null) {
+      blockMeta = mTempBlocks.getFirstByField(INDEX_TEMP_BLOCK_ID, blockId);
+    }
+    if (blockMeta != null) {
+      return blockMeta.getDir().getBlockPages(blockId);
+    }
     return Collections.emptySet();
   }
 

--- a/dora/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockStoreDir.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockStoreDir.java
@@ -15,7 +15,6 @@ import static alluxio.worker.page.PagedBlockStoreMeta.DEFAULT_MEDIUM;
 import static alluxio.worker.page.PagedBlockStoreMeta.DEFAULT_TIER;
 
 import alluxio.client.file.cache.CacheUsage;
-import alluxio.client.file.cache.PageId;
 import alluxio.client.file.cache.PageInfo;
 import alluxio.client.file.cache.PageStore;
 import alluxio.client.file.cache.store.PageStoreDir;
@@ -24,6 +23,7 @@ import alluxio.worker.block.BlockStoreLocation;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -288,8 +288,7 @@ public class PagedBlockStoreDir implements PageStoreDir {
    * @param blockId the block id
    * @return pages in this block being cached
    */
-  public Set<PageId> getBlockPages(long blockId) {
-    return mBlockToPagesMap.get(blockId).stream().map(PageInfo::getPageId)
-      .collect(Collectors.toSet());
+  public Set<PageInfo> getBlockPages(long blockId) {
+    return ImmutableSet.copyOf(mBlockToPagesMap.get(blockId));
   }
 }

--- a/dora/core/server/worker/src/test/java/alluxio/worker/page/ByteArrayCacheManager.java
+++ b/dora/core/server/worker/src/test/java/alluxio/worker/page/ByteArrayCacheManager.java
@@ -99,6 +99,11 @@ class ByteArrayCacheManager implements CacheManager {
   }
 
   @Override
+  public void deleteFile(String fileId) {
+    // Add its specific implementation here.
+  }
+
+  @Override
   public Optional<CacheUsage> getUsage() {
     return Optional.of(new Usage());
   }

--- a/dora/core/server/worker/src/test/java/alluxio/worker/page/ByteArrayCacheManager.java
+++ b/dora/core/server/worker/src/test/java/alluxio/worker/page/ByteArrayCacheManager.java
@@ -100,7 +100,7 @@ class ByteArrayCacheManager implements CacheManager {
 
   @Override
   public void deleteFile(String fileId) {
-    // Add its specific implementation here.
+    mPages.keySet().removeIf(pageId -> pageId.getFileId().equals(fileId));
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add and implement functions to invalidate all cached pages by fileId.

### Why are the changes needed?

When we know that some file is to be removed, or renamed, or overwritten, we need to invalidate the cached pages in PagingStore.
Please note, at this moment, it is possible that the target file is already removed from UFS. So, getStatus() of this file will fail with exception. But we still need to invalidate all the cached pages.

### Does this PR introduce any user facing changes?

N/A
