### PR TITLE
Set dora ufs root to local underFSStorage directory

### DIFF
--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -7793,7 +7793,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
 
   public static final PropertyKey DORA_CLIENT_UFS_ROOT =
       stringBuilder(Name.DORA_CLIENT_UFS_ROOT)
-          .setDefaultValue("/tmp")
+          .setDefaultValue(format("${%s}/underFSStorage", Name.WORK_DIR))
           .setDescription("UFS root for dora client")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.ALL)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Set `alluxio.dora.client.ufs.root` to `${alluxio.work.dir}/underFSStorage`.

### Why are the changes needed?

The previous default was `/tmp`, which happens to clash with the default worker cache directory. Additionally, during integration tests we want to empty the UFS after each test, but `/tmp` is a shared system directory that cannot be emptied.

The new default is also consistent with the convention in 2.x.

### Does this PR introduce any user facing changes?

Yes, the default Dora UFS root is changed.
