### PR TITLE
Simplify `elect` command

### DIFF
--- a/dora/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/dora/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -1032,22 +1032,6 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       }
 
       RaftPeerId newLeaderPeerId = RaftJournalUtils.getPeerId(serverAddress);
-      /* update priorities to enable transfer */
-      List<RaftPeer> peersWithNewPriorities = new ArrayList<>();
-      for (RaftPeer peer : oldPeers) {
-        peersWithNewPriorities.add(
-            RaftPeer.newBuilder(peer)
-                .setPriority(peer.getId().equals(newLeaderPeerId) ? 2 : 1)
-                .build()
-        );
-      }
-      try (RaftClient client = createClient()) {
-        String stringPeers = "[" + peersWithNewPriorities.stream().map(RaftPeer::toString)
-            .collect(Collectors.joining(", ")) + "]";
-        LOG.info("Applying new peer state before transferring leadership: {}", stringPeers);
-        RaftClientReply reply = client.admin().setConfiguration(peersWithNewPriorities);
-        processReply(reply, "failed to set master priorities before initiating election");
-      }
       /* transfer leadership */
       LOG.info("Transferring leadership to master with address <{}> and with RaftPeerId <{}>",
           serverAddress, newLeaderPeerId);

--- a/dora/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/dora/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -1017,13 +1017,10 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       Collection<RaftPeer> peers = mRaftGroup.getPeers();
       // The NetUtil function is used by Ratis to convert InetSocketAddress to string
       String strAddr = NetUtils.address2String(serverAddress);
-      // if you cannot find the address in the quorum, throw exception.
+      // if you cannot find the address in the quorum, return error message.
       if (peers.stream().map(RaftPeer::getAddress).noneMatch(addr -> addr.equals(strAddr))) {
         return String.format("<%s> is not part of the quorum <%s>.",
             strAddr, peers.stream().map(RaftPeer::getAddress).collect(Collectors.toList()));
-      }
-      if (strAddr.equals(mRaftGroup.getPeer(mPeerId).getAddress())) {
-        return String.format("%s is already the leader", strAddr);
       }
 
       RaftPeerId newLeaderPeerId = RaftJournalUtils.getPeerId(serverAddress);

