### PR TITLE
Fix copyFromLocal while dest path is endsWith a `/`

### DIFF
--- a/dora/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/dora/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -114,6 +114,8 @@ public enum ExceptionMessage {
   CANNOT_OVERWRITE_DIRECTORY("{0} already exists. Directories cannot be overwritten with create"),
   CANNOT_OVERWRITE_FILE_WITHOUT_OVERWRITE("{0} already exists. If you want to overwrite the file,"
       + " you need to specify the overwrite option."),
+  CANNOT_COPY_TO_NOT_EXIST_DIRECTORY("{0} is a directory and should be created first."),
+  FILE_TYPE_NOT_MATCH("{0} exists but it's not a directory."),
 
   // block master
   NO_WORKER_FOUND("No worker with workerId {0,number,#} is found"),

--- a/dora/core/common/src/test/java/alluxio/AlluxioURITest.java
+++ b/dora/core/common/src/test/java/alluxio/AlluxioURITest.java
@@ -635,6 +635,7 @@ public class AlluxioURITest {
     assertEquals("/a/b", new AlluxioURI("alluxio://localhost:80/a/./b").getPath());
     assertEquals("/a/b", new AlluxioURI("/a/b").getPath());
     assertEquals("/a/b", new AlluxioURI("file:///a/b").getPath());
+    assertEquals("/a/b", new AlluxioURI("alluxio://localhost:80/a/b/").getPath());
   }
 
   /**

--- a/dora/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -358,7 +358,12 @@ public final class CpCommand extends AbstractFileSystemCommand {
       // and must be created first
       boolean dstExist = mFileSystem.exists(dstPath);
       if (!dstExist && args[1].endsWith(AlluxioURI.SEPARATOR)) {
-        throw new IOException(dstPath + " is a directory and should be created first.");
+        throw new IOException(
+                ExceptionMessage.CANNOT_COPY_TO_NOT_EXIST_DIRECTORY.getMessage(dstPath.getPath()));
+      }
+      if (dstExist && args[1].endsWith(AlluxioURI.SEPARATOR)
+              && !mFileSystem.getStatus(dstPath).isFolder()) {
+        throw new IOException(ExceptionMessage.FILE_TYPE_NOT_MATCH.getMessage(dstPath.getPath()));
       }
       List<AlluxioURI> srcPaths = new ArrayList<>();
       if (srcPath.containsWildcard()) {

--- a/dora/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/dora/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -205,6 +205,37 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
   }
 
   @Test
+  public void copyFromLocalDirectoryNotExist() throws Exception {
+    final int LEN = 10;
+    File testFile1 = generateFileContent("/testFile1", BufferUtils.getIncreasingByteArray(LEN));
+    String dirPath = "/testDir-notExist/";
+    AlluxioURI alluxioFilePath = new AlluxioURI(dirPath);
+    String[] cmd = {"copyFromLocal", testFile1.getPath(), dirPath};
+    Assert.assertEquals(-1, sFsShell.run(cmd));
+    Assert.assertThat(mOutput.toString(), containsString(
+            ExceptionMessage.CANNOT_COPY_TO_NOT_EXIST_DIRECTORY.getMessage(
+                    alluxioFilePath.getPath())));
+  }
+
+  @Test
+  public void copyFromLocalTypeNotMatch() throws Exception {
+    final int LEN = 10;
+    String path = "/testFile1";
+    File testFile1 = generateFileContent(path, BufferUtils.getIncreasingByteArray(LEN));
+    AlluxioURI alluxioFilePath = new AlluxioURI(path);
+
+    // Write the first file
+    String[] cmd1 = {"copyFromLocal", testFile1.getPath(), alluxioFilePath.getPath()};
+    Assert.assertEquals(0, sFsShell.run(cmd1));
+    mOutput.reset();
+
+    String[] cmd2 = {"copyFromLocal", testFile1.getPath(), alluxioFilePath.getPath() + "/"};
+    Assert.assertEquals(-1, sFsShell.run(cmd2));
+    Assert.assertThat(mOutput.toString(), containsString(
+            ExceptionMessage.FILE_TYPE_NOT_MATCH.getMessage(alluxioFilePath.getPath())));
+  }
+
+  @Test
   public void copyFromLocal() throws IOException, AlluxioException {
     File testDir = new File(sLocalAlluxioCluster.getAlluxioHome() + "/testDir");
     testDir.mkdir();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix copyFromLocal while dest path is endsWith a `/`.

### Why are the changes needed?

Fix #10191

Now the behaviour likes below

```
$ ./bin/alluxio fs mkdir /230610
Successfully created directory /230610

$ ./bin/alluxio fs copyFromLocal LICENSE /230610/dir.01/
/230610/dir.01 is a directory and should be created first.

./bin/alluxio fs copyFromLocal LICENSE /230610/file.01
Copied file:///.../LICENSE to /230610/file.01

$ ./bin/alluxio fs copyFromLocal LICENSE /230610/file.01/
/230610/file.01 exists but it's not a directory.
```

### Does this PR introduce any user facing changes?

NO
