### PR TITLE
Fix deadlock issue when master process exit

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectoryIdGenerator.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectoryIdGenerator.java
@@ -72,9 +72,10 @@ public class InodeDirectoryIdGenerator implements Journaled {
   /**
    * @return the next directory id
    */
-  public synchronized long peekDirectoryId() {
-    long containerId = mNextDirectoryId.getContainerId();
-    long sequenceNumber = mNextDirectoryId.getSequenceNumber();
+  public long peekDirectoryId() {
+    DirectoryId directoryId = mNextDirectoryId;
+    long containerId = directoryId.getContainerId();
+    long sequenceNumber = directoryId.getSequenceNumber();
     return BlockId.createBlockId(containerId, sequenceNumber);
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix deadlock issue when master process exit

### Why are the changes needed?

```
stackTrace:
java.lang.Thread.State: BLOCKED (on object monitor)
at java.lang.Shutdown.exit(java.base@11.0.12-ga/Shutdown.java:173)
- **waiting to lock <0x00007f55e98d1920> (a java.lang.Class for java.lang.Shutdown)**
at java.lang.Runtime.exit(java.base@11.0.12-ga/Runtime.java:116)
at java.lang.System.exit(java.base@11.0.12-ga/System.java:1752)
at alluxio.ProcessUtils.fatalError(ProcessUtils.java:83)
at alluxio.ProcessUtils.fatalError(ProcessUtils.java:63)
at alluxio.master.journal.MasterJournalContext.waitForJournalFlush(MasterJournalContext.java:99)
at alluxio.master.journal.MasterJournalContext.close(MasterJournalContext.java:109)
- locked <0x00007f5602000010> (a alluxio.master.journal.MasterJournalContext)
at alluxio.master.journal.StateChangeJournalContext.close(StateChangeJournalContext.java:55)
at alluxio.master.block.DefaultBlockMaster.getNewContainerId(DefaultBlockMaster.java:906)
- locked <0x00007f594a000298> (a alluxio.master.block.BlockContainerIdGenerator)
at alluxio.master.file.meta.InodeDirectoryIdGenerator.initialize(InodeDirectoryIdGenerator.java:83)
at alluxio.master.file.meta.InodeDirectoryIdGenerator.getNewDirectoryId(InodeDirectoryIdGenerator.java:57)
- **locked <0x00007f55e197de68> (a alluxio.master.file.meta.InodeDirectoryIdGenerator)**
at alluxio.master.file.meta.InodeTree.createPath(InodeTree.java:979)
at alluxio.master.file.DefaultFileSystemMaster.createDirectoryInternal(DefaultFileSystemMaster.java:2746)
at alluxio.master.file.InodeSyncStream.loadDirectoryMetadataInternal(InodeSyncStream.java:1374)
at alluxio.master.file.InodeSyncStream.loadDirectoryMetadata(InodeSyncStream.java:1294)
at alluxio.master.file.TxInodeSyncStream.concurrentLoadMetadata(TxInodeSyncStream.java:123)
at alluxio.master.file.TxInodeSyncStream.loadMetadataForPath(TxInodeSyncStream.java:98)
at alluxio.master.file.InodeSyncStream.syncInodeMetadata(InodeSyncStream.java:743)
at alluxio.master.file.InodeSyncStream.syncInternal(InodeSyncStream.java:491)
at alluxio.master.file.InodeSyncStream.sync(InodeSyncStream.java:409)
at alluxio.master.file.DefaultFileSystemMaster.syncMetadata(DefaultFileSystemMaster.java:4075)
at alluxio.master.file.TxFileSystemMaster.syncMetadata(TxFileSystemMaster.java:298)
at alluxio.master.file.DefaultFileSystemMaster.listStatus(DefaultFileSystemMaster.java:1111)
at alluxio.master.file.TxFileSystemMaster.listStatus(TxFileSystemMaster.java:827)
...

```

```
stackTrace:
java.lang.Thread.State: WAITING (on object monitor)
at java.lang.Object.wait(java.base@11.0.12-ga/Native Method)
- waiting on <no object reference available>
at java.lang.Thread.join(java.base@11.0.12-ga/Thread.java:1300)
- waiting to re-lock in wait() <0x00007f55e98d0918> (a java.lang.Thread)
at java.lang.Thread.join(java.base@11.0.12-ga/Thread.java:1375)
at java.lang.ApplicationShutdownHooks.runHooks(java.base@11.0.12-ga/ApplicationShutdownHooks.java:107)
at java.lang.ApplicationShutdownHooks$1.run(java.base@11.0.12-ga/ApplicationShutdownHooks.java:46)
at java.lang.Shutdown.runHooks(java.base@11.0.12-ga/Shutdown.java:130)
at java.lang.Shutdown.exit(java.base@11.0.12-ga/Shutdown.java:174)
- locked <0x00007f55e98d1920> (a java.lang.Class for java.lang.Shutdown)
at java.lang.Runtime.exit(java.base@11.0.12-ga/Runtime.java:116)
at java.lang.System.exit(java.base@11.0.12-ga/System.java:1752)
at alluxio.ProcessUtils.fatalError(ProcessUtils.java:83)
at alluxio.ProcessUtils.fatalError(ProcessUtils.java:63)
at alluxio.master.journal.MasterJournalContext.waitForJournalFlush(MasterJournalContext.java:99)
at alluxio.master.journal.MasterJournalContext.close(MasterJournalContext.java:109)
- locked <0x00007f5c0a60bda0> (a alluxio.master.journal.MasterJournalContext)
at alluxio.master.journal.StateChangeJournalContext.close(StateChangeJournalContext.java:55)
at alluxio.master.journal.FileSystemMergeJournalContext.close(FileSystemMergeJournalContext.java:90)
- locked <0x00007f5c0a60bde0> (a alluxio.master.journal.FileSystemMergeJournalContext)
at alluxio.master.file.RpcContext.closeQuietly(RpcContext.java:141)
at alluxio.master.file.RpcContext.close(RpcContext.java:129)
at alluxio.master.file.DefaultFileSystemMaster.listStatus(DefaultFileSystemMaster.java:1227)
at alluxio.master.file.TxFileSystemMaster.listStatus(TxFileSystemMaster.java:827)
```

```
java.lang.Thread.State: BLOCKED (on object monitor)
at alluxio.master.file.meta.InodeDirectoryIdGenerator.peekDirectoryId(InodeDirectoryIdGenerator.java:76)
- **waiting to lock <0x00007f55e197de68> (a alluxio.master.file.meta.InodeDirectoryIdGenerator)**
at alluxio.master.file.DefaultFileSystemMaster.stop(DefaultFileSystemMaster.java:787)
at alluxio.master.file.TxFileSystemMaster.stop(TxFileSystemMaster.java:245)
at alluxio.master.AbstractMaster.close(AbstractMaster.java:156)
at alluxio.master.file.DefaultFileSystemMaster.close(DefaultFileSystemMaster.java:800)
at alluxio.master.file.TxFileSystemMaster.close(TxFileSystemMaster.java:581)
at alluxio.Registry.close(Registry.java:156)
at alluxio.master.AlluxioMasterProcess.stop(AlluxioMasterProcess.java:412)
- locked <0x00007f55e51e2ba8> (a java.util.concurrent.atomic.AtomicBoolean)
at alluxio.ProcessUtils.lambda$stopProcessOnShutdown$0(ProcessUtils.java:98)
at alluxio.ProcessUtils$$Lambda$363/0x00007f54f02dc840.run(Unknown Source)
at java.lang.Thread.run(java.base@11.0.12-ga/Thread.java:829)
```


The blocked listStatus thread(called thread1) wait to  get lock <0x00007f55e98d1920> , while it is owned by another wating listStatus thread(called thread2) which also want to exit, thread2 wait the hook process(alluxio-process-shutdown-hook) finished and then continue exit. The alluxio-process-shutdown-hook wait to get lock <0x00007f55e197de68>, which is owned by thread1. 

### Does this PR introduce any user facing changes?
No
