### PR TITLE
Improve build-artifact to print mvn error to stderr

### DIFF
--- a/dev/scripts/src/alluxio.org/build/cmd/build.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/build.go
@@ -127,6 +127,7 @@ func buildTarball(opts *buildOpts) error {
 		cmd := command.New(baseMvnCmd).WithDir(repoBuildDir)
 		if !opts.suppressMavenOutput {
 			cmd = cmd.SetStdout(os.Stdout)
+			cmd = cmd.SetStderr(os.Stderr)
 		}
 		if err := cmd.Run(); err != nil {
 			return stacktrace.Propagate(err, "error building project with command %v", baseMvnCmd)
@@ -147,6 +148,7 @@ func buildTarball(opts *buildOpts) error {
 			cmd := command.New(moduleMvnCmd).WithDir(repoBuildDir)
 			if !opts.suppressMavenOutput {
 				cmd = cmd.SetStdout(os.Stdout)
+				cmd = cmd.SetStderr(os.Stderr)
 			}
 			if err := cmd.Run(); err != nil {
 				return stacktrace.Propagate(err, "error building module with command %v", moduleMvnCmd)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Redirect the err output to stderr, just like how we redirect to stdout