--- a/dora/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/dora/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -1014,13 +1014,13 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     try {
       InetSocketAddress serverAddress = InetSocketAddress
           .createUnresolved(newLeaderNetAddress.getHost(), newLeaderNetAddress.getRpcPort());
-      List<RaftPeer> oldPeers = new ArrayList<>(mRaftGroup.getPeers());
+      Collection<RaftPeer> peers = mRaftGroup.getPeers();
       // The NetUtil function is used by Ratis to convert InetSocketAddress to string
       String strAddr = NetUtils.address2String(serverAddress);
       // if you cannot find the address in the quorum, throw exception.
-      if (oldPeers.stream().map(RaftPeer::getAddress).noneMatch(addr -> addr.equals(strAddr))) {
+      if (peers.stream().map(RaftPeer::getAddress).noneMatch(addr -> addr.equals(strAddr))) {
         return String.format("<%s> is not part of the quorum <%s>.",
-            strAddr, oldPeers.stream().map(RaftPeer::getAddress).collect(Collectors.toList()));
+            strAddr, peers.stream().map(RaftPeer::getAddress).collect(Collectors.toList()));
       }
       if (strAddr.equals(mRaftGroup.getPeer(mPeerId).getAddress())) {
         return String.format("%s is already the leader", strAddr);

--- a/dora/core/server/master/src/main/java/alluxio/master/journal/DefaultJournalMaster.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/journal/DefaultJournalMaster.java
@@ -15,7 +15,6 @@ import alluxio.Constants;
 import alluxio.clock.SystemClock;
 import alluxio.grpc.GetNodeStatePResponse;
 import alluxio.grpc.GetQuorumInfoPResponse;
-import alluxio.grpc.GetTransferLeaderMessagePResponse;
 import alluxio.grpc.GrpcService;
 import alluxio.grpc.JournalDomain;
 import alluxio.grpc.NetAddress;
@@ -88,14 +87,6 @@ public class DefaultJournalMaster extends AbstractMaster implements JournalMaste
   public void resetPriorities() throws IOException {
     checkQuorumOpSupported();
     ((RaftJournalSystem) mJournalSystem).resetPriorities();
-  }
-
-  @Override
-  public GetTransferLeaderMessagePResponse getTransferLeaderMessage(String transferId) {
-    checkQuorumOpSupported();
-    return GetTransferLeaderMessagePResponse.newBuilder()
-           .setTransMsg(((RaftJournalSystem) mJournalSystem).getTransferLeaderMessage(transferId))
-           .build();
   }
 
   @Override

--- a/dora/core/server/master/src/main/java/alluxio/master/journal/JournalMaster.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/journal/JournalMaster.java
@@ -13,7 +13,6 @@ package alluxio.master.journal;
 
 import alluxio.grpc.GetNodeStatePResponse;
 import alluxio.grpc.GetQuorumInfoPResponse;
-import alluxio.grpc.GetTransferLeaderMessagePResponse;
 import alluxio.grpc.NetAddress;
 import alluxio.master.Master;
 
@@ -46,7 +45,7 @@ public interface JournalMaster extends Master {
    * {@link alluxio.master.journal.JournalType#EMBEDDED} journal.
    *
    * @param newLeaderAddress server address to remove from quorum
-   * @return the guid of transfer leader command
+   * @return an error message if an error occurred, otherwise empty string
    */
   String transferLeadership(NetAddress newLeaderAddress);
 
@@ -56,13 +55,6 @@ public interface JournalMaster extends Master {
    * @throws IOException if error occurs while performing the operation
    */
   void resetPriorities() throws IOException;
-
-  /**
-   * Gets exception messages thrown when transferring the leader.
-   * @param transferId the guid of transferLeader command
-   * @return exception message
-   */
-  GetTransferLeaderMessagePResponse getTransferLeaderMessage(String transferId);
 
   /**
    * Gets the node state. This endpoint is available for both UFS and embedded journals.

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
@@ -41,10 +41,6 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
   public static final String TRANSFER_INIT = "Initiating transfer of leadership to %s";
   public static final String TRANSFER_SUCCESS = "Successfully elected %s as the new leader";
   public static final String TRANSFER_FAILED = "Failed to elect %s as the new leader: %s";
-  public static final String RESET_INIT = "Resetting priorities of masters after %s transfer of "
-      + "leadership";
-  public static final String RESET_SUCCESS = "Quorum priorities were reset to 1";
-  public static final String RESET_FAILED = "Quorum priorities failed to be reset: %s";
 
   /**
    * @param context fsadmin command context
@@ -83,9 +79,8 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
           GetQuorumInfoPResponse quorumInfo = jmClient.getQuorumInfo();
           Optional<QuorumServerInfo> leadingMasterInfoOpt = quorumInfo.getServerInfoList().stream()
               .filter(QuorumServerInfo::getIsLeader).findFirst();
-          NetAddress leaderAddress = leadingMasterInfoOpt.isPresent()
-              ? leadingMasterInfoOpt.get().getServerAddress() : null;
-          return address.equals(leaderAddress);
+          return leadingMasterInfoOpt.isPresent()
+              && address.equals(leadingMasterInfoOpt.get().getServerAddress());
         } catch (IOException e) {
           return false;
         }
@@ -99,7 +94,6 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
       mPrintStream.println(String.format(TRANSFER_FAILED, serverAddress, e.getMessage()));
       return -1;
     }
-
     return 0;
   }
 

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
@@ -67,7 +67,6 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
     JournalMasterClient jmClient = mMasterJournalMasterClient;
     String serverAddress = cl.getOptionValue(ADDRESS_OPTION_NAME);
     NetAddress address = QuorumCommand.stringToAddress(serverAddress);
-    boolean success = false;
     try {
       mPrintStream.println(String.format(TRANSFER_INIT, serverAddress));
       String transferId = jmClient.transferLeadership(address);
@@ -96,21 +95,12 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
         throw new Exception(errorMessage.get());
       }
       mPrintStream.println(String.format(TRANSFER_SUCCESS, serverAddress));
-      success = true;
     } catch (Exception e) {
       mPrintStream.println(String.format(TRANSFER_FAILED, serverAddress, e.getMessage()));
-    }
-    // reset priorities regardless of transfer success
-    try {
-      mPrintStream.println(String.format(RESET_INIT, success ? "successful" : "failed"));
-      jmClient.resetPriorities();
-      mPrintStream.println(RESET_SUCCESS);
-    } catch (IOException e) {
-      mPrintStream.println(String.format(RESET_FAILED, e));
-      success = false;
+      return -1;
     }
 
-    return success ? 0 : -1;
+    return 0;
   }
 
   @Override

--- a/dora/tests/src/test/java/alluxio/client/cli/fsadmin/command/QuorumCommandIntegrationTest.java
+++ b/dora/tests/src/test/java/alluxio/client/cli/fsadmin/command/QuorumCommandIntegrationTest.java
@@ -208,11 +208,9 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
       mOutput.reset();
       shell.run("journal", "quorum", "elect", "-address" , newLeaderAddr);
       String output = mOutput.toString().trim();
-      String expected = String.format("%s\n%s\n%s\n%s",
+      String expected = String.format("%s\n%s",
           String.format(QuorumElectCommand.TRANSFER_INIT, newLeaderAddr),
-          String.format(QuorumElectCommand.TRANSFER_SUCCESS, newLeaderAddr),
-          String.format(QuorumElectCommand.RESET_INIT, "successful"),
-          QuorumElectCommand.RESET_SUCCESS);
+          String.format(QuorumElectCommand.TRANSFER_SUCCESS, newLeaderAddr));
       Assert.assertEquals(expected, output);
     }
     mCluster.notifySuccess();
@@ -246,7 +244,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
       shell.run("journal", "quorum", "info", "-domain", "MASTER");
       String output = mOutput.toString().trim();
       for (MasterNetAddress masterAddr : mCluster.getMasterAddresses()) {
-        String expected = String.format(QuorumInfoCommand.OUTPUT_SERVER_INFO, "AVAILABLE", "1",
+        String expected = String.format(QuorumInfoCommand.OUTPUT_SERVER_INFO, "AVAILABLE", "0",
             String.format("%s:%d", masterAddr.getHostname(), masterAddr.getEmbeddedJournalPort()));
         Assert.assertTrue(output.contains(expected.trim()));
       }

--- a/dora/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestTransferLeadership.java
+++ b/dora/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestTransferLeadership.java
@@ -206,7 +206,7 @@ public class EmbeddedJournalIntegrationTestTransferLeadership
     String transferId = transferAndWait(leaderAddr);
     GetTransferLeaderMessagePResponse transferLeaderMessage =
         mCluster.getJournalMasterClientForMaster().getTransferLeaderMessage(transferId);
-    Assert.assertFalse(transferLeaderMessage.getTransMsg().getMsg().isEmpty());
+    Assert.assertTrue(transferLeaderMessage.getTransMsg().getMsg().isEmpty());
 
     int newLeaderIdx = (leaderIdx + 1) % NUM_MASTERS;
     MasterNetAddress newLeaderAddr = mCluster.getMasterAddresses().get(newLeaderIdx);


### PR DESCRIPTION
After upgrading Apache Ratis to version 2.5.1 (#17571), it is possible to transfer leadership between two masters of equal priority. This PR removes the need to update priorities twice when using the `elect` command.
In addition, this PR reworks the inner working of the command to make them thread safe: the new logic ensures that the transfer id is selected and reserved atomically. Moreover, it ensures that the transfer id is returned to the client before initiating the transfer of leadership. This is important because the leader receiving this RPC will be demoted and close its RPC server, potentially propagating an error to the client erroneously. 