### PR TITLE
Clean up scheduler job informations when stop

### DIFF
--- a/dora/core/server/master/src/main/java/alluxio/master/scheduler/Scheduler.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/scheduler/Scheduler.java
@@ -169,6 +169,9 @@ public final class Scheduler {
       mWorkerInfoHub.mActiveWorkers.values().forEach(CloseableResource::close);
       mWorkerInfoHub.mActiveWorkers = ImmutableMap.of();
       ThreadUtils.shutdownAndAwaitTermination(mSchedulerExecutor, EXECUTOR_SHUTDOWN_MS);
+      mExistingJobs.clear();
+      mJobToRunningTasks.clear();
+      mWorkerInfoHub.mWorkerToTaskQ.clear();
       mRunning = false;
     }
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Clean up scheduler job information when stop.
And when it start, we use jobMetaStore as the source of truth.
This avoids the job metadata is not consistent when transfer master.

### Why are the changes needed?
bug fix

### Does this PR introduce any user facing changes?

na
