### PR TITLE
Fix `mount` command

### DIFF
--- a/dora/shell/src/main/java/alluxio/cli/fs/command/MountCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fs/command/MountCommand.java
@@ -15,12 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.annotation.PublicApi;
 import alluxio.cli.fsadmin.report.UfsCommand;
 import alluxio.client.file.BaseFileSystem;
-import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
-import alluxio.client.file.options.FileSystemOptions;
-import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.AlluxioProperties;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
@@ -77,14 +72,7 @@ public final class MountCommand extends AbstractFileSystemCommand {
    */
   public MountCommand(FileSystemContext fsContext) {
     super(fsContext);
-    AlluxioProperties properties = fsContext.getClusterConf().copyProperties();
-    properties.set(PropertyKey.DORA_ENABLED, false);
-    AlluxioConfiguration config = new InstancedConfiguration(properties);
-    mFileSystem = FileSystem.Factory.create(fsContext,
-        FileSystemOptions.Builder.fromConf(config)
-            .setUfsFallbackEnabled(false)
-            .build());
-    assert (mFileSystem instanceof BaseFileSystem);
+    mFileSystem = new BaseFileSystem(fsContext);
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?
Ensures the `MountCommand` uses `BaseFileSystem` as its client. 

### Why are the changes needed?
`FileSystem.Factory.create(FileSystemContext, FileSystemOptions)` can never return `BaseFileSystem`. This is because `FileSystemOptions` can only be created through `FileSystemOptions.Builder.fromConf(AlluxioConfiguration)` which always sets the `ufsFileSystemOptions`. `FileSystemOptions.Builder.setUfsFileSystemOptions` does not accept `null`. Therefore, `FileSystemOptions.mUfsFileSystemOptions` is never `Optional.empty()`. This means that [these lines](https://github.com/Alluxio/alluxio/blob/c4b8e05f8f9a3a336d644781b9616383eff9780b/dora/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java#L182-L184) never return `BaseFileSystem`.
The previous `assert (mFileSystem instanceof BaseFileSystem);` statement only works if `java -ea` is used when running the `FileSystemShell`. Since `-ea` is not a standard option, the `assert` was always avoided, but upon inspection (and turning on the `-ea` option) it fails systematically. 

This PR ensures that `MountCommand` always uses `BaseFileSystem` like it is supposed to. 

### Does this PR introduce any user facing changes?
No.