### PR TITLE
Show stacktrace on maven error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -947,6 +947,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
+<!--          Update the version here?          -->
           <version>3.8.1</version>
           <configuration>
             <source>${java.version}</source>
@@ -960,6 +961,7 @@
               <arg>--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED</arg>
               <arg>--add-exports=java.management/sun.management=ALL-UNNAMED</arg>
             </compilerArgs>
+            <forceJavacCompilerUse>true</forceJavacCompilerUse>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -947,7 +947,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-<!--          Update the version here?          -->
           <version>3.8.1</version>
           <configuration>
             <source>${java.version}</source>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Change mvn compiler plugin to use javac to expose internal errors better.
Ref: https://stackoverflow.com/a/52536499/4933827

### Why are the changes needed?

When using `javac`, the compile time error stack trace can be shown when `mvn` fails in some cases.

Before
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  06:24 min (Wall Clock)
[INFO] Finished at: 2023-06-21T18:48:37+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] AssertionError -> [Help 1]
[ERROR] java.lang.AssertionError
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/AssertionError
```

After
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile (default-testCompile) on project alluxio-core-server-worker: Compilation failure: Compilation failure:
[ERROR] /Users/jiacheng/Documents/Alluxio/alluxio-jiacheng/alluxio-3x/alluxio/dora/core/server/worker/src/test/java/alluxio/worker/grpc/ShortCircuitBlockWriteHandlerTest.java:[24,27] error: cannot access NoopBlockWorker
[ERROR]   bad source file: /Users/jiacheng/Documents/Alluxio/alluxio-jiacheng/alluxio-3x/alluxio/dora/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
[ERROR]     file does not contain class alluxio.worker.block.NoopBlockWorker
[ERROR]     Please remove or make sure it appears in the correct subdirectory of the sourcepath.
[ERROR] /Users/jiacheng/Documents/Alluxio/alluxio-jiacheng/alluxio-3x/alluxio/dora/core/server/worker/src/test/java/alluxio/worker/page/PagedBlockStoreCommitBlockTest.java:[75,2] error: cannot find symbol
[ERROR]   symbol:   class PagedBlockStore
[ERROR]   location: class PagedBlockStoreCommitBlockTest
[ERROR] /Users/jiacheng/Documents/Alluxio/alluxio-jiacheng/alluxio-3x/alluxio/dora/core/server/worker/src/test/java/alluxio/worker/grpc/ShortCircuitBlockWriteHandlerTest.java:[197,53] error: cannot find symbol
[ERROR]   symbol:   class NoopBlockWorker
[ERROR]   location: class ShortCircuitBlockWriteHandlerTest
[ERROR] /Users/jiacheng/Documents/Alluxio/alluxio-jiacheng/alluxio-3x/alluxio/dora/core/server/worker/src/test/java/alluxio/worker/grpc/ShortCircuitBlockWriteHandlerTest.java:[53,10] error: cannot find symbol
[ERROR]   symbol:   class ShortCircuitBlockWriteHandler
[ERROR]   location: class ShortCircuitBlockWriteHandlerTest
[ERROR] -> [Help 1]
```
