### PR TITLE
Fix local cache metrics in log

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -759,7 +759,12 @@ public class LocalCacheManager implements CacheManager {
   }
 
   private boolean restore(PageStoreDir pageStoreDir) {
+    long restoredPages = mPageMetaStore.numPages();
+    long restoredBytes = mPageMetaStore.bytes();
+    long discardPages = Metrics.PAGE_DISCARDED.getCount();
+    long discardBytes = Metrics.BYTE_DISCARDED.getCount();
     LOG.info("Restoring PageStoreDir ({})", pageStoreDir.getRootPath());
+
     if (!Files.exists(pageStoreDir.getRootPath())) {
       LOG.error("Failed to restore PageStore: Directory {} does not exist",
           pageStoreDir.getRootPath());
@@ -777,8 +782,9 @@ public class LocalCacheManager implements CacheManager {
     }
     LOG.info("PageStore ({}) restored with {} pages ({} bytes), "
             + "discarded {} pages ({} bytes)",
-        pageStoreDir.getRootPath(), mPageMetaStore.numPages(), mPageMetaStore.bytes(),
-        Metrics.PAGE_DISCARDED.getCount(), Metrics.BYTE_DISCARDED);
+        pageStoreDir.getRootPath(), mPageMetaStore.numPages() - restoredPages,
+        mPageMetaStore.bytes() - restoredBytes, Metrics.PAGE_DISCARDED.getCount() - discardPages,
+        Metrics.BYTE_DISCARDED.getCount() - discardBytes);
     return true;
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix local cache metrics in log.

### Why are the changes needed?

When there are multiple cache directories, the metrics of LocalCacheManager log are incorrect. For example

```
2023-06-22 16:04:38,437 INFO  LocalCacheManager - Restoring PageStoreDir (/mnt/disk/1/alluxio.local.cache/LOCAL)
2023-06-22 16:04:38,443 INFO  LocalCacheManager - PageStore (/mnt/disk/1/alluxio.local.cache/LOCAL) restored with 7 pages (6895353 bytes), discarded 0 pages (com.codahale.metrics.Counter@347d2634 bytes)
2023-06-22 16:04:38,443 INFO  LocalCacheManager - Restoring PageStoreDir (/mnt/disk/2/alluxio.local.cache/LOCAL)
2023-06-22 16:04:38,443 INFO  LocalCacheManager - PageStore (/mnt/disk/2/alluxio.local.cache/LOCAL) restored with 7 pages (6895353 bytes), discarded 0 pages (com.codahale.metrics.Counter@347d2634 bytes)
```

The second directory is empty, but it has the same metric with the first one.

With this PR, the log became the following version

```
2023-06-22 16:37:20,780 INFO  LocalCacheManager - Restoring PageStoreDir (/mnt/disk/1/alluxio.local.cache/LOCAL)
2023-06-22 16:37:20,787 INFO  LocalCacheManager - PageStore (/mnt/disk/1/alluxio.local.cache/LOCAL) restored with 7 pages (6895353 bytes), discarded 0 pages (0 bytes)
2023-06-22 16:37:20,787 INFO  LocalCacheManager - Restoring PageStoreDir (/mnt/disk/2/alluxio.local.cache/LOCAL)
2023-06-22 16:37:20,788 INFO  LocalCacheManager - PageStore (/mnt/disk/2/alluxio.local.cache/LOCAL) restored with 0 pages (0 bytes), discarded 0 pages (0 bytes)
```

### Does this PR introduce any user facing changes?

NO
