### PR TITLE
Throw exception when there's error deleting file

### DIFF
--- a/dora/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/dora/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -572,8 +572,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
     try {
       mClient.deleteObject(mBucketName, key);
     } catch (AmazonClientException e) {
-      LOG.error("Failed to delete {}", key, e);
-      return false;
+      throw AlluxioS3Exception.from(e);
     }
     return true;
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Throw an exception when there's an error deleting the file. Limit to S3 first and see if is there any object from the user about the semantic change. And from the `Filesystem` interface, we are dropping the returned value so we would never know there's an exception even though we are not able to delete ufs objects and this PR fixes this.

We probably need to update other ufs as well.



### Why are the changes needed?

otherwise, exception would be swallowed.

### Does this PR introduce any user facing changes?
throwing exception when there's delete error
This would break SafeUfsDeleter but we don't care about that