### PR TITLE
alluxio proxy http server support basic auth authentication

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1433,6 +1433,28 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+
+  public static final PropertyKey PROXY_HTTP_AUTH_ENABLE =
+          stringBuilder(Name.PROXY_HTTP_AUTH_ENABLE)
+                  .setDefaultValue(false)
+                  .setDescription("Optionally, specify proxy http auth.")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+                  .setScope(Scope.SERVER)
+                  .build();
+
+  public static final PropertyKey PROXY_HTTP_AUTH_USERNAME =
+          stringBuilder(Name.PROXY_HTTP_AUTH_USERNAME)
+                  .setDescription("Optionally, specify proxy http auth username.")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+                  .setScope(Scope.SERVER)
+                  .build();
+
+  public static final PropertyKey PROXY_HTTP_AUTH_PASSWORD =
+          stringBuilder(Name.PROXY_HTTP_AUTH_PASSWORD)
+                  .setDescription("Optionally, specify proxy http auth pass.")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+                  .setScope(Scope.SERVER)
+                  .build();
   public static final PropertyKey UNDERFS_S3_PROXY_HOST =
       stringBuilder(Name.UNDERFS_S3_PROXY_HOST)
           .setDescription("Optionally, specify a proxy host for communicating with S3.")
@@ -8748,6 +8770,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.proxy.s3.global.read.rate.limit.mb";
     public static final String PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB =
         "alluxio.proxy.s3.single.connection.read.rate.limit.mb";
+    public static final String PROXY_HTTP_AUTH_ENABLE =
+        "alluxio.proxy.http.auth.enable";
+    public static final String PROXY_HTTP_AUTH_USERNAME =
+        "alluxio.proxy.http.auth.username";
+    public static final String PROXY_HTTP_AUTH_PASSWORD =
+        "alluxio.proxy.http.auth.password";
 
     //
     // Locality related properties

--- a/core/server/proxy/src/main/java/alluxio/proxy/AuthenticationFilter.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AuthenticationFilter.java
@@ -1,0 +1,53 @@
+package alluxio.proxy;
+
+
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import sun.misc.BASE64Decoder;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+
+public class AuthenticationFilter implements Filter {
+
+    private static String username = Configuration.getString(PropertyKey.PROXY_HTTP_AUTH_USERNAME);
+    private static String password = Configuration.getString(PropertyKey.PROXY_HTTP_AUTH_PASSWORD);
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws java.io.IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+        String authorization = httpServletRequest.getHeader("Authorization");
+        Boolean authResult = false;
+        if (authorization != null && !authorization.equals("")) {
+            String userAndPass = new String(new BASE64Decoder().decodeBuffer(authorization.split(" ")[1]));
+            if (userAndPass.split(":").length == 2) {
+                String user = userAndPass.split(":")[0];
+                String pass = userAndPass.split(":")[1];
+                if (user.equals(username) && pass.equals(password)) {
+                    authResult = true;
+                    chain.doFilter(request, response);
+                }
+            }
+        }
+        if (!authResult) {
+            httpServletResponse.setCharacterEncoding("utf-8");
+            PrintWriter out = httpServletResponse.getWriter();
+            httpServletResponse.setStatus(401);
+            httpServletResponse.setHeader("WWW-Authenticate", "Basic realm=\"input username and password\"");
+            out.print("401 Authentication failed");
+        }
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -19,6 +19,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.master.audit.AsyncUserAccessAuditLogWriter;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
+import alluxio.proxy.AuthenticationFilter;
 import alluxio.proxy.ProxyProcess;
 import alluxio.proxy.s3.CompleteMultipartUploadHandler;
 import alluxio.proxy.s3.S3BaseTask;
@@ -43,12 +44,14 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
+import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -179,6 +182,10 @@ public final class ProxyWebServer extends WebServer {
     ServletHolder rsServletHolder = new ServletHolder("Alluxio Proxy Web Service", servlet);
     mServletContextHandler
         .addServlet(rsServletHolder, PathUtils.concatPath(Constants.REST_API_PREFIX, "*"));
+    Boolean httpAuthEnable = Configuration.getBoolean(PropertyKey.PROXY_HTTP_AUTH_ENABLE);
+    if(httpAuthEnable){
+      mServletContextHandler.addFilter(AuthenticationFilter.class, PathUtils.concatPath(Constants.REST_API_PREFIX, "*"), EnumSet.of(DispatcherType.REQUEST));
+    }
   }
 
   private ThreadPoolExecutor createLightThreadPool() {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Proxy server doesn't support authentication, it may cause security issues. I implement interface Filter to compare username and password. finally, it will improve proxy security.

### Why are the changes needed?

Alluxio proxy http service contains many sensitive operations, but there is no permission or user restriction.

### Does this PR introduce any user facing changes?


  2. addition or removal of property keys：
        1.alluxio.proxy.http.auth.enable
        2.alluxio.proxy.http.auth.username
        3.alluxio.proxy.http.auth.password

