### PR TITLE
Support getFileBlockLocation in LocalCacheFileSystem

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
@@ -210,12 +210,16 @@ public class LocalCacheFileSystem extends org.apache.hadoop.fs.FileSystem {
   @Override
   public BlockLocation[] getFileBlockLocations(FileStatus file, long start,
       long len) throws IOException {
+    // This is used by application to schedule/distribute the tasks
+    // By returning the real locations in the UFS.
     return mExternalFileSystem.getFileBlockLocations(file, start, len);
   }
 
   @Override
   public BlockLocation[] getFileBlockLocations(Path p, long start, long len)
       throws IOException {
+    // This is used by application to schedule/distribute the tasks
+    // By returning the real locations in the UFS.
     return mExternalFileSystem.getFileBlockLocations(p, start, len);
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
@@ -26,6 +26,7 @@ import alluxio.metrics.MetricsSystem;
 import alluxio.wire.FileInfo;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -204,5 +205,17 @@ public class LocalCacheFileSystem extends org.apache.hadoop.fs.FileSystem {
   @Override
   public FileStatus getFileStatus(Path f) throws IOException {
     return mExternalFileSystem.getFileStatus(f);
+  }
+
+  @Override
+  public BlockLocation[] getFileBlockLocations(FileStatus file, long start,
+      long len) throws IOException {
+    return mExternalFileSystem.getFileBlockLocations(file, start, len);
+  }
+
+  @Override
+  public BlockLocation[] getFileBlockLocations(Path p, long start, long len)
+      throws IOException {
+    return mExternalFileSystem.getFileBlockLocations(p, start, len);
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
@@ -210,16 +210,18 @@ public class LocalCacheFileSystem extends org.apache.hadoop.fs.FileSystem {
   @Override
   public BlockLocation[] getFileBlockLocations(FileStatus file, long start,
       long len) throws IOException {
-    // This is used by application to schedule/distribute the tasks
-    // By returning the real locations in the UFS.
+    // Applications use the block information here to schedule/distribute the tasks.
+    // Return the UFS locations directly instead of the local cache location,
+    // so the application can schedule the tasks accordingly
     return mExternalFileSystem.getFileBlockLocations(file, start, len);
   }
 
   @Override
   public BlockLocation[] getFileBlockLocations(Path p, long start, long len)
       throws IOException {
-    // This is used by application to schedule/distribute the tasks
-    // By returning the real locations in the UFS.
+    // Applications use the block information here to schedule/distribute the tasks.
+    // Return the UFS locations directly instead of the local cache location,
+    // so the application can schedule the tasks accordingly
     return mExternalFileSystem.getFileBlockLocations(p, start, len);
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Delegate `getFileBlockLocation` to external file system in `LocalCacheFileSystem`.

### Why are the changes needed?

Otherwise, `LocalCacheFileSystem` inherits the default behavior of `org.apache.hadoop.fs.FileSystem` which returns `localhost` only. 

### Does this PR introduce any user facing changes?

No.
