### PR TITLE
Apply RocksDB thread safety changes to Dora

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreDir.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreDir.java
@@ -67,8 +67,11 @@ public class RocksPageStoreDir extends QuotaManagedPageStoreDir {
 
   @Override
   public void scanPages(Consumer<Optional<PageInfo>> pageInfoConsumer) {
+    // Fix thread safety on this iterator or or demise RocksPageStore
+    // https://github.com/Alluxio/alluxio/issues/17131
     try (CloseableIterator<Optional<PageInfo>> pageIterator =
-        RocksUtils.createCloseableIterator(mPageStore.createNewInterator(), this::parsePageInfo)) {
+        RocksUtils.createCloseableIterator(mPageStore.createNewInterator(), this::parsePageInfo,
+            () -> null, null)) {
       Streams.stream(pageIterator).forEach(pageInfoConsumer);
     }
   }

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2679,6 +2679,19 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT =
+      durationBuilder(Name.MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT)
+          .setDefaultValue("10s")
+          .setIsHidden(true)
+          .setDescription("Before RocksDB is shut down/restarted/restored, Master will wait for "
+              + "ongoing operations to complete/abort. This timeout specifies how long to wait "
+              + "before forcing the action. Then the leftover operations will fail. Normally the "
+              + "wait will be short, because when master fails over/shuts down/replays journal, "
+              + "all other concurrent operations should have been stopped. This is just one extra "
+              + "safety guard. Therefore we do not recommend setting this manually.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
       booleanBuilder(Name.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP)
         .setDefaultValue(false)
@@ -8470,6 +8483,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metastore.rocks.checkpoint.compression.level";
     public static final String MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_TYPE =
         "alluxio.master.metastore.rocks.checkpoint.compression.type";
+    public static final String MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT =
+        "alluxio.master.metastore.rocks.exclusive.lock.timeout";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
         "alluxio.master.metastore.rocks.parallel.backup";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS =

--- a/dora/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/dora/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -214,6 +214,16 @@ public enum ExceptionMessage {
   // ufs maintenance
   UFS_OP_NOT_ALLOWED("Operation {0} not allowed on ufs path {1} under maintenance mode {2}"),
 
+  // RocksDB
+  ROCKS_DB_CLOSING("RocksDB is being closed because the master is under one of the following "
+      + "events: primary failover/shut down/checkpoint/journal replay"),
+  ROCKS_DB_REWRITTEN("RocksDB has been rewritten. Typically this is because the master is "
+      + "restored to a checkpoint."),
+  ROCKS_DB_EXCLUSIVE_LOCK_FORCED("RocksDB exclusive lock is forced with {0} ongoing "
+      + "r/w operations. There is a risk to crash!"),
+  ROCKS_DB_REF_COUNT_DIRTY("Some read/write operations did not respect the exclusive lock on "
+      + "the RocksStore and messed up the ref count! Current ref count is {0}."),
+
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;
 

--- a/dora/core/common/src/main/java/alluxio/master/metastore/rocks/RocksExclusiveLockHandle.java
+++ b/dora/core/common/src/main/java/alluxio/master/metastore/rocks/RocksExclusiveLockHandle.java
@@ -1,0 +1,48 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.metastore.rocks;
+
+import alluxio.exception.runtime.AlluxioRuntimeException;
+
+import java.util.concurrent.Callable;
+
+/**
+ * This is a handle used to manage the write lock(exclusive lock) on RocksStore.
+ * The exclusive lock is acquired when ref count is zero, and the StopServing flag ensures
+ * no new r/w will come in, so the ref count will stay zero throughout the period.
+ *
+ * One exception is when the exclusive lock is forced (ignoring uncompleted r/w operations),
+ * when the reader comes back the exclusive lock is already held. At this moment when the late
+ * reader comes back, it should not update the ref count anymore. See Javadoc on
+ * {@link RocksSharedLockHandle#close()} for how that is handled.
+ */
+public class RocksExclusiveLockHandle implements AutoCloseable {
+  private final Callable<Void> mCloseAction;
+
+  /**
+   * The constructor.
+   * @param closeAction the action called on close
+   */
+  public RocksExclusiveLockHandle(Callable<Void> closeAction) {
+    mCloseAction = closeAction;
+  }
+
+  @Override
+  public void close() {
+    try {
+      mCloseAction.call();
+    } catch (Exception e) {
+      // From the current usage in RocksStore, this is unreachable
+      throw AlluxioRuntimeException.from(e);
+    }
+  }
+}

--- a/dora/core/common/src/main/java/alluxio/master/metastore/rocks/RocksSharedLockHandle.java
+++ b/dora/core/common/src/main/java/alluxio/master/metastore/rocks/RocksSharedLockHandle.java
@@ -1,0 +1,59 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.metastore.rocks;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * This is a handle used to manage a read lock(shared lock) on RocksStore.
+ * When the shared lock is held, exclusive locks will wait. That guarantees the RocksDB
+ * is not wiped out/closed while an r/w operation is active.
+ *
+ * RocksStore uses ref count for locking so releasing a read lock is just decrementing the
+ * reference count.
+ */
+public class RocksSharedLockHandle implements AutoCloseable {
+  private final int mDbVersion;
+  private final LongAdder mRefCount;
+
+  /**
+   * The constructor.
+   *
+   * @param dbVersion The RocksDB version. This version is updated when the RocksDB
+   *                  is restored or wiped out.
+   * @param refCount the ref count to decrement on close
+   */
+  public RocksSharedLockHandle(int dbVersion, LongAdder refCount) {
+    mDbVersion = dbVersion;
+    mRefCount = refCount;
+  }
+
+  /**
+   * Gets the version on the lock.
+   * @return version
+   */
+  public int getLockVersion() {
+    return mDbVersion;
+  }
+
+  @Override
+  public void close() {
+    /*
+     * If the exclusive lock has been forced and the ref count is reset, this reference will point
+     * to an out-of-date counter. Therefore, we can just update this counter without concerns.
+     * If the exclusive lock is has NOT been forced, we decrement the ref count normally.
+     * If the exclusive lock has been forced, we decrement an irrelevant counter which will never
+     * be read.
+     */
+    mRefCount.decrement();
+  }
+}

--- a/dora/core/common/src/main/java/alluxio/master/metastore/rocks/RocksUtils.java
+++ b/dora/core/common/src/main/java/alluxio/master/metastore/rocks/RocksUtils.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 /**
  * Convenience methods for working with RocksDB.
@@ -94,13 +95,31 @@ public final class RocksUtils {
    * Used to wrap an {@link CloseableIterator} over {@link RocksIterator}.
    * It seeks given iterator to first entry before returning the iterator.
    *
+   * The Iterator is associated with a shared lock to the RocksStore. The lock should be acquired
+   * by the caller (See java doc on RocksStore.checkAndAcquireSharedLock()) for how.
+   * And the lock is held throughout the lifecycle of this iterator until it is closed
+   * either on completion or on exception. This shared lock guarantees thread safety when
+   * accessing the RocksDB. In other words, when this shared lock is held, the underlying
+   * RocksDB will not be stopped/restarted.
+   *
+   * The abortCheck defines a way to voluntarily abort the iteration. This typically happens
+   * when the underlying RocksDB will be closed/restart/checkpointed, where all accesses should
+   * be stopped.
+   *
+   * With the thread safety baked into hasNext() and next(), users of this Iterator do not need
+   * to worry about safety and can use this Iterator normally.
+   * See examples in how this iterator is used in RocksBlockMetaStore and RocksInodeStore.
+   *
    * @param rocksIterator the rocks iterator
    * @param parser parser to produce iterated values from rocks key-value
    * @param <T> iterator value type
+   * @param abortCheck if true, abort the iteration
+   * @param rocksDbSharedLock the shared lock acquired by the iterator
    * @return wrapped iterator
    */
   public static <T> CloseableIterator<T> createCloseableIterator(
-      RocksIterator rocksIterator, RocksIteratorParser<T> parser) {
+        RocksIterator rocksIterator, RocksIteratorParser<T> parser,
+        Supplier<Void> abortCheck, RocksSharedLockHandle rocksDbSharedLock) {
     rocksIterator.seekToFirst();
     AtomicBoolean valid = new AtomicBoolean(true);
     Iterator<T> iter = new Iterator<T>() {
@@ -111,23 +130,41 @@ public final class RocksUtils {
 
       @Override
       public T next() {
+        boolean succeeded = false;
+
+        /*
+         * If the RocksDB wants to stop, abort the loop instead of finishing it.
+         * The abortCheck will throw an exception, which closes the CloseableIterator
+         * if the CloseableIterator is correctly put in a try-with-resource section.
+         */
+        abortCheck.get();
+
         try {
-          return parser.next(rocksIterator);
+          T result = parser.next(rocksIterator);
+          rocksIterator.next();
+          succeeded = true;
+          return result;
         } catch (Exception exc) {
           LOG.warn("Iteration aborted because of error", exc);
-          rocksIterator.close();
-          valid.set(false);
           throw new RuntimeException(exc);
         } finally {
-          rocksIterator.next();
-          if (!rocksIterator.isValid()) {
-            rocksIterator.close();
+          if (!succeeded) {
             valid.set(false);
+            rocksIterator.close();
           }
         }
       }
     };
 
-    return CloseableIterator.create(iter, (whatever) -> rocksIterator.close());
+    return CloseableIterator.create(iter, (whatever) -> {
+      try {
+        rocksIterator.close();
+      } finally {
+        if (rocksDbSharedLock != null) {
+          // Release the lock after recycling the iterator safely
+          rocksDbSharedLock.close();
+        }
+      }
+    });
   }
 }

--- a/dora/core/common/src/main/java/alluxio/resource/CloseableIterator.java
+++ b/dora/core/common/src/main/java/alluxio/resource/CloseableIterator.java
@@ -43,7 +43,7 @@ public abstract class CloseableIterator<T> extends CloseableResource<Iterator<T>
    *
    * @param iterator the resource to wrap
    */
-  CloseableIterator(Iterator<T> iterator) {
+  protected CloseableIterator(Iterator<T> iterator) {
     super(iterator);
     mIter = iterator;
   }

--- a/dora/core/server/common/src/main/java/alluxio/rocks/RocksCheckpointed.java
+++ b/dora/core/server/common/src/main/java/alluxio/rocks/RocksCheckpointed.java
@@ -15,8 +15,8 @@ import alluxio.exception.runtime.AlluxioRuntimeException;
 import alluxio.grpc.ErrorType;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.Checkpointed;
-
 import alluxio.master.metastore.rocks.RocksExclusiveLockHandle;
+
 import io.grpc.Status;
 import org.rocksdb.RocksDBException;
 

--- a/dora/core/server/common/src/main/java/alluxio/rocks/RocksCheckpointed.java
+++ b/dora/core/server/common/src/main/java/alluxio/rocks/RocksCheckpointed.java
@@ -16,6 +16,7 @@ import alluxio.grpc.ErrorType;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.Checkpointed;
 
+import alluxio.master.metastore.rocks.RocksExclusiveLockHandle;
 import io.grpc.Status;
 import org.rocksdb.RocksDBException;
 
@@ -39,21 +40,25 @@ public interface RocksCheckpointed extends Checkpointed {
                                                    ExecutorService executorService) {
     return CompletableFuture.runAsync(() -> {
       LOG.debug("taking {} snapshot started", getCheckpointName());
-      File subDir = new File(directory, getCheckpointName().toString());
-      try {
-        getRocksStore().writeToCheckpoint(subDir);
-      } catch (RocksDBException e) {
-        throw new AlluxioRuntimeException(Status.INTERNAL,
-            String.format("Failed to take snapshot %s in dir %s", getCheckpointName(), directory),
-            e, ErrorType.Internal, false);
+      try (RocksExclusiveLockHandle lock = getRocksStore().lockForCheckpoint()) {
+        File subDir = new File(directory, getCheckpointName().toString());
+        try {
+          getRocksStore().writeToCheckpoint(subDir);
+        } catch (RocksDBException e) {
+          throw new AlluxioRuntimeException(Status.INTERNAL,
+              String.format("Failed to take snapshot %s in dir %s", getCheckpointName(), directory),
+              e, ErrorType.Internal, false);
+        }
+        LOG.debug("taking {} snapshot finished", getCheckpointName());
       }
-      LOG.debug("taking {} snapshot finished", getCheckpointName());
     }, executorService);
   }
 
   @Override
   default void writeToCheckpoint(OutputStream output) throws IOException, InterruptedException {
-    getRocksStore().writeToCheckpoint(output);
+    try (RocksExclusiveLockHandle lock = getRocksStore().lockForCheckpoint()) {
+      getRocksStore().writeToCheckpoint(output);
+    }
   }
 
   @Override
@@ -62,7 +67,7 @@ public interface RocksCheckpointed extends Checkpointed {
     return CompletableFuture.runAsync(() -> {
       LOG.debug("loading {} snapshot started", getCheckpointName());
       File subDir = new File(directory, getCheckpointName().toString());
-      try {
+      try (RocksExclusiveLockHandle lock = getRocksStore().lockForRewrite()) {
         getRocksStore().restoreFromCheckpoint(subDir);
       } catch (Exception e) {
         throw new AlluxioRuntimeException(Status.INTERNAL,
@@ -75,6 +80,8 @@ public interface RocksCheckpointed extends Checkpointed {
 
   @Override
   default void restoreFromCheckpoint(CheckpointInputStream input) throws IOException {
-    getRocksStore().restoreFromCheckpoint(input);
+    try (RocksExclusiveLockHandle lock = getRocksStore().lockForRewrite()) {
+      getRocksStore().restoreFromCheckpoint(input);
+    }
   }
 }

--- a/dora/core/server/common/src/main/java/alluxio/rocks/RocksStore.java
+++ b/dora/core/server/common/src/main/java/alluxio/rocks/RocksStore.java
@@ -14,14 +14,21 @@ package alluxio.rocks;
 import alluxio.Constants;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.ExceptionMessage;
+import alluxio.exception.runtime.UnavailableRuntimeException;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointOutputStream;
 import alluxio.master.journal.checkpoint.CheckpointType;
+import alluxio.master.metastore.rocks.RocksExclusiveLockHandle;
+import alluxio.master.metastore.rocks.RocksSharedLockHandle;
+import alluxio.retry.CountingRetry;
 import alluxio.retry.TimeoutRetry;
+import alluxio.util.SleepUtils;
 import alluxio.util.compression.ParallelZipUtils;
 import alluxio.util.compression.TarUtils;
 import alluxio.util.io.FileUtils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.IOUtils;
 import org.rocksdb.BlockBasedTableConfig;
@@ -47,40 +54,127 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.concurrent.ThreadSafe;
+import java.util.concurrent.atomic.AtomicStampedReference;
+import java.util.concurrent.atomic.LongAdder;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * Class for managing a rocksdb database. This class handles common functionality such as
  * initializing the database and performing database backup/restore.
  *
- * Thread safety is achieved by synchronizing all public methods.
+ * This class provides locking methods for the callers. And the thread safety of RocksDB
+ * relies on the caller to use the corresponding lock methods.
+ * The reasons why this class only provides thread safety utilities to the callers
+ * (instead of wrapping it under each call) are:
+ * 1. Callers like RocksInodeStore and RocksBlockMetaStore have specific read/write logic
+ *    like iteration, which cannot be abstracted and locked internally in this class.
+ * 2. With locking methods provided by this class, callers like RocksInodeStore
+ *    can actually reuse the locks to perform concurrency control on their own logic.
+ *
+ * For reading/writing on the RocksDB, use the shared lock
+ * <blockquote><pre>
+ *   try (RocksSharedLockHandle r = mRocksStore.checkAndAcquireSharedLock() {
+ *     // perform your read/write operation
+ *   }
+ * </pre></blockquote>
+ *
+ * For operations like closing/restart/restoring on the RocksDB, an exclusive lock should
+ * be acquired by calling one of:
+ * 1. {@link #lockForClosing()}
+ * 2. {@link #lockForRewrite()}
+ * 3. {@link #lockForCheckpoint()}
+ *
+ * Rule of thumb:
+ * 1. Use the proper locking methods when you access RocksDB.
+ * 2. Make each operation short. Make the locked section short.
+ * 3. If you have to make the operation long (like iteration), utilize {@link #shouldAbort(int)}
+ *    to check and abort voluntarily.
+ * See Javadoc on the locking methods for details.
  */
-@ThreadSafe
+@NotThreadSafe
 public final class RocksStore implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(RocksStore.class);
   public static final int ROCKS_OPEN_RETRY_TIMEOUT = 20 * Constants.SECOND_MS;
+  public static final Duration ROCKS_CLOSE_WAIT_TIMEOUT =
+      Configuration.getDuration(PropertyKey.MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT);
+  private static final boolean TEST_MODE = Configuration.getBoolean(PropertyKey.TEST_MODE);
+
   private final String mName;
   private final String mDbPath;
   private final String mDbCheckpointPath;
   private final Integer mParallelBackupPoolSize;
-  private final Collection<ColumnFamilyDescriptor> mColumnFamilyDescriptors;
-  private final DBOptions mDbOpts;
 
   private final int mCompressLevel = Configuration.getInt(
       PropertyKey.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_REPLICATION_COMPRESSION_LEVEL);
   private final boolean mParallelBackup = Configuration.getBoolean(
       PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP);
 
-  private RocksDB mDb;
-  private Checkpoint mCheckpoint;
-  // When we create the database, we must set these handles.
+  /*
+   * Below 2 fields are created and managed by the external user class,
+   * no need to close in this class.
+   */
+  private final Collection<ColumnFamilyDescriptor> mColumnFamilyDescriptors;
+  private final DBOptions mDbOpts;
+  /*
+   * Below 3 fields are created and managed internally to this class,
+   * must be closed in this class.
+   */
+  private volatile RocksDB mDb;
+  private volatile Checkpoint mCheckpoint;
   private final List<AtomicReference<ColumnFamilyHandle>> mColumnHandles;
+
+  /*
+   * The state consists of two information.
+   *
+   * The boolean flag indicates whether the RocksDB wants to stop serving.
+   * TRUE - Stop serving
+   * FALSE - Serving normally
+   *
+   * The version number indicates whether the RocksDB has been rewritten.
+   * If the RocksDB is restored or wiped out, the version number goes up.
+   * If the RocksDB is paused just to dump a checkpoint, the version number is kept the same.
+   * A reader can rely on the version to tell whether it can still read the RocksDB
+   * after the exclusive lock is taken and released.
+   */
+  public final AtomicStampedReference<Boolean> mRocksDbStopServing =
+      new AtomicStampedReference<>(false, 0);
+  public volatile LongAdder mRefCount = new LongAdder();
+
+  /*
+   * Normally, the ref count will still be zero when the exclusive lock is held because:
+   * 1. If the exclusive lock was not forced, that means the ref count has decremented to zero
+   *    before the exclusive lock was taken. And while the exclusive lock was held, no readers
+   *    was able to come in and increment the ref count.
+   * 2. If the exclusive lock was forced, the old ref count instance was thrown away.
+   *    So even if there were a slow reader, that would not touch the new ref count incorrectly.
+   *    Therefore, the new ref count should stay zero.
+   *
+   * However, we still added this sanity check as a canary for incorrect ref count usages.
+   */
+  private final Callable<Void> mCheckRefCount = () -> {
+    long refCount = getSharedLockCount();
+    if (TEST_MODE) {
+      // In test mode we enforce strict ref count check, as a canary for ref count issues
+      Preconditions.checkState(refCount == 0,
+          ExceptionMessage.ROCKS_DB_REF_COUNT_DIRTY.getMessage(refCount));
+    } else {
+      // In a real deployment, we forgive potential ref count problems and take the risk
+      if (refCount != 0) {
+        LOG.warn(ExceptionMessage.ROCKS_DB_REF_COUNT_DIRTY.getMessage(refCount));
+      }
+      resetRefCounter();
+    }
+    return null;
+  };
 
   /**
    * @param name a name to distinguish what store this is
@@ -103,7 +197,7 @@ public final class RocksStore implements Closeable {
     mColumnFamilyDescriptors = columnFamilyDescriptors;
     mDbOpts = dbOpts;
     mColumnHandles = columnHandles;
-    try {
+    try (RocksExclusiveLockHandle lock = lockForRewrite()) {
       if (reset) {
         resetDb();
       } else {
@@ -115,17 +209,20 @@ public final class RocksStore implements Closeable {
   }
 
   /**
+   * Requires the caller to acquire a shared lock by calling {@link #checkAndAcquireSharedLock()}.
+   *
    * @return the underlying rocksdb instance. The instance changes when clear() is called, so if the
    *         caller caches the returned db, they must reset it after calling clear()
    */
-  public synchronized RocksDB getDb() {
+  public RocksDB getDb() {
     return mDb;
   }
 
   /**
    * Clears and re-initializes the database.
+   * Requires the caller to acquire exclusive lock by calling {@link #lockForRewrite()}.
    */
-  public synchronized void clear() {
+  public void clear() {
     try {
       resetDb();
     } catch (RocksDBException e) {
@@ -216,10 +313,11 @@ public final class RocksStore implements Closeable {
 
   /**
    * Writes a checkpoint of the database's content to the given output stream.
+   * Requires the caller to acquire an exclusive lock by calling {@link #lockForCheckpoint()}.
    *
    * @param output the stream to write to
    */
-  public synchronized void writeToCheckpoint(OutputStream output)
+  public void writeToCheckpoint(OutputStream output)
       throws IOException, InterruptedException {
     LOG.info("Creating rocksdb checkpoint at {}", mDbCheckpointPath);
     long startNano = System.nanoTime();
@@ -269,10 +367,11 @@ public final class RocksStore implements Closeable {
 
   /**
    * Restores the database from a checkpoint.
+   * Requires the caller to acquire an exclusive lock by calling {@link #lockForRewrite()}.
    *
    * @param input the checkpoint stream to restore from
    */
-  public synchronized void restoreFromCheckpoint(CheckpointInputStream input) throws IOException {
+  public void restoreFromCheckpoint(CheckpointInputStream input) throws IOException {
     LOG.info("Restoring rocksdb from checkpoint");
     long startNano = System.nanoTime();
     Preconditions.checkState(input.getType() == CheckpointType.ROCKS_SINGLE
@@ -284,7 +383,7 @@ public final class RocksStore implements Closeable {
     if (input.getType() == CheckpointType.ROCKS_PARALLEL) {
       List<String> tmpDirs = Configuration.getList(PropertyKey.TMP_DIRS);
       String tmpZipFilePath = new File(tmpDirs.get(0), "alluxioRockStore-" + UUID.randomUUID())
-          .getPath();
+              .getPath();
 
       try {
         try (FileOutputStream fos = new FileOutputStream(tmpZipFilePath)) {
@@ -292,7 +391,7 @@ public final class RocksStore implements Closeable {
         }
 
         ParallelZipUtils.decompress(Paths.get(mDbPath), tmpZipFilePath,
-            mParallelBackupPoolSize);
+                mParallelBackupPoolSize);
 
         FileUtils.deletePathRecursively(tmpZipFilePath);
       } catch (Exception e) {
@@ -309,11 +408,14 @@ public final class RocksStore implements Closeable {
       throw new IOException(e);
     }
     LOG.info("Restored rocksdb checkpoint in {}ms",
-        (System.nanoTime() - startNano) / Constants.MS_NANO);
+            (System.nanoTime() - startNano) / Constants.MS_NANO);
   }
 
   @Override
-  public synchronized void close() {
+  /**
+   * Requires the caller to acquire exclusive lock by calling {@link #lockForClosing()}.
+   */
+  public void close() {
     stopDb();
     LOG.info("Closed store at {}", mDbPath);
   }
@@ -393,5 +495,286 @@ public final class RocksStore implements Closeable {
       default:
         throw new IllegalArgumentException(String.format("Unknown IndexType %s", index));
     }
+  }
+
+  /**
+   * This is the core logic of the shared lock mechanism.
+   *
+   * Before any r/w operation on the RocksDB, acquire a shared lock with this method.
+   * The shared lock guarantees the RocksDB will not be restarted/cleared during the
+   * r/w access. In other words, similar to a read-write lock, exclusive lock requests
+   * will wait for shared locks to be released first.
+   *
+   * However, note that exclusive lock acquisition only waits for a certain period of time,
+   * defined by {@link PropertyKey#MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT}.
+   * After this timeout, the exclusive lock will be forced, and the shared lock holders
+   * are disrespected. Normally, the r/w operation should either complete or abort within
+   * seconds so the timeout {@link PropertyKey#MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT}
+   * should not be exceeded at all.
+   *
+   * @return a shared lock handle used to manage and close the shared lock
+   */
+  public RocksSharedLockHandle checkAndAcquireSharedLock() {
+    if (mRocksDbStopServing.getReference()) {
+      throw new UnavailableRuntimeException(ExceptionMessage.ROCKS_DB_CLOSING.getMessage());
+    }
+    /*
+     * The lock action is merely incrementing the lock so it is very fast
+     * The closer will respect the ref count and only close when the ref count is zero
+     */
+    mRefCount.increment();
+
+    /*
+     * Need to check the flag again to PREVENT the sequence of events below:
+     * 1. Reader checks flag
+     * 2. Closer sets flag
+     * 3. Closer sees refCount=0
+     * 4. Reader increments refCount
+     * 5. Closer closes RocksDB
+     * 6. Reader reads RocksDB and incurs a segfault
+     *
+     * With the 2nd check, we make sure the ref count will be respected by the closer and
+     * the closer will therefore wait for this reader to complete/abort.
+     */
+    if (mRocksDbStopServing.getReference()) {
+      mRefCount.decrement();
+      throw new UnavailableRuntimeException(ExceptionMessage.ROCKS_DB_CLOSING.getMessage());
+    }
+
+    return new RocksSharedLockHandle(mRocksDbStopServing.getStamp(), mRefCount);
+  }
+
+  /**
+   * This is the core logic of the exclusive lock mechanism.
+   *
+   * The exclusive lock will first set a flag and then wait for all shared lock holders to
+   * complete/abort. The time to wait is defined by
+   * {@link PropertyKey#MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT}.
+   * When the r/w operations observe this flag by {@link #shouldAbort(int)},
+   * the operation will be aborted and the shared lock will be released.
+   * Some short operations do not check the {@link #shouldAbort(int)} because we expect
+   * them to finish fast.
+   *
+   * Normally, the default value of this timeout is long enough.
+   * However, if the ref count is still not zero after this wait, the exclusive lock will
+   * be forced and some warnings will be logged. There are multiple possibilities:
+   * 1. There is a very slow r/w operation.
+   * 2. Some r/w operation somewhere are not following the rules.
+   * 3. There is a bug somewhere, and the ref count is incorrect.
+   * In either case, submit an issue to https://github.com/Alluxio/alluxio/issues
+   * And we do not recommend tuning
+   * {@link PropertyKey#MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT}
+   * because it usually just covers the real issue.
+   *
+   * There are 4 cases where the exclusive lock is acquired:
+   * 1. The master is closing (and the process will exit).
+   * 2. The RocksDB will be cleared. This happens when the master process starts or in a failover.
+   * 3. The master is just dumping a checkpoint, where the RocksDB contents will not change.
+   * 4. The master is restoring from a checkpoint/backup where the RocksDB is rebuilt.
+   *
+   * When the master is closing, it will not wait for an ongoing checkpoint/restore/clear
+   * operation and will just grab the lock even though the exclusive lock is taken.
+   * Then the master process will exit and whatever operation will be aborted.
+   * This covers case 1 and yieldToAnotherCloser=false.
+   *
+   * In case 2, 3 or 4, we let the later closer(writer) fail. It will be the caller's
+   * responsibility to either retry or abort. In other words, when yieldToAnotherClose=true,
+   * the one who sets the mState will succeed and the other one will fail.
+   *
+   * @param yieldToAnotherCloser if true, the operation will fail if it observes a concurrent
+   *                             action on the exclusive lock
+   */
+  private void setFlagAndBlockingWait(boolean yieldToAnotherCloser) {
+    // Another known operation has acquired the exclusive lock
+    if (yieldToAnotherCloser && mRocksDbStopServing.getReference()) {
+      throw new UnavailableRuntimeException(ExceptionMessage.ROCKS_DB_CLOSING.getMessage());
+    }
+
+    int version = mRocksDbStopServing.getStamp();
+    if (yieldToAnotherCloser) {
+      if (!mRocksDbStopServing.compareAndSet(false, true, version, version)) {
+        throw new UnavailableRuntimeException(ExceptionMessage.ROCKS_DB_CLOSING.getMessage());
+      }
+    } else {
+      // Just set the state with no respect to concurrent actions
+      mRocksDbStopServing.set(true, version);
+    }
+
+    /*
+    * Wait until:
+    * 1. Ref count is zero, meaning all concurrent r/w have completed or aborted
+    * 2. Timeout is reached, meaning we force close/restart without waiting
+    *
+    * According to Java doc
+    * https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/LongAdder.html
+    * In absence of concurrent updates, sum() returns an accurate result.
+    * But sum() does not see concurrent updates and therefore can miss an update.
+    *
+    * The correctness then relies on the 2nd check in checkAndAcquireSharedLock()
+    * because the reader will see the flag and just abort voluntarily. An example sequence
+    * of events is like below:
+    * 1. Reader checks flag, the flag is not set by the closer
+    * 2. Closer sets flag
+    * 3. Closer sees refCount=0
+    * 4. Reader increments refCount
+    * 5. Closer closes RocksDB
+    * 6. Reader checks flag again and sees the flag
+    * 7. Reader decrements refCount aborts in checkAndAcquireSharedLock()
+    */
+    Instant waitStart = Instant.now();
+    CountingRetry retry = new CountingRetry((int) ROCKS_CLOSE_WAIT_TIMEOUT.getSeconds() * 10);
+    while (mRefCount.sum() != 0 && retry.attempt()) {
+      SleepUtils.sleepMs(100);
+    }
+    Duration elapsed = Duration.between(waitStart, Instant.now());
+    LOG.info("Waited {}ms for ongoing read/write to complete/abort", elapsed.toMillis());
+
+    /*
+     * Reset the ref count to forget about the aborted operations
+     */
+    long unclosedOperations = mRefCount.sum();
+    if (unclosedOperations != 0) {
+      if (Configuration.getBoolean(PropertyKey.TEST_MODE)) {
+        throw new RuntimeException(ExceptionMessage.ROCKS_DB_EXCLUSIVE_LOCK_FORCED
+            .getMessage(unclosedOperations));
+      }
+      /*
+       * Set the flag so shared locks know that the ref count has been reset,
+       * no need to update the ref count on unlock.
+       * If one shared lock did not decrement the ref count before this reset, it should not
+       * decrement the ref count when it is released.
+       */
+      resetRefCounter();
+      LOG.warn("{} readers/writers fail to complete/abort before we stop/restart the RocksDB",
+          unclosedOperations);
+    }
+  }
+
+  /**
+   * When the exclusive lock is forced (after a timeout), we have to reset the ref count to zero
+   * and throw away the updates from the concurrent readers. In other words, those readers should
+   * not update the ref count when they release the lock. One possible sequence of events
+   * goes as below:
+   *
+   * 1. Reader checks the flag.
+   * 2. Reader increments refCount.
+   * 3. Reader is blocked (for a lock) or goes to sleep.
+   * 4. One Closer comes in, sets the flag and waits on refCount.
+   * 5. Closer wait times out. Closer forces the exclusive lock and resets refCount to 0.
+   * 6. Instead of closing the RocksDB, the exclusive lock is taken for restoring the RocksDB.
+   * 7. Closer finishes and resets the flag to 0.
+   * 8. Reader wakes up and releases the shared lock, now it should NOT decrement the ref count.
+   *
+   * We create a new ref counter and throw away the existing one. So the old readers will
+   * update the old counter when they release the lock, and only the new counter will be used.
+   */
+  private void resetRefCounter() {
+    mRefCount = new LongAdder();
+  }
+
+  /**
+   * Before the process shuts down, acquire an exclusive lock on the RocksDB before closing.
+   * Note this lock only exists on the Alluxio side. A STOP_SERVING flag will be set so all
+   * existing readers/writers will abort asap.
+   * The exclusive lock ensures there are no existing concurrent r/w operations, so it is safe to
+   * close the RocksDB and recycle all relevant resources.
+   *
+   * The STOP_SERVING status will NOT be reset, because the process will shut down soon.
+   *
+   * @return the exclusive lock handle used to manage and close the lock
+   */
+  public RocksExclusiveLockHandle lockForClosing() {
+    Exception e = new RuntimeException("Log trace here");
+    LOG.error("Just recording the trace here", e);
+    // Grab the lock with no respect to concurrent operations
+    // Just grab the lock and close
+    setFlagAndBlockingWait(false);
+    return new RocksExclusiveLockHandle(mCheckRefCount);
+  }
+
+  /**
+   * Before the process shuts down, acquire an exclusive lock on the RocksDB before closing.
+   * Note this lock only exists on the Alluxio side. A STOP_SERVING flag will be set so all
+   * existing readers/writers will abort asap.
+   * The exclusive lock ensures there are no existing concurrent r/w operations, so it is safe to
+   * restart/checkpoint the RocksDB and update the DB reference.
+   *
+   * The STOP_SERVING status will be reset and the RocksDB will be open for operations again.
+   * The version will not be bumped up, because the RocksDB contents has not changed.
+   * See {@link #checkAndAcquireSharedLock} for how this affects the shared lock logic.
+   *
+   * @return the exclusive lock handle used to manage and close the lock
+   */
+  public RocksExclusiveLockHandle lockForCheckpoint() {
+    // Grab the lock with respect to contenders
+    setFlagAndBlockingWait(true);
+    return new RocksExclusiveLockHandle(() -> {
+      mCheckRefCount.call();
+      // There is no need to worry about overwriting another concurrent Closer action
+      // The only chance of concurrency is with lockForClosing()
+      // But lockForClosing() guarantees the master process will close immediately
+      mRocksDbStopServing.set(false, mRocksDbStopServing.getStamp());
+      return null;
+    });
+  }
+
+  /**
+   * Before the process shuts down, acquire an exclusive lock on the RocksDB before closing.
+   * Note this lock only exists on the Alluxio side. A STOP_SERVING flag will be set so all
+   * existing readers/writers will abort asap.
+   * The exclusive lock ensures there are no existing concurrent r/w operations, so it is safe to
+   * restart/checkpoint the RocksDB and update the DB reference.
+   *
+   * The STOP_SERVING status will be reset and the RocksDB will be open for operations again.
+   * The version will be bumped up, because the RocksDB contents has changed. If there is one slow
+   * operation expecting to see the old version, that operation should abort.
+   * See {@link #checkAndAcquireSharedLock} for how this affects the shared lock logic.
+   *
+   * @return the exclusive lock handle used to manage and close the lock
+   */
+  public RocksExclusiveLockHandle lockForRewrite() {
+    // Grab the lock with respect to contenders
+    setFlagAndBlockingWait(true);
+    return new RocksExclusiveLockHandle(() -> {
+      mCheckRefCount.call();
+      // There is no need to worry about overwriting another concurrent Closer action
+      // The only chance of concurrency is with lockForClosing()
+      // But lockForClosing() guarantees the master process will close immediately
+      mRocksDbStopServing.set(false, mRocksDbStopServing.getStamp() + 1);
+      return null;
+    });
+  }
+
+  /**
+   * Used by ongoing r/w operations to check if the operation needs to abort and yield
+   * to the RocksDB shutdown.
+   *
+   * @param lockedVersion The RocksDB version from the shared lock. This version is used to tell
+   *                      if a restore or clear operation has happened on the RocksDB.
+   */
+  public void shouldAbort(int lockedVersion) {
+    if (mRocksDbStopServing.getReference()) {
+      throw new UnavailableRuntimeException(ExceptionMessage.ROCKS_DB_CLOSING.getMessage());
+    } else if (lockedVersion < mRocksDbStopServing.getStamp()) {
+      throw new UnavailableRuntimeException(ExceptionMessage.ROCKS_DB_REWRITTEN.getMessage());
+    }
+  }
+
+  /**
+   * Checks whether the RocksDB is marked for exclusive access, so the operation should abort.
+   * @return whether the RocksDB expects to stop
+   */
+  public boolean isServiceStopping() {
+    return mRocksDbStopServing.getReference();
+  }
+
+  /**
+   * Gets the number of shared lock on the RocksStore.
+   *
+   * @return the count
+   */
+  @VisibleForTesting
+  public long getSharedLockCount() {
+    return mRefCount.sum();
   }
 }

--- a/dora/core/server/common/src/main/java/alluxio/rocks/RocksStore.java
+++ b/dora/core/server/common/src/main/java/alluxio/rocks/RocksStore.java
@@ -684,8 +684,6 @@ public final class RocksStore implements Closeable {
    * @return the exclusive lock handle used to manage and close the lock
    */
   public RocksExclusiveLockHandle lockForClosing() {
-    Exception e = new RuntimeException("Log trace here");
-    LOG.error("Just recording the trace here", e);
     // Grab the lock with no respect to concurrent operations
     // Just grab the lock and close
     setFlagAndBlockingWait(false);

--- a/dora/core/server/common/src/test/java/alluxio/rocks/RocksStoreTest.java
+++ b/dora/core/server/common/src/test/java/alluxio/rocks/RocksStoreTest.java
@@ -12,10 +12,23 @@
 package alluxio.rocks;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.ExceptionMessage;
+import alluxio.exception.runtime.UnavailableRuntimeException;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
+import alluxio.master.metastore.rocks.RocksExclusiveLockHandle;
+import alluxio.master.metastore.rocks.RocksSharedLockHandle;
+import alluxio.util.ThreadFactoryUtils;
 
 import com.google.common.primitives.Longs;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -26,60 +39,484 @@ import org.rocksdb.CompressionType;
 import org.rocksdb.DBOptions;
 import org.rocksdb.HashLinkedListMemTableConfig;
 import org.rocksdb.RocksDB;
+import org.rocksdb.RocksObject;
 import org.rocksdb.WriteOptions;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class RocksStoreTest {
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
 
-  @Test
-  public void backupRestore() throws Exception {
+  private RocksStore mStore;
+  List<RocksObject> mToClose;
+  AtomicReference<ColumnFamilyHandle> mTestColumn;
+  String mDbDir;
+  String mBackupsDir;
+  List<ColumnFamilyDescriptor> mColumnDescriptors;
+  ExecutorService mThreadPool;
+
+  @Before
+  public void setup() throws Exception {
+    Configuration.set(PropertyKey.MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT, "500ms");
+    Configuration.set(PropertyKey.TEST_MODE, true);
+
+    mToClose = new ArrayList<>();
     ColumnFamilyOptions cfOpts = new ColumnFamilyOptions()
         .setMemTableConfig(new HashLinkedListMemTableConfig())
         .setCompressionType(CompressionType.NO_COMPRESSION)
         .useFixedLengthPrefixExtractor(Longs.BYTES); // We always search using the initial long key
+    mToClose.add(cfOpts);
 
-    List<ColumnFamilyDescriptor> columnDescriptors =
+    mColumnDescriptors =
         Arrays.asList(new ColumnFamilyDescriptor("test".getBytes(), cfOpts));
-    String dbDir = mFolder.newFolder("rocks").getAbsolutePath();
-    String backupsDir = mFolder.newFolder("rocks-backups").getAbsolutePath();
-    AtomicReference<ColumnFamilyHandle> testColumn = new AtomicReference<>();
+    mDbDir = mFolder.newFolder("rocks").getAbsolutePath();
+    mBackupsDir = mFolder.newFolder("rocks-backups").getAbsolutePath();
+    mTestColumn = new AtomicReference<>();
     DBOptions dbOpts = new DBOptions().setCreateIfMissing(true)
         .setCreateMissingColumnFamilies(true)
         .setAllowConcurrentMemtableWrite(false);
-    RocksStore store =
-        new RocksStore("test", dbDir, backupsDir, dbOpts, columnDescriptors,
-            Arrays.asList(testColumn), true);
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    RocksDB db = store.getDb();
-    int count = 10;
-    for (int i = 0; i < count; i++) {
-      db.put(testColumn.get(), new WriteOptions().setDisableWAL(true), ("a" + i).getBytes(),
-          "b".getBytes());
-    }
-    store.writeToCheckpoint(baos);
-    store.close();
+    mToClose.add(dbOpts);
 
-    String newBbDir = mFolder.newFolder("rocks-new").getAbsolutePath();
-    dbOpts = new DBOptions().setCreateIfMissing(true)
+    mStore = new RocksStore("test", mDbDir, mBackupsDir, dbOpts, mColumnDescriptors,
+        Arrays.asList(mTestColumn), true);
+
+    mThreadPool = Executors.newCachedThreadPool(
+        ThreadFactoryUtils.build("test-executor-%d", true));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    try (RocksExclusiveLockHandle lock = mStore.lockForClosing()) {
+      mStore.close();
+    }
+
+    Collections.reverse(mToClose);
+    mToClose.forEach(RocksObject::close);
+
+    mThreadPool.shutdownNow();
+  }
+
+  @Test
+  public void backupRestore() throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    RocksDB db;
+    int count = 10;
+    try (RocksSharedLockHandle lock = mStore.checkAndAcquireSharedLock()) {
+      db = mStore.getDb();
+      for (int i = 0; i < count; i++) {
+        db.put(mTestColumn.get(), new WriteOptions().setDisableWAL(true), ("a" + i).getBytes(),
+            "b".getBytes());
+      }
+    }
+    try (RocksExclusiveLockHandle lock = mStore.lockForCheckpoint()) {
+      mStore.writeToCheckpoint(baos);
+    }
+    try (RocksExclusiveLockHandle lock = mStore.lockForClosing()) {
+      mStore.close();
+    }
+
+    String newDbDir = mFolder.newFolder("rocks-new").getAbsolutePath();
+    DBOptions dbOpts = new DBOptions().setCreateIfMissing(true)
         .setCreateMissingColumnFamilies(true)
         .setAllowConcurrentMemtableWrite(false);
-    store =
-        new RocksStore("test-new", newBbDir, backupsDir, dbOpts, columnDescriptors,
-            Arrays.asList(testColumn), true);
-    store.restoreFromCheckpoint(
-        new CheckpointInputStream(new ByteArrayInputStream(baos.toByteArray())));
-    db = store.getDb();
-    for (int i = 0; i < count; i++) {
-      assertArrayEquals("b".getBytes(), db.get(testColumn.get(), ("a" + i).getBytes()));
+    mToClose.add(dbOpts);
+    mStore =
+        new RocksStore("test-new", newDbDir, mBackupsDir, dbOpts, mColumnDescriptors,
+            Arrays.asList(mTestColumn), true);
+    try (RocksExclusiveLockHandle lock = mStore.lockForRewrite()) {
+      mStore.restoreFromCheckpoint(
+          new CheckpointInputStream(new ByteArrayInputStream(baos.toByteArray())));
     }
-    store.close();
-    cfOpts.close();
+    try (RocksSharedLockHandle lock = mStore.checkAndAcquireSharedLock()) {
+      db = mStore.getDb();
+      for (int i = 0; i < count; i++) {
+        assertArrayEquals("b".getBytes(), db.get(mTestColumn.get(), ("a" + i).getBytes()));
+      }
+    }
+  }
+
+  @Test
+  public void sharedLockRefCount() {
+    List<RocksSharedLockHandle> readLocks = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      assertEquals(i, mStore.getSharedLockCount());
+      RocksSharedLockHandle lockHandle = mStore.checkAndAcquireSharedLock();
+      readLocks.add(lockHandle);
+    }
+    assertEquals(20, mStore.getSharedLockCount());
+
+    for (int i = 0; i < 20; i++) {
+      assertEquals(20 - i, mStore.getSharedLockCount());
+      readLocks.get(i).close();
+    }
+    assertEquals(0, mStore.getSharedLockCount());
+  }
+
+  @Test
+  public void exclusiveLockOnClosing() {
+    RocksExclusiveLockHandle exclusiveLock = mStore.lockForClosing();
+
+    Exception e = assertThrows(UnavailableRuntimeException.class, () -> {
+      mStore.checkAndAcquireSharedLock();
+    });
+    assertTrue(e.getMessage().contains(ExceptionMessage.ROCKS_DB_CLOSING.getMessage()));
+    Exception f = assertThrows(UnavailableRuntimeException.class, () -> {
+      mStore.shouldAbort(0);
+    });
+    assertTrue(f.getMessage().contains(ExceptionMessage.ROCKS_DB_CLOSING.getMessage()));
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+    exclusiveLock.close();
+    assertEquals(0, mStore.getSharedLockCount());
+    // The flag is NOT reset after the lock is released, because the service will exit
+    assertTrue(mStore.isServiceStopping());
+  }
+
+  @Test
+  public void exclusiveLockOnCheckpoint() {
+    RocksExclusiveLockHandle exclusiveLock = mStore.lockForCheckpoint();
+
+    Exception e = assertThrows(UnavailableRuntimeException.class, () -> {
+      mStore.checkAndAcquireSharedLock();
+    });
+    assertTrue(e.getMessage().contains(ExceptionMessage.ROCKS_DB_CLOSING.getMessage()));
+    Exception f = assertThrows(UnavailableRuntimeException.class, () -> {
+      mStore.shouldAbort(0);
+    });
+    assertTrue(f.getMessage().contains(ExceptionMessage.ROCKS_DB_CLOSING.getMessage()));
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+    exclusiveLock.close();
+    assertEquals(0, mStore.getSharedLockCount());
+    // The flag is reset after the lock is released, because the service will restore
+    assertFalse(mStore.isServiceStopping());
+  }
+
+  @Test
+  public void exclusiveLockOnRewrite() {
+    RocksExclusiveLockHandle exclusiveLock = mStore.lockForRewrite();
+
+    Exception e = assertThrows(UnavailableRuntimeException.class, () -> {
+      mStore.checkAndAcquireSharedLock();
+    });
+    assertTrue(e.getMessage().contains(ExceptionMessage.ROCKS_DB_CLOSING.getMessage()));
+    Exception f = assertThrows(UnavailableRuntimeException.class, () -> {
+      mStore.shouldAbort(0);
+    });
+    assertTrue(f.getMessage().contains(ExceptionMessage.ROCKS_DB_CLOSING.getMessage()));
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+    exclusiveLock.close();
+    assertEquals(0, mStore.getSharedLockCount());
+    // The flag is reset after the lock is released, because the service will restore
+    assertFalse(mStore.isServiceStopping());
+  }
+
+  @Test
+  public void exclusiveLockForcedAndReleasedAfterSharedLock() throws Exception {
+    // One reader gets the shared lock and does not release for a long time
+    CountDownLatch readerCloseLatch = new CountDownLatch(1);
+    CountDownLatch writerStartLatch = new CountDownLatch(1);
+    Future<Void> f = mThreadPool.submit(() -> {
+      RocksSharedLockHandle lockHandle = mStore.checkAndAcquireSharedLock();
+      System.out.println("Read lock grabbed");
+      writerStartLatch.countDown();
+      assertEquals(1, mStore.getSharedLockCount());
+      try {
+        readerCloseLatch.await();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      System.out.println("Able to unlock read lock now");
+      // After a long time, this lock is released after the exclusive lock has been forced
+      lockHandle.close();
+      System.out.println("Read lock released");
+      // The lock release should not mess up the ref count
+      assertEquals(0, mStore.getSharedLockCount());
+      return null;
+    });
+
+    // One closer comes in and eventually will grab the lock after wait
+    writerStartLatch.await();
+    // Manually set this flag, otherwise an exception will be thrown when the exclusive lock
+    // is forced.
+    Configuration.set(PropertyKey.TEST_MODE, false);
+    RocksExclusiveLockHandle exclusiveLock = mStore.lockForCheckpoint();
+    // After some wait, the closer will force the lock and reset the ref count
+    // And the ref count will be reset on that force
+    assertEquals(0, mStore.getSharedLockCount());
+    // Let the reader finish before the exclusive lock is released
+    readerCloseLatch.countDown();
+    f.get();
+    // That should not mess up the ref count
+    assertEquals(0, mStore.getSharedLockCount());
+    exclusiveLock.close();
+    assertEquals(0, mStore.getSharedLockCount());
+  }
+
+  @Test
+  public void exclusiveLockForcedAndReleasedBeforeSharedLock() throws Exception {
+    // One reader gets the shared lock and does not release for a long time
+    CountDownLatch readerCloseLatch = new CountDownLatch(1);
+    CountDownLatch writerStartLatch = new CountDownLatch(1);
+    Future<Void> f = mThreadPool.submit(() -> {
+      RocksSharedLockHandle lockHandle = mStore.checkAndAcquireSharedLock();
+      System.out.println("Read lock grabbed");
+      writerStartLatch.countDown();
+      assertEquals(1, mStore.getSharedLockCount());
+      try {
+        readerCloseLatch.await();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      System.out.println("Able to unlock read lock now");
+      // After a long time, this lock is released after the exclusive lock has been forced
+      lockHandle.close();
+      System.out.println("Read lock released");
+      // The lock release should not mess up the ref count
+      assertEquals(0, mStore.getSharedLockCount());
+      return null;
+    });
+
+    // One closer comes in and eventually will grab the lock after wait
+    writerStartLatch.await();
+    // Manually set this flag, otherwise an exception will be thrown when the exclusive lock
+    // is forced.
+    Configuration.set(PropertyKey.TEST_MODE, false);
+    RocksExclusiveLockHandle exclusiveLock = mStore.lockForCheckpoint();
+    // After some wait, the closer will force the lock and reset the ref count
+    // And the ref count will be reset on that force
+    assertEquals(0, mStore.getSharedLockCount());
+    // The exclusive lock releases before the reader even wakes up
+    exclusiveLock.close();
+    // Let the reader finish
+    readerCloseLatch.countDown();
+    f.get();
+    // The ref count is not messed up
+    assertEquals(0, mStore.getSharedLockCount());
+  }
+
+  @Test
+  public void forcingExclusiveLockInTestWillErr() throws Exception {
+    // One reader gets the shared lock and does not release for a long time
+    CountDownLatch readerCloseLatch = new CountDownLatch(1);
+    CountDownLatch writerStartLatch = new CountDownLatch(1);
+    Future<Void> f = mThreadPool.submit(() -> {
+      RocksSharedLockHandle lockHandle = mStore.checkAndAcquireSharedLock();
+      System.out.println("Read lock grabbed");
+      writerStartLatch.countDown();
+      assertEquals(1, mStore.getSharedLockCount());
+      try {
+        readerCloseLatch.await();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      System.out.println("Able to unlock read lock now");
+      // After a long time, this lock is released after the exclusive lock has been forced
+      lockHandle.close();
+      System.out.println("Read lock released");
+      // The lock release should not mess up the ref count
+      assertEquals(0, mStore.getSharedLockCount());
+      return null;
+    });
+
+    // One closer comes in and eventually will grab the lock after wait
+    writerStartLatch.await();
+    // In test mode, forcing the exclusive lock will result in an exception
+    // This will help us detect issues with the ref count
+    assertThrows(RuntimeException.class, () -> {
+      RocksExclusiveLockHandle exclusiveLock = mStore.lockForCheckpoint();
+    });
+    // Let the reader finish
+    readerCloseLatch.countDown();
+    f.get();
+    // Even if the exclusive lock attempt failed, the ref count will be correct
+    assertEquals(0, mStore.getSharedLockCount());
+  }
+
+  @Test
+  public void readerCanContinueAfterCheckpoint() throws Exception {
+    // One reader gets the shared lock and does not release for a long time
+    CountDownLatch readerCloseLatch = new CountDownLatch(1);
+    CountDownLatch writerStartLatch = new CountDownLatch(1);
+    Future<Void> f = mThreadPool.submit(() -> {
+      RocksSharedLockHandle lockHandle = mStore.checkAndAcquireSharedLock();
+      System.out.println("Read lock grabbed");
+      writerStartLatch.countDown();
+      try {
+        readerCloseLatch.await();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      // While this reader is sleeping, one checkpoint is completed in the background
+      // This check should pass without throwing an exception
+      // And that means the reader can continue doing what it was doing
+      mStore.shouldAbort(lockHandle.getLockVersion());
+
+      System.out.println("Able to continue reading");
+      // After finishing its work, this lock is released
+      lockHandle.close();
+      System.out.println("Read lock released");
+      // The lock release has passed due but should not mess up the ref count
+      assertEquals(0, mStore.getSharedLockCount());
+      return null;
+    });
+
+    // One closer comes in and eventually will grab the lock after wait
+    writerStartLatch.await();
+    // Manually set this flag, otherwise an exception will be thrown when the exclusive lock
+    // is forced.
+    Configuration.set(PropertyKey.TEST_MODE, false);
+    RocksExclusiveLockHandle exclusiveLock = mStore.lockForCheckpoint();
+    // After some wait, the closer will force the lock and reset the ref count
+    // And the ref count will be reset on that force
+    assertEquals(0, mStore.getSharedLockCount());
+    // Now the checkpointing was done, while the reader is still asleep
+    exclusiveLock.close();
+    // Let the reader wake up and continue
+    readerCloseLatch.countDown();
+    f.get();
+    assertEquals(0, mStore.getSharedLockCount());
+  }
+
+  @Test
+  public void readerCanNotContinueAfterRestore() throws Exception {
+    // One reader gets the shared lock and does not release for a long time
+    CountDownLatch readerCloseLatch = new CountDownLatch(1);
+    CountDownLatch writerStartLatch = new CountDownLatch(1);
+    Future<Void> f = mThreadPool.submit(() -> {
+      RocksSharedLockHandle lockHandle = mStore.checkAndAcquireSharedLock();
+      System.out.println("Read lock grabbed");
+      writerStartLatch.countDown();
+      try {
+        readerCloseLatch.await();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      // While this reader is sleeping, one restore action is completed in the background
+      // This check should throw an exception because the RocksDB contents have changed
+      Exception e = assertThrows(UnavailableRuntimeException.class, () -> {
+        mStore.shouldAbort(lockHandle.getLockVersion());
+      });
+      assertTrue(e.getMessage().contains(ExceptionMessage.ROCKS_DB_REWRITTEN.getMessage()));
+
+      System.out.println("Not able to continue reading");
+      // After finishing its work, this lock is released
+      lockHandle.close();
+      System.out.println("Read lock released");
+      // The lock release has passed due but should not mess up the ref count
+      assertEquals(0, mStore.getSharedLockCount());
+      return null;
+    });
+
+    // One closer comes in and eventually will grab the lock after wait
+    writerStartLatch.await();
+    // Manually set this flag, otherwise an exception will be thrown when the exclusive lock
+    // is forced.
+    Configuration.set(PropertyKey.TEST_MODE, false);
+    RocksExclusiveLockHandle exclusiveLock = mStore.lockForRewrite();
+    // After some wait, the closer will force the lock and reset the ref count
+    // And the ref count will be reset on that force
+    assertEquals(0, mStore.getSharedLockCount());
+    // Now the checkpointing was done, while the reader is still asleep
+    exclusiveLock.close();
+    // Let the reader wake up and continue
+    readerCloseLatch.countDown();
+    f.get();
+    assertEquals(0, mStore.getSharedLockCount());
+  }
+
+  @Test
+  public void checkpointThenClose() {
+    RocksExclusiveLockHandle checkpointLock = mStore.lockForCheckpoint();
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+
+    // Before the checkpoint finishes, an attempt comes in to close
+    // This should succeed
+    RocksExclusiveLockHandle closeLock = mStore.lockForClosing();
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+
+    checkpointLock.close();
+    closeLock.close();
+  }
+
+  @Test
+  public void rewriteThenClose() {
+    RocksExclusiveLockHandle rewriteLock = mStore.lockForRewrite();
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+
+    // Before the checkpoint finishes, an attempt comes in to close
+    // This should succeed
+    RocksExclusiveLockHandle closeLock = mStore.lockForClosing();
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+
+    rewriteLock.close();
+    closeLock.close();
+  }
+
+  @Test
+  public void closeThenCheckpoint() {
+    RocksExclusiveLockHandle closeLock = mStore.lockForClosing();
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+
+    // Closing takes higher priority and a checkpoint attempt will fail
+    Exception e = assertThrows(UnavailableRuntimeException.class, () -> {
+      RocksExclusiveLockHandle checkpointLock = mStore.lockForCheckpoint();
+    });
+    assertTrue(e.getMessage().contains(ExceptionMessage.ROCKS_DB_CLOSING.getMessage()));
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+
+    closeLock.close();
+  }
+
+  @Test
+  public void closeThenRewrite() {
+    RocksExclusiveLockHandle closeLock = mStore.lockForClosing();
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+
+    // Closing takes higher priority and a checkpoint attempt will fail
+    Exception e = assertThrows(UnavailableRuntimeException.class, () -> {
+      RocksExclusiveLockHandle rewriteLock = mStore.lockForRewrite();
+    });
+    assertTrue(e.getMessage().contains(ExceptionMessage.ROCKS_DB_CLOSING.getMessage()));
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+
+    closeLock.close();
+  }
+
+  @Test
+  public void checkpointThenRewrite() {
+    RocksExclusiveLockHandle checkpointLock = mStore.lockForCheckpoint();
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+
+    // Rewrite/Checkpoint will yield to exclusive lock
+    Exception e = assertThrows(UnavailableRuntimeException.class, () -> {
+      RocksExclusiveLockHandle rewriteLock = mStore.lockForRewrite();
+    });
+    assertTrue(e.getMessage().contains(ExceptionMessage.ROCKS_DB_CLOSING.getMessage()));
+    assertEquals(0, mStore.getSharedLockCount());
+    assertTrue(mStore.isServiceStopping());
+
+    checkpointLock.close();
   }
 }

--- a/dora/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -491,6 +491,10 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
         if (!hasNext()) {
           throw new NoSuchElementException();
         }
+        /*
+         * When the BlockStore is RocksBlockMetaStore, thread safety is embedded in the iterator.
+         * So no need to worry if the RocksDB is closed while this iterator is active.
+         */
         Block block = blockStoreIterator.next();
         BlockInfoEntry blockInfoEntry =
             BlockInfoEntry.newBuilder().setBlockId(block.getId())

--- a/dora/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockMetaStore.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockMetaStore.java
@@ -70,6 +70,10 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
   private static final String BLOCK_LOCATIONS_COLUMN = "block-locations";
   private static final String ROCKS_STORE_NAME = "BlockStore";
 
+  /*
+   * Below 3 fields are created and managed by the external user class,
+   * no need to close in this class
+   */
   // This is a field instead of a constant because it depends on the call to RocksDB.loadLibrary().
   private final WriteOptions mDisableWAL;
   private final ReadOptions mIteratorOption;
@@ -78,7 +82,9 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
   private final List<RocksObject> mToClose = new ArrayList<>();
 
   private final RocksStore mRocksStore;
-  // The handles are closed in RocksStore
+  /*
+   * The ColumnFamilyHandle instances are created and closed in RocksStore
+   */
   private final AtomicReference<ColumnFamilyHandle> mBlockMetaColumn = new AtomicReference<>();
   private final AtomicReference<ColumnFamilyHandle> mBlockLocationsColumn = new AtomicReference<>();
   private final LongAdder mSize = new LongAdder();
@@ -92,11 +98,14 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
     RocksDB.loadLibrary();
     // the rocksDB objects must be initialized after RocksDB.loadLibrary() is called
     mDisableWAL = new WriteOptions().setDisableWAL(true);
+    mToClose.add(mDisableWAL);
     mReadPrefixSameAsStart = new ReadOptions().setPrefixSameAsStart(true);
+    mToClose.add(mReadPrefixSameAsStart);
     mIteratorOption = new ReadOptions()
         .setReadaheadSize(Configuration.getBytes(
             PropertyKey.MASTER_METASTORE_ITERATOR_READAHEAD_SIZE))
         .setTotalOrderSeek(true);
+    mToClose.add(mIteratorOption);
 
     List<ColumnFamilyDescriptor> columns = new ArrayList<>();
     DBOptions opts = new DBOptions();
@@ -268,7 +277,7 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
   }
 
   private long getProperty(String rocksPropertyName) {
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       return db().getAggregatedLongProperty(rocksPropertyName);
     } catch (RocksDBException e) {
       LOG.warn(String.format("error collecting %s", rocksPropertyName), e);
@@ -279,7 +288,7 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
   @Override
   public Optional<BlockMeta> getBlock(long id) {
     byte[] meta;
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       meta = db().get(mBlockMetaColumn.get(), Longs.toByteArray(id));
     } catch (RocksDBException e) {
       throw new RuntimeException(e);
@@ -296,7 +305,7 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
 
   @Override
   public void putBlock(long id, BlockMeta meta) {
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       byte[] buf = db().get(mBlockMetaColumn.get(), Longs.toByteArray(id));
       // Overwrites the key if it already exists.
       db().put(mBlockMetaColumn.get(), mDisableWAL, Longs.toByteArray(id), meta.toByteArray());
@@ -311,7 +320,7 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
 
   @Override
   public void removeBlock(long id) {
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       byte[] buf = db().get(mBlockMetaColumn.get(), Longs.toByteArray(id));
       db().delete(mBlockMetaColumn.get(), mDisableWAL, Longs.toByteArray(id));
       if (buf != null) {
@@ -325,8 +334,14 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
 
   @Override
   public void clear() {
-    mSize.reset();
-    mRocksStore.clear();
+    LOG.info("Waiting to clear RocksBlockMetaStore..");
+    try (RocksExclusiveLockHandle lock = mRocksStore.lockForRewrite()) {
+      LOG.info("Clearing RocksDB");
+      mSize.reset();
+      mRocksStore.clear();
+    }
+    // Reset the DB state and prepare to serve again
+    LOG.info("RocksBlockMetaStore cleared and ready to serve again");
   }
 
   @Override
@@ -335,17 +350,23 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
   }
 
   @Override
+  /**
+   * There may be concurrent readers and writers so we have to guarantee thread safety when
+   * closing the RocksDB and all RocksObject instances. The sequence for closing is:
+   * 1. Mark flag mClosed = true without locking.
+   *    All new readers/writers should see the flag and not start the operation.
+   * 2. Acquire the WriteLock before shutting down, so it waits for all concurrent r/w to
+   *    bail or finish.
+   */
   public void close() {
-    mSize.reset();
-    LOG.info("Closing RocksBlockStore and recycling all RocksDB JNI objects");
-    mRocksStore.close();
-    mIteratorOption.close();
-    mDisableWAL.close();
-    mReadPrefixSameAsStart.close();
-    // Close the elements in the reverse order they were added
-    Collections.reverse(mToClose);
-    mToClose.forEach(RocksObject::close);
-    LOG.info("RocksBlockStore closed");
+    LOG.info("RocksBlockStore is being closed");
+    try (RocksExclusiveLockHandle lock = mRocksStore.lockForClosing()) {
+      mSize.reset();
+      mRocksStore.close();
+      // Close the elements in the reverse order they were added
+      Collections.reverse(mToClose);
+      mToClose.forEach(RocksObject::close);
+    }
   }
 
   @Override
@@ -357,8 +378,11 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
     // When there are multiple resources declared in the try-with-resource block
     // They are closed in the opposite order of declaration
     // Ref: https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html
-    try (final RocksIterator iter = db().newIterator(mBlockLocationsColumn.get(),
-        mReadPrefixSameAsStart)) {
+    // We assume this operation is short (one block cannot have too many locations)
+    // and lock the full iteration
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock();
+         final RocksIterator iter = db().newIterator(mBlockLocationsColumn.get(),
+            mReadPrefixSameAsStart)) {
       iter.seek(Longs.toByteArray(id));
       List<BlockLocation> locations = new ArrayList<>();
       for (; iter.isValid(); iter.next()) {
@@ -375,7 +399,7 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
   @Override
   public void addLocation(long id, BlockLocation location) {
     byte[] key = RocksUtils.toByteArray(id, location.getWorkerId());
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       db().put(mBlockLocationsColumn.get(), mDisableWAL, key, location.toByteArray());
     } catch (RocksDBException e) {
       throw new RuntimeException(e);
@@ -385,7 +409,7 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
   @Override
   public void removeLocation(long blockId, long workerId) {
     byte[] key = RocksUtils.toByteArray(blockId, workerId);
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       db().delete(mBlockLocationsColumn.get(), mDisableWAL, key);
     } catch (RocksDBException e) {
       throw new RuntimeException(e);
@@ -393,10 +417,28 @@ public class RocksBlockMetaStore implements BlockMetaStore, RocksCheckpointed {
   }
 
   @Override
+  /**
+   * Acquires an iterator to iterate all Blocks in RocksDB.
+   * A shared lock will be acquired when this iterator is created, and released when:
+   * 1. This iterator is complete.
+   * 2. At each step, the iterator finds the RocksDB is closing and aborts voluntarily.
+   *
+   * This iterator is used in:
+   * 1. {@link BlockIntegrityChecker} to iterate all existing blocks
+   * 2. Journal dumping like checkpoint/backup sequences
+   */
   public CloseableIterator<Block> getCloseableIterator() {
-    RocksIterator iterator = db().newIterator(mBlockMetaColumn.get(), mIteratorOption);
-    return RocksUtils.createCloseableIterator(iterator,
-        (iter) -> new Block(Longs.fromByteArray(iter.key()), BlockMeta.parseFrom(iter.value())));
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
+      RocksSharedLockHandle readLock = mRocksStore.checkAndAcquireSharedLock();
+
+      RocksIterator iterator = db().newIterator(mBlockMetaColumn.get(), mIteratorOption);
+      return RocksUtils.createCloseableIterator(iterator,
+          (iter) -> new Block(Longs.fromByteArray(iter.key()), BlockMeta.parseFrom(iter.value())),
+          () -> {
+            mRocksStore.shouldAbort(lock.getLockVersion());
+            return null;
+          }, readLock);
+    }
   }
 
   private RocksDB db() {

--- a/dora/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -65,6 +65,7 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -82,6 +83,10 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
   private static final String EDGES_COLUMN = "edges";
   private static final String ROCKS_STORE_NAME = "InodeStore";
 
+  /*
+   * Below 3 fields are created and managed by the external user class,
+   * no need to close in this class.
+   */
   // These are fields instead of constants because they depend on the call to RocksDB.loadLibrary().
   private final WriteOptions mDisableWAL;
   private final ReadOptions mReadPrefixSameAsStart;
@@ -95,6 +100,9 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
   private final RocksStore mRocksStore;
   private final List<RocksObject> mToClose = new ArrayList<>();
 
+  /*
+   * The ColumnFamilyHandle instances are created and closed in RocksStore
+   */
   private final AtomicReference<ColumnFamilyHandle> mInodesColumn = new AtomicReference<>();
   private final AtomicReference<ColumnFamilyHandle> mEdgesColumn = new AtomicReference<>();
 
@@ -107,10 +115,13 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
     RocksDB.loadLibrary();
     // the rocksDB objects must be initialized after RocksDB.loadLibrary() is called
     mDisableWAL = new WriteOptions().setDisableWAL(true);
+    mToClose.add(mDisableWAL);
     mReadPrefixSameAsStart = new ReadOptions().setPrefixSameAsStart(true);
+    mToClose.add(mReadPrefixSameAsStart);
     mIteratorOption = new ReadOptions().setReadaheadSize(
         Configuration.getBytes(PropertyKey.MASTER_METASTORE_ITERATOR_READAHEAD_SIZE))
         .setTotalOrderSeek(true);
+    mToClose.add(mIteratorOption);
     String dbPath = PathUtils.concatPath(baseDir, INODES_DB_NAME);
     String backupPath = PathUtils.concatPath(baseDir, INODES_DB_NAME + "-backup");
 
@@ -279,7 +290,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
   }
 
   private long getProperty(String rocksPropertyName) {
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       return db().getAggregatedLongProperty(rocksPropertyName);
     } catch (RocksDBException e) {
       LOG.warn(String.format("error collecting %s", rocksPropertyName), e);
@@ -289,7 +300,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
   @Override
   public void remove(Long inodeId) {
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       byte[] id = Longs.toByteArray(inodeId);
       db().delete(mInodesColumn.get(), mDisableWAL, id);
     } catch (RocksDBException e) {
@@ -299,7 +310,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
   @Override
   public void writeInode(MutableInode<?> inode) {
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       db().put(mInodesColumn.get(), mDisableWAL, Longs.toByteArray(inode.getId()),
           inode.toProto().toByteArray());
     } catch (RocksDBException e) {
@@ -314,12 +325,18 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
   @Override
   public void clear() {
-    mRocksStore.clear();
+    LOG.info("Waiting to clear RocksInodeStore..");
+    try (RocksExclusiveLockHandle lock = mRocksStore.lockForRewrite()) {
+      LOG.info("Clearing RocksDB");
+      mRocksStore.clear();
+    }
+    // Reset the DB state and prepare to serve again
+    LOG.info("RocksInodeStore cleared and ready to serve again");
   }
 
   @Override
   public void addChild(long parentId, String childName, Long childId) {
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       db().put(mEdgesColumn.get(), mDisableWAL, RocksUtils.toByteArray(parentId, childName),
           Longs.toByteArray(childId));
     } catch (RocksDBException e) {
@@ -329,7 +346,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
   @Override
   public void removeChild(long parentId, String name) {
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       db().delete(mEdgesColumn.get(), mDisableWAL, RocksUtils.toByteArray(parentId, name));
     } catch (RocksDBException e) {
       throw new RuntimeException(e);
@@ -339,7 +356,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
   @Override
   public Optional<MutableInode<?>> getMutable(long id, ReadOption option) {
     byte[] inode;
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       inode = db().get(mInodesColumn.get(), Longs.toByteArray(id));
     } catch (RocksDBException e) {
       throw new RuntimeException(e);
@@ -356,37 +373,54 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
   @Override
   public CloseableIterator<Long> getChildIds(Long inodeId, ReadOption option) {
-    RocksIterator iter = db().newIterator(mEdgesColumn.get(), mReadPrefixSameAsStart);
-    // first seek to the correct bucket
-    iter.seek(Longs.toByteArray(inodeId));
-    // now seek to a specific file if needed
-    String prefix = option.getPrefix();
-    String fromName = option.getStartFrom();
-    String seekTo;
-    if (fromName != null && prefix != null) {
-      if (fromName.compareTo(prefix) > 0) {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
+      RocksIterator iter = db().newIterator(mEdgesColumn.get(), mReadPrefixSameAsStart);
+      // first seek to the correct bucket
+      iter.seek(Longs.toByteArray(inodeId));
+      // now seek to a specific file if needed
+      String prefix = option.getPrefix();
+      String fromName = option.getStartFrom();
+      String seekTo;
+      if (fromName != null && prefix != null) {
+        if (fromName.compareTo(prefix) > 0) {
+          seekTo = fromName;
+        } else {
+          seekTo = prefix;
+        }
+      } else if (fromName != null) {
         seekTo = fromName;
       } else {
         seekTo = prefix;
       }
-    } else if (fromName != null) {
-      seekTo = fromName;
-    } else {
-      seekTo = prefix;
+      if (seekTo != null && seekTo.length() > 0) {
+        iter.seek(RocksUtils.toByteArray(inodeId, seekTo));
+      }
+      /*
+       * Acquire a second lock for iteration, instead of using the same lock for initialization.
+       * Because init takes many operations and should be protected by try-with-resource.
+       * This is fine because the shared lock is reentrant.
+       */
+      RocksSharedLockHandle readLock = mRocksStore.checkAndAcquireSharedLock();
+      RocksIter rocksIter = new RocksIter(iter, prefix, () -> {
+        mRocksStore.shouldAbort(readLock.getLockVersion());
+        return null;
+      });
+      Stream<Long> idStream = StreamSupport.stream(Spliterators
+          .spliteratorUnknownSize(rocksIter, Spliterator.ORDERED), false);
+      return CloseableIterator.create(idStream.iterator(), (any) -> {
+        try {
+          iter.close();
+        } finally {
+          readLock.close();
+        }
+      });
     }
-    if (seekTo != null && seekTo.length() > 0) {
-      iter.seek(RocksUtils.toByteArray(inodeId, seekTo));
-    }
-    RocksIter rocksIter = new RocksIter(iter, prefix);
-    Stream<Long> idStream = StreamSupport.stream(Spliterators
-        .spliteratorUnknownSize(rocksIter, Spliterator.ORDERED), false);
-    return CloseableIterator.create(idStream.iterator(), (any) -> iter.close());
   }
 
   @Override
   public Optional<Long> getChildId(Long inodeId, String name, ReadOption option) {
     byte[] id;
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       id = db().get(mEdgesColumn.get(), RocksUtils.toByteArray(inodeId, name));
     } catch (RocksDBException e) {
       throw new RuntimeException(e);
@@ -402,8 +436,10 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
     final RocksIterator mIter;
     boolean mStopped = false;
     final byte[] mPrefix;
+    Supplier<Void> mAbortCheck;
 
-    RocksIter(RocksIterator rocksIterator, @Nullable String prefix) {
+    RocksIter(RocksIterator rocksIterator, @Nullable String prefix,
+          Supplier<Void> abortCheck) {
       mIter = rocksIterator;
       if (prefix != null && prefix.length() > 0) {
         mPrefix = prefix.getBytes();
@@ -411,6 +447,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
         mPrefix = null;
       }
       checkPrefix();
+      mAbortCheck = abortCheck;
     }
 
     private void checkPrefix() {
@@ -436,6 +473,8 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
     @Override
     public Long next() {
+      // Abort the operation if RocksDB stops serving
+      mAbortCheck.get();
       Long l = Longs.fromByteArray(mIter.value());
       mIter.next();
       checkPrefix();
@@ -445,6 +484,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
   @Override
   public Optional<Inode> getChild(Long inodeId, String name, ReadOption option) {
+    // The underlying calls should each handle locking internally
     return getChildId(inodeId, name).flatMap(id -> {
       Optional<Inode> child = get(id);
       if (!child.isPresent()) {
@@ -457,7 +497,8 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
   @Override
   public boolean hasChildren(InodeDirectoryView inode, ReadOption option) {
-    try (RocksIterator iter = db().newIterator(mEdgesColumn.get(), mReadPrefixSameAsStart)) {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock();
+         RocksIterator iter = db().newIterator(mEdgesColumn.get(), mReadPrefixSameAsStart)) {
       iter.seek(Longs.toByteArray(inode.getId()));
       return iter.isValid();
     }
@@ -466,10 +507,11 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
   @Override
   public Set<EdgeEntry> allEdges() {
     Set<EdgeEntry> edges = new HashSet<>();
-    try (RocksIterator iter = db().newIterator(mEdgesColumn.get(),
-        mIteratorOption)) {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock();
+         RocksIterator iter = db().newIterator(mEdgesColumn.get(), mIteratorOption)) {
       iter.seekToFirst();
       while (iter.isValid()) {
+        mRocksStore.shouldAbort(lock.getLockVersion());
         long parentId = RocksUtils.readLong(iter.key(), 0);
         String childName = new String(iter.key(), Longs.BYTES, iter.key().length - Longs.BYTES);
         long childId = Longs.fromByteArray(iter.value());
@@ -483,10 +525,11 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
   @Override
   public Set<MutableInode<?>> allInodes() {
     Set<MutableInode<?>> inodes = new HashSet<>();
-    try (RocksIterator iter = db().newIterator(mInodesColumn.get(),
-        mIteratorOption)) {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock();
+         RocksIterator iter = db().newIterator(mInodesColumn.get(), mIteratorOption)) {
       iter.seekToFirst();
       while (iter.isValid()) {
+        mRocksStore.shouldAbort(lock.getLockVersion());
         inodes.add(getMutable(Longs.fromByteArray(iter.key()), ReadOption.defaults()).get());
         iter.next();
       }
@@ -495,14 +538,28 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
   }
 
   /**
-   * The name is intentional, in order to distinguish from the {@code Iterable} interface.
+   * Acquires an iterator to iterate all Inodes in RocksDB.
+   * A shared lock will be acquired when this iterator is created, and released when:
+   * 1. This iterator is complete.
+   * 2. At each step, the iterator finds the RocksDB is closing and aborts voluntarily.
+   *
+   * Except tests, this iterator is only used in:
+   * 1. {@link alluxio.master.journal.tool.AbstractJournalDumper} which translates RocksDB
+   *    checkpoints to a human-readable form.
    *
    * @return an iterator over stored inodes
    */
   public CloseableIterator<InodeView> getCloseableIterator() {
-    return RocksUtils.createCloseableIterator(
-        db().newIterator(mInodesColumn.get(), mIteratorOption),
-        (iter) -> getMutable(Longs.fromByteArray(iter.key()), ReadOption.defaults()).get());
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
+      RocksSharedLockHandle readLock = mRocksStore.checkAndAcquireSharedLock();
+      return RocksUtils.createCloseableIterator(
+          db().newIterator(mInodesColumn.get(), mIteratorOption),
+          (iter) -> getMutable(Longs.fromByteArray(iter.key()), ReadOption.defaults()).get(),
+          () -> {
+            mRocksStore.shouldAbort(lock.getLockVersion());
+            return null;
+          }, readLock);
+    }
   }
 
   @Override
@@ -525,7 +582,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
     @Override
     public void writeInode(MutableInode<?> inode) {
-      try {
+      try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
         mBatch.put(mInodesColumn.get(), Longs.toByteArray(inode.getId()),
             inode.toProto().toByteArray());
       } catch (RocksDBException e) {
@@ -535,7 +592,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
     @Override
     public void removeInode(Long key) {
-      try {
+      try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
         mBatch.delete(mInodesColumn.get(), Longs.toByteArray(key));
       } catch (RocksDBException e) {
         throw new RuntimeException(e);
@@ -544,7 +601,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
     @Override
     public void addChild(Long parentId, String childName, Long childId) {
-      try {
+      try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
         mBatch.put(mEdgesColumn.get(), RocksUtils.toByteArray(parentId, childName),
             Longs.toByteArray(childId));
       } catch (RocksDBException e) {
@@ -554,7 +611,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
     @Override
     public void removeChild(Long parentId, String childName) {
-      try {
+      try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
         mBatch.delete(mEdgesColumn.get(), RocksUtils.toByteArray(parentId, childName));
       } catch (RocksDBException e) {
         throw new RuntimeException(e);
@@ -563,7 +620,7 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
     @Override
     public void commit() {
-      try {
+      try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
         db().write(mDisableWAL, mBatch);
       } catch (RocksDBException e) {
         throw new RuntimeException(e);
@@ -578,14 +635,13 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
   @Override
   public void close() {
-    LOG.info("Closing RocksInodeStore and recycling all RocksDB JNI objects");
-    mRocksStore.close();
-    mDisableWAL.close();
-    mReadPrefixSameAsStart.close();
-    // Close the elements in the reverse order they were added
-    Collections.reverse(mToClose);
-    mToClose.forEach(RocksObject::close);
-    LOG.info("RocksInodeStore closed");
+    LOG.info("RocksInodeStore is being closed");
+    try (RocksExclusiveLockHandle lock = mRocksStore.lockForClosing()) {
+      mRocksStore.close();
+      // Close the elements in the reverse order they were added
+      Collections.reverse(mToClose);
+      mToClose.forEach(RocksObject::close);
+    }
   }
 
   private RocksDB db() {
@@ -598,10 +654,12 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
    */
   public String toStringEntries() {
     StringBuilder sb = new StringBuilder();
-    try (ReadOptions readOptions = new ReadOptions().setTotalOrderSeek(true);
-        RocksIterator inodeIter = db().newIterator(mInodesColumn.get(), readOptions)) {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock();
+         ReadOptions readOptions = new ReadOptions().setTotalOrderSeek(true);
+         RocksIterator inodeIter = db().newIterator(mInodesColumn.get(), readOptions)) {
       inodeIter.seekToFirst();
       while (inodeIter.isValid()) {
+        mRocksStore.shouldAbort(lock.getLockVersion());
         MutableInode<?> inode;
         try {
           inode = MutableInode.fromProto(InodeMeta.Inode.parseFrom(inodeIter.value()));
@@ -613,9 +671,11 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
         inodeIter.next();
       }
     }
-    try (RocksIterator edgeIter = db().newIterator(mEdgesColumn.get())) {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock();
+         RocksIterator edgeIter = db().newIterator(mEdgesColumn.get())) {
       edgeIter.seekToFirst();
       while (edgeIter.isValid()) {
+        mRocksStore.shouldAbort(lock.getLockVersion());
         byte[] key = edgeIter.key();
         byte[] id = new byte[Longs.BYTES];
         byte[] name = new byte[key.length - Longs.BYTES];
@@ -631,6 +691,8 @@ public class RocksInodeStore implements InodeStore, RocksCheckpointed {
 
   /**
    * A testing only method to access the internal objects.
+   * For simplicity, no thread safety is provided on the escaping objects.
+   *
    * @return the RocksDB objects references the InodesColumn
    */
   @VisibleForTesting

--- a/dora/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksBlockMetaStoreTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksBlockMetaStoreTest.java
@@ -15,7 +15,6 @@ import static alluxio.master.metastore.rocks.RocksStoreTestUtils.waitForReaders;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;

--- a/dora/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksBlockMetaStoreTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksBlockMetaStoreTest.java
@@ -1,0 +1,276 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.metastore.rocks;
+
+import static alluxio.master.metastore.rocks.RocksStoreTestUtils.waitForReaders;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.master.journal.checkpoint.CheckpointInputStream;
+import alluxio.master.metastore.BlockMetaStore;
+import alluxio.proto.meta.Block;
+import alluxio.resource.CloseableIterator;
+import alluxio.util.ThreadFactoryUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+public class RocksBlockMetaStoreTest {
+  private static final int FILE_NUMBER = 400;
+  private static final int THREAD_NUMBER = 20;
+
+  @Rule
+  public TemporaryFolder mFolder = new TemporaryFolder();
+
+  public String mPath;
+  public RocksBlockMetaStore mStore;
+
+  private ExecutorService mThreadPool;
+
+  @Before
+  public void setUp() throws Exception {
+    Configuration.set(PropertyKey.MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT, "500ms");
+    Configuration.set(PropertyKey.TEST_MODE, true);
+    // Wait for a shorter period of time in test
+    Configuration.set(PropertyKey.MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT, "1s");
+    mPath = mFolder.newFolder().getAbsolutePath();
+    mStore = new RocksBlockMetaStore(mFolder.newFolder().getAbsolutePath());
+    mThreadPool = Executors.newCachedThreadPool(ThreadFactoryUtils.build("test-executor-%d", true));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mStore.close();
+    mThreadPool.shutdownNow();
+    mThreadPool = null;
+  }
+
+  @Test
+  public void escapingIteratorExceptionInNext() throws Exception {
+    prepareBlocks(FILE_NUMBER);
+
+    FlakyRocksBlockStore delegateStore = new FlakyRocksBlockStore(mPath, mStore);
+    AtomicReference<Exception> exception = new AtomicReference<>(null);
+    try (CloseableIterator<BlockMetaStore.Block> brokenIter =
+             delegateStore.getCloseableIterator(false, true)) {
+      while (brokenIter.hasNext()) {
+        brokenIter.next();
+      }
+    } catch (Exception e) {
+      exception.set(e);
+    }
+    assertNotNull(exception.get());
+
+    // Even if the iter is flaky, the lock and ref count are managed correctly
+    // A close action will look at the ref count and err if there is a lock leak
+    assertEquals(0, mStore.getRocksStore().getSharedLockCount());
+    mStore.close();
+  }
+
+  @Test
+  public void escapingIteratorExceptionInHasNext() throws Exception {
+    prepareBlocks(FILE_NUMBER);
+
+    FlakyRocksBlockStore delegateStore = new FlakyRocksBlockStore(mPath, mStore);
+    AtomicReference<Exception> exception = new AtomicReference<>(null);
+    try (CloseableIterator<BlockMetaStore.Block> brokenIter =
+             delegateStore.getCloseableIterator(true, false)) {
+      while (brokenIter.hasNext()) {
+        brokenIter.next();
+      }
+    } catch (Exception e) {
+      exception.set(e);
+    }
+    assertNotNull(exception.get());
+
+    // Even if the iter is flaky, the lock and ref count are managed correctly
+    // A close action will look at the ref count and err if there is a lock leak
+    assertEquals(0, mStore.getRocksStore().getSharedLockCount());
+    mStore.close();
+  }
+
+  @Test
+  public void longRunningIterAndCheckpoint() throws Exception {
+    // Manually set this flag, otherwise an exception will be thrown when the exclusive lock
+    // is forced.
+    Configuration.set(PropertyKey.TEST_MODE, false);
+    prepareBlocks(FILE_NUMBER);
+
+    // Create a bunch of long running iterators on the InodeStore
+    CountDownLatch readerLatch = new CountDownLatch(THREAD_NUMBER);
+    CountDownLatch restoreLatch = new CountDownLatch(1);
+    ArrayBlockingQueue<Exception> errors = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    ArrayBlockingQueue<Integer> results = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    List<Future<Void>> futures =
+        submitIterJob(THREAD_NUMBER, errors, results, readerLatch, restoreLatch);
+
+    // Await for the 20 threads to be iterating in the middle, then trigger the shutdown event
+    readerLatch.await();
+    File checkpointFile = File.createTempFile("checkpoint-for-recovery", "");
+    try (BufferedOutputStream out =
+             new BufferedOutputStream(new FileOutputStream(checkpointFile))) {
+      mStore.writeToCheckpoint(out);
+    }
+    assertTrue(Files.size(checkpointFile.toPath()) > 0);
+
+    // Verify that the iterators can still run
+    restoreLatch.countDown();
+    waitForReaders(futures);
+
+    // All iterators should abort because the RocksDB contents have changed
+    assertEquals(0, errors.size());
+    long completed = results.stream().filter(n -> n == FILE_NUMBER).count();
+    assertEquals(THREAD_NUMBER, completed);
+  }
+
+  @Test
+  public void longRunningIterAndRestore() throws Exception {
+    // Manually set this flag, otherwise an exception will be thrown when the exclusive lock
+    // is forced.
+    Configuration.set(PropertyKey.TEST_MODE, false);
+    prepareBlocks(FILE_NUMBER);
+
+    // Prepare a checkpoint file
+    File checkpointFile = File.createTempFile("checkpoint-for-recovery", "");
+    try (BufferedOutputStream out =
+             new BufferedOutputStream(new FileOutputStream(checkpointFile))) {
+      mStore.writeToCheckpoint(out);
+    }
+
+    // Create a bunch of long running iterators on the InodeStore
+    CountDownLatch readerLatch = new CountDownLatch(THREAD_NUMBER);
+    CountDownLatch restoreLatch = new CountDownLatch(1);
+    ArrayBlockingQueue<Exception> errors = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    ArrayBlockingQueue<Integer> results = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    List<Future<Void>> futures =
+        submitIterJob(THREAD_NUMBER, errors, results, readerLatch, restoreLatch);
+
+    // Await for the 20 threads to be iterating in the middle, then trigger the shutdown event
+    readerLatch.await();
+    try (CheckpointInputStream in = new CheckpointInputStream(
+        (new DataInputStream(new FileInputStream(checkpointFile))))) {
+      mStore.restoreFromCheckpoint(in);
+    }
+
+    // Verify that the iterators can still run
+    restoreLatch.countDown();
+    waitForReaders(futures);
+
+    // All iterators should abort because the RocksDB contents have changed
+    assertEquals(THREAD_NUMBER, errors.size());
+    long completed = results.stream().filter(n -> n == FILE_NUMBER).count();
+    assertEquals(0, completed);
+    long aborted = results.stream().filter(n -> n == 10).count();
+    assertEquals(THREAD_NUMBER, aborted);
+  }
+
+  public static class FlakyRocksBlockStore extends RocksInodeStore {
+    private final RocksBlockMetaStore mDelegate;
+
+    public FlakyRocksBlockStore(String baseDir, RocksBlockMetaStore delegate) {
+      super(baseDir);
+      mDelegate = delegate;
+    }
+
+    public CloseableIterator<BlockMetaStore.Block> getCloseableIterator(
+        boolean hasNextIsFlaky, boolean nextIsFlaky) {
+      CloseableIterator<BlockMetaStore.Block> iter = mDelegate.getCloseableIterator();
+
+      // This iterator is flaky
+      return new CloseableIterator<BlockMetaStore.Block>(iter) {
+        private int mCounter = 0;
+
+        @Override
+        public void closeResource() {
+          iter.closeResource();
+        }
+
+        @Override
+        public boolean hasNext() {
+          if (mCounter == 5 && hasNextIsFlaky) {
+            throw new RuntimeException("Unexpected exception in iterator");
+          }
+          return iter.hasNext();
+        }
+
+        @Override
+        public BlockMetaStore.Block next() {
+          mCounter++;
+          if (mCounter == 5 && nextIsFlaky) {
+            throw new RuntimeException("Unexpected exception in iterator");
+          }
+          return iter.next();
+        }
+      };
+    }
+  }
+
+  private void prepareBlocks(int blockCount) throws Exception {
+    for (int i = 1; i < blockCount + 1; i++) {
+      mStore.putBlock(i, Block.BlockMeta.newBuilder().setLength(100).build());
+    }
+  }
+
+  private List<Future<Void>> submitIterJob(int threadCount,
+      ArrayBlockingQueue<Exception> errors, ArrayBlockingQueue<Integer> results,
+      @Nullable CountDownLatch readersRunningLatch,
+      @Nullable CountDownLatch writerCompletedLatch) {
+    List<Future<Void>> futures = new ArrayList<>();
+    for (int k = 0; k < threadCount; k++) {
+      futures.add(mThreadPool.submit(() -> {
+        int listedCount = 0;
+        try (CloseableIterator<BlockMetaStore.Block> iter = mStore.getCloseableIterator()) {
+          while (iter.hasNext()) {
+            if (listedCount == 10 && readersRunningLatch != null) {
+              readersRunningLatch.countDown();
+              if (writerCompletedLatch != null) {
+                // Pretend the reader is blocked and will wake up after the writer is done
+                writerCompletedLatch.await();
+              }
+            }
+            iter.next();
+            listedCount++;
+          }
+        } catch (Exception e) {
+          errors.add(e);
+        } finally {
+          results.add(listedCount);
+        }
+        return null;
+      }));
+    }
+    return futures;
+  }
+}

--- a/dora/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksInodeStoreTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksInodeStoreTest.java
@@ -11,45 +11,732 @@
 
 package alluxio.master.metastore.rocks;
 
+import static alluxio.master.metastore.rocks.RocksStoreTestUtils.waitForReaders;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.master.file.contexts.CreateDirectoryContext;
+import alluxio.master.file.meta.InodeView;
+import alluxio.master.file.meta.MutableInode;
 import alluxio.master.file.meta.MutableInodeDirectory;
+import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.metastore.InodeStore.WriteBatch;
+import alluxio.master.metastore.ReadOption;
+import alluxio.resource.CloseableIterator;
+import alluxio.util.ThreadFactoryUtils;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import javax.annotation.Nullable;
 
 public class RocksInodeStoreTest {
+  private static final int FILE_NUMBER = 400;
+  private static final int THREAD_NUMBER = 20;
+
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
 
+  public String mPath;
+  public RocksInodeStore mStore;
+
+  private ExecutorService mThreadPool;
+
+  // Functional wrappers of RocksDB r/w actions
+  private QuadFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>,
+          CountDownLatch, CountDownLatch, List<Future<Void>>> mCreateAddReaders =
+              (errors, results, readerRunningLatch, writerCompletedLatch) -> {
+                return submitAddInodeJob(
+                        errors, results, readerRunningLatch, writerCompletedLatch);
+              };
+  private QuadFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>,
+          CountDownLatch, CountDownLatch, List<Future<Void>>> mCreateGetReaders =
+              (errors, results, readerRunningLatch, writerCompletedLatch) -> {
+                return submitGetInodeJob(
+                        errors, results, readerRunningLatch, writerCompletedLatch);
+              };
+  private QuadFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>,
+          CountDownLatch, CountDownLatch, List<Future<Void>>> mCreateListReadersAbort =
+              (errors, results, readerRunningLatch, writerCompletedLatch) -> {
+                // Do not wait for the writer latch, writer will run concurrent to the list actions
+                return submitListingJob(
+                        errors, results, readerRunningLatch, null);
+              };
+
+  @Before
+  public void setUp() throws Exception {
+    Configuration.set(PropertyKey.MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT, "500ms");
+    Configuration.set(PropertyKey.TEST_MODE, true);
+    // Wait for a shorter period of time in test
+    Configuration.set(PropertyKey.MASTER_METASTORE_ROCKS_EXCLUSIVE_LOCK_TIMEOUT, "1s");
+    mPath = mFolder.newFolder().getAbsolutePath();
+    mStore = new RocksInodeStore(mFolder.newFolder().getAbsolutePath());
+    mThreadPool = Executors.newCachedThreadPool(
+        ThreadFactoryUtils.build("test-executor-%d", true));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mStore.close();
+    mThreadPool.shutdownNow();
+    mThreadPool = null;
+  }
+
   @Test
   public void batchWrite() throws IOException {
-    RocksInodeStore store = new RocksInodeStore(mFolder.newFolder().getAbsolutePath());
-    WriteBatch batch = store.createWriteBatch();
+    WriteBatch batch = mStore.createWriteBatch();
     for (int i = 1; i < 20; i++) {
       batch.writeInode(
           MutableInodeDirectory.create(i, 0, "dir" + i, CreateDirectoryContext.defaults()));
     }
     batch.commit();
     for (int i = 1; i < 20; i++) {
-      assertEquals("dir" + i, store.get(i).get().getName());
+      assertEquals("dir" + i, mStore.get(i).get().getName());
     }
   }
 
   @Test
   public void toStringEntries() throws IOException {
-    RocksInodeStore store = new RocksInodeStore(mFolder.newFolder().getAbsolutePath());
-    assertEquals("", store.toStringEntries());
+    assertEquals("", mStore.toStringEntries());
 
-    store.writeInode(MutableInodeDirectory.create(1, 0, "dir", CreateDirectoryContext.defaults()));
-    assertEquals("dir", store.get(1).get().getName());
-    assertThat(store.toStringEntries(), containsString("name=dir"));
+    mStore.writeInode(MutableInodeDirectory.create(
+        1, 0, "dir", CreateDirectoryContext.defaults()));
+    assertEquals("dir", mStore.get(1).get().getName());
+    assertThat(mStore.toStringEntries(), containsString("name=dir"));
+  }
+
+  @Test
+  public void concurrentListAndClose() throws Exception {
+    testConcurrentReaderAndClose(mCreateListReadersAbort);
+  }
+
+  @Test
+  public void concurrentListAndRestore() throws Exception {
+    testConcurrentReaderAndRestore(mCreateListReadersAbort, (errors, results) -> {
+      assertTrue(errors.size() <= THREAD_NUMBER);
+      // Depending on the thread execution order, sometimes the reader threads
+      // may run to finish before the writer thread picks up the signal and flag
+      long completed = results.stream().filter(n -> n == FILE_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed + errors.size());
+      return null;
+    }, (errors, results) -> {
+      // Results are all empty after the clear
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == FILE_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    });
+  }
+
+  @Test
+  public void concurrentListAndCheckpoint() throws Exception {
+    testConcurrentReaderAndCheckpoint(mCreateListReadersAbort, (errors, results) -> {
+      assertTrue(errors.size() <= THREAD_NUMBER);
+      // Depending on the thread execution order, sometimes the reader threads
+      // may run to finish before the writer thread picks up the signal and flag
+      long completed = results.stream().filter(n -> n == FILE_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed + errors.size());
+      return null;
+    }, (errors, results) -> {
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == FILE_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    });
+  }
+
+  @Test
+  public void concurrentListAndClear() throws Exception {
+    testConcurrentReaderAndClear(mCreateListReadersAbort, (errors, results) -> {
+      assertTrue(errors.size() <= THREAD_NUMBER);
+      // Depending on the thread execution order, sometimes the reader threads
+      // may run to finish before the writer thread picks up the signal and flag
+      long completed = results.stream().filter(n -> n == FILE_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed + errors.size());
+      return null;
+    }, (errors, results) -> {
+      // Results are all empty after the clear
+      assertEquals(0, errors.size());
+      long seeEmpty = results.stream().filter(n -> n == 0).count();
+      assertEquals(THREAD_NUMBER, seeEmpty);
+      return null;
+    });
+  }
+
+  @Test
+  public void concurrentGetAndClose() throws Exception {
+    testConcurrentReaderAndClose(mCreateGetReaders);
+  }
+
+  @Test
+  public void concurrentGetAndRestore() throws Exception {
+    testConcurrentReaderAndRestore(mCreateGetReaders, (errors, results) -> {
+      // The closer will finish and the new Get operations are unaffected
+      // If one inode does not exist, result will be Optional.empty
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    }, (errors, results) -> {
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    });
+  }
+
+  @Test
+  public void concurrentGetAndCheckpoint() throws Exception {
+    testConcurrentReaderAndCheckpoint(mCreateGetReaders, (errors, results) -> {
+      // The closer will finish and the new Get operations are unaffected
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    }, (errors, results) -> {
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    });
+  }
+
+  @Test
+  public void concurrentGetAndClear() throws Exception {
+    testConcurrentReaderAndClear(mCreateGetReaders, (errors, results) -> {
+      // The closer will finish and the new Get operations are unaffected
+      // However, Get after the RocksDB is cleared will get empty results
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    }, (errors, results) -> {
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    });
+  }
+
+  @Test
+  public void concurrentAddAndClose() throws Exception {
+    testConcurrentReaderAndClose(mCreateAddReaders);
+  }
+
+  @Test
+  public void concurrentAddAndRestore() throws Exception {
+    testConcurrentReaderAndRestore(mCreateAddReaders, (errors, results) -> {
+      // After the restore finishes, new add operations can go on unaffected
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    }, (errors, results) -> {
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    });
+  }
+
+  @Test
+  public void concurrentAddAndCheckpoint() throws Exception {
+    testConcurrentReaderAndCheckpoint(mCreateAddReaders, (errors, results) -> {
+      // After the clear finishes, add operations can go on unaffected
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    }, (errors, results) -> {
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    });
+  }
+
+  @Test
+  public void concurrentAddAndClear() throws Exception {
+    testConcurrentReaderAndClear(mCreateAddReaders, (errors, results) -> {
+      // After the clear finishes, add operations can go on unaffected
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    }, (errors, results) -> {
+      assertEquals(0, errors.size());
+      long completed = results.stream().filter(n -> n == THREAD_NUMBER).count();
+      assertEquals(THREAD_NUMBER, completed);
+      return null;
+    });
+  }
+
+  private List<Future<Void>> submitListingJob(
+          ArrayBlockingQueue<Exception> errors,
+          ArrayBlockingQueue<Integer> results,
+          @Nullable CountDownLatch readersRunningLatch,
+          @Nullable CountDownLatch writerCompletedLatch) {
+    List<Future<Void>> futures = new ArrayList<>();
+    for (int k = 0; k < THREAD_NUMBER; k++) {
+      futures.add(mThreadPool.submit(() -> {
+        int listedCount = 0;
+        try (CloseableIterator<Long> iter = mStore.getChildIds(0L)) {
+          while (iter.hasNext()) {
+            if (listedCount == 10 && readersRunningLatch != null) {
+              readersRunningLatch.countDown();
+              if (writerCompletedLatch != null) {
+                // Pretend the reader is blocked and will wake up after the writer is done
+                writerCompletedLatch.await();
+              }
+            }
+            iter.next();
+            listedCount++;
+          }
+        } catch (Exception e) {
+          errors.add(e);
+        } finally {
+          results.add(listedCount);
+        }
+        return null;
+      }));
+    }
+    return futures;
+  }
+
+  private List<Future<Void>> submitIterJob(int threadCount,
+                                              ArrayBlockingQueue<Exception> errors,
+                                              ArrayBlockingQueue<Integer> results,
+                                           @Nullable CountDownLatch readersRunningLatch,
+                                           @Nullable CountDownLatch writerCompletedLatch) {
+    List<Future<Void>> futures = new ArrayList<>();
+    for (int k = 0; k < threadCount; k++) {
+      futures.add(mThreadPool.submit(() -> {
+        int listedCount = 0;
+        try (CloseableIterator<InodeView> iter = mStore.getCloseableIterator()) {
+          while (iter.hasNext()) {
+            if (listedCount == 10 && readersRunningLatch != null) {
+              readersRunningLatch.countDown();
+              if (writerCompletedLatch != null) {
+                // Pretend the reader is blocked and will wake up after the writer is done
+                writerCompletedLatch.await();
+              }
+            }
+            iter.next();
+            listedCount++;
+          }
+        } catch (Exception e) {
+          errors.add(e);
+        } finally {
+          results.add(listedCount);
+        }
+        return null;
+      }));
+    }
+    return futures;
+  }
+
+  @Test
+  public void escapingIteratorExceptionInNext() throws Exception {
+    prepareFiles(FILE_NUMBER);
+
+    FlakyRocksInodeStore delegateStore = new FlakyRocksInodeStore(mPath, mStore);
+    AtomicReference<Exception> exception = new AtomicReference<>(null);
+    try (CloseableIterator<InodeView> brokenIter =
+             delegateStore.getCloseableIterator(false, true)) {
+      while (brokenIter.hasNext()) {
+        brokenIter.next();
+      }
+    } catch (Exception e) {
+      exception.set(e);
+    }
+    assertNotNull(exception.get());
+
+    // Even if the iter is flaky, the lock and ref count are managed correctly
+    // A close action will look at the ref count and err if there is a lock leak
+    assertEquals(0, mStore.getRocksStore().getSharedLockCount());
+    mStore.close();
+  }
+
+  @Test
+  public void escapingIteratorExceptionInHasNext() throws Exception {
+    prepareFiles(FILE_NUMBER);
+
+    FlakyRocksInodeStore delegateStore = new FlakyRocksInodeStore(mPath, mStore);
+    AtomicReference<Exception> exception = new AtomicReference<>(null);
+    try (CloseableIterator<InodeView> brokenIter =
+             delegateStore.getCloseableIterator(true, false)) {
+      while (brokenIter.hasNext()) {
+        brokenIter.next();
+      }
+    } catch (Exception e) {
+      exception.set(e);
+    }
+    assertNotNull(exception.get());
+
+    // Even if the iter is flaky, the lock and ref count are managed correctly
+    // A close action will look at the ref count and err if there is a lock leak
+    assertEquals(0, mStore.getRocksStore().getSharedLockCount());
+    mStore.close();
+  }
+
+  @Test
+  public void longRunningIterAndRestore() throws Exception {
+    // Manually set this flag, otherwise an exception will be thrown when the exclusive lock
+    // is forced.
+    Configuration.set(PropertyKey.TEST_MODE, false);
+    prepareFiles(FILE_NUMBER);
+
+    // Prepare a checkpoint file
+    File checkpointFile = File.createTempFile("checkpoint-for-recovery", "");
+    try (BufferedOutputStream out =
+             new BufferedOutputStream(new FileOutputStream(checkpointFile))) {
+      mStore.writeToCheckpoint(out);
+    }
+
+    // Create a bunch of long running iterators on the InodeStore
+    CountDownLatch readerLatch = new CountDownLatch(THREAD_NUMBER);
+    CountDownLatch restoreLatch = new CountDownLatch(1);
+    ArrayBlockingQueue<Exception> errors = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    ArrayBlockingQueue<Integer> results = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    List<Future<Void>> futures =
+        submitIterJob(THREAD_NUMBER, errors, results, readerLatch, restoreLatch);
+
+    // Await for the 20 threads to be iterating in the middle, then trigger the shutdown event
+    readerLatch.await();
+    try (CheckpointInputStream in = new CheckpointInputStream(
+        (new DataInputStream(new FileInputStream(checkpointFile))))) {
+      mStore.restoreFromCheckpoint(in);
+    }
+
+    // Verify that the iterators can still run
+    restoreLatch.countDown();
+    waitForReaders(futures);
+
+    // All iterators should abort because the RocksDB contents have changed
+    assertEquals(THREAD_NUMBER, errors.size());
+    long completed = results.stream().filter(n -> n == FILE_NUMBER).count();
+    assertEquals(0, completed);
+    long aborted = results.stream().filter(n -> n == 10).count();
+    assertEquals(THREAD_NUMBER, aborted);
+  }
+
+  @Test
+  public void longRunningIterAndCheckpoint() throws Exception {
+    // Manually set this flag, otherwise an exception will be thrown when the exclusive lock
+    // is forced.
+    Configuration.set(PropertyKey.TEST_MODE, false);
+    prepareFiles(FILE_NUMBER);
+
+    // Create a bunch of long running iterators on the InodeStore
+    CountDownLatch readerLatch = new CountDownLatch(THREAD_NUMBER);
+    CountDownLatch restoreLatch = new CountDownLatch(1);
+    ArrayBlockingQueue<Exception> errors = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    ArrayBlockingQueue<Integer> results = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    List<Future<Void>> futures =
+        submitIterJob(THREAD_NUMBER, errors, results, readerLatch, restoreLatch);
+
+    // Await for the 20 threads to be iterating in the middle, then trigger the shutdown event
+    readerLatch.await();
+    File checkpointFile = File.createTempFile("checkpoint-for-recovery", "");
+    try (BufferedOutputStream out =
+             new BufferedOutputStream(new FileOutputStream(checkpointFile))) {
+      mStore.writeToCheckpoint(out);
+    }
+    assertTrue(Files.size(checkpointFile.toPath()) > 0);
+
+    // Verify that the iterators can still run
+    restoreLatch.countDown();
+    waitForReaders(futures);
+
+    // All iterators should abort because the RocksDB contents have changed
+    assertEquals(0, errors.size());
+    long completed = results.stream().filter(n -> n == FILE_NUMBER).count();
+    assertEquals(THREAD_NUMBER, completed);
+  }
+
+  public static class FlakyRocksInodeStore extends RocksInodeStore {
+    private final RocksInodeStore mDelegate;
+
+    public FlakyRocksInodeStore(String baseDir, RocksInodeStore delegate) {
+      super(baseDir);
+      mDelegate = delegate;
+    }
+
+    public CloseableIterator<InodeView> getCloseableIterator(
+            boolean hasNextIsFlaky, boolean nextIsFlaky) {
+      CloseableIterator<InodeView> iter = mDelegate.getCloseableIterator();
+
+      // This iterator is flaky
+      return new CloseableIterator<InodeView>(iter) {
+        private int mCounter = 0;
+
+        @Override
+        public void closeResource() {
+          iter.closeResource();
+        }
+
+        @Override
+        public boolean hasNext() {
+          if (mCounter == 5 && hasNextIsFlaky) {
+            throw new RuntimeException("Unexpected exception in iterator");
+          }
+          return iter.hasNext();
+        }
+
+        @Override
+        public InodeView next() {
+          mCounter++;
+          if (mCounter == 5 && nextIsFlaky) {
+            throw new RuntimeException("Unexpected exception in iterator");
+          }
+          return iter.next();
+        }
+      };
+    }
+  }
+
+  private List<Future<Void>> submitGetInodeJob(
+          ArrayBlockingQueue<Exception> errors,
+          ArrayBlockingQueue<Integer> results,
+          @Nullable CountDownLatch readersRunningLatch,
+          @Nullable CountDownLatch writerCompletedLatch) {
+    List<Future<Void>> futures = new ArrayList<>();
+    for (int k = 0; k < THREAD_NUMBER; k++) {
+      final int iterNum = k;
+      futures.add(mThreadPool.submit(() -> {
+        int finishedCount = 0;
+        try {
+          for (int x = 0; x < THREAD_NUMBER; x++) {
+            long targetInodeId = iterNum * THREAD_NUMBER + x;
+            Optional<MutableInode<?>> dir = mStore.getMutable(targetInodeId, ReadOption.defaults());
+            finishedCount++;
+            if (x == 10 && readersRunningLatch != null) {
+              readersRunningLatch.countDown();
+              if (writerCompletedLatch != null) {
+                // Pretend the reader is blocked and will wake up after the writer is done
+                writerCompletedLatch.await();
+              }
+            }
+          }
+        } catch (Exception e) {
+          e.printStackTrace();
+          errors.add(e);
+        } finally {
+          results.add(finishedCount);
+        }
+        return null;
+      }));
+    }
+    return futures;
+  }
+
+  private List<Future<Void>> submitAddInodeJob(
+          ArrayBlockingQueue<Exception> errors,
+          ArrayBlockingQueue<Integer> results,
+          @Nullable CountDownLatch readersRunningLatch,
+          @Nullable CountDownLatch writerCompletedLatch) {
+    List<Future<Void>> futures = new ArrayList<>();
+    for (int k = 0; k < THREAD_NUMBER; k++) {
+      final int iterNum = k;
+      futures.add(mThreadPool.submit(() -> {
+        int finishedCount = 0;
+        try {
+          for (int x = 0; x < THREAD_NUMBER; x++) {
+            long targetInodeId = iterNum * THREAD_NUMBER + x;
+            MutableInodeDirectory dir =
+                MutableInodeDirectory.create(targetInodeId, 0, "dir" + targetInodeId,
+                    CreateDirectoryContext.defaults());
+            mStore.addChild(0L, dir);
+            if (x == 10 && readersRunningLatch != null) {
+              readersRunningLatch.countDown();
+              if (writerCompletedLatch != null) {
+                // Pretend the reader is blocked and will wake up after the writer is done
+                writerCompletedLatch.await();
+              }
+            }
+            finishedCount++;
+          }
+        } catch (Exception e) {
+          errors.add(e);
+        } finally {
+          results.add(finishedCount);
+        }
+        return null;
+      }));
+    }
+    return futures;
+  }
+
+  private void testConcurrentReaderAndClose(
+      QuadFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>, CountDownLatch,
+          CountDownLatch, List<Future<Void>>> reader) throws Exception {
+    prepareFiles(FILE_NUMBER);
+
+    CountDownLatch readerRunningLatch = new CountDownLatch(THREAD_NUMBER);
+    CountDownLatch writerCompletedLatch = new CountDownLatch(1);
+    ArrayBlockingQueue<Exception> errors = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    ArrayBlockingQueue<Integer> results = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    List<Future<Void>> futures =
+        reader.apply(errors, results, readerRunningLatch, writerCompletedLatch);
+
+    // Await for the threads to be running in the middle, then trigger the closer event
+    readerRunningLatch.await();
+    mStore.close();
+    writerCompletedLatch.countDown();
+
+    waitForReaders(futures);
+    // Reaching here means close() was successfully, which implies ref count reached zero
+    assertTrue(errors.size() <= THREAD_NUMBER);
+  }
+
+  private void testConcurrentReaderAndCheckpoint(
+      QuadFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>, CountDownLatch,
+          CountDownLatch, List<Future<Void>>> reader,
+      BiFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>,
+          Void> stateCheckAfterReadersFinish,
+      BiFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>,
+          Void> stateCheckAfterReadersFinishAgain
+  ) throws Exception {
+    prepareFiles(FILE_NUMBER);
+
+    CountDownLatch readerRunningLatch = new CountDownLatch(THREAD_NUMBER);
+    CountDownLatch writerCompletedLatch = new CountDownLatch(1);
+    ArrayBlockingQueue<Exception> errors = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    ArrayBlockingQueue<Integer> results = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    List<Future<Void>> futures =
+        reader.apply(errors, results, readerRunningLatch, writerCompletedLatch);
+
+    // Await for the 20 threads to be iterating in the middle, then trigger the shutdown event
+    readerRunningLatch.await();
+    File checkpointFile = File.createTempFile("checkpoint-file", "");
+    try (BufferedOutputStream out =
+             new BufferedOutputStream(new FileOutputStream(checkpointFile))) {
+      mStore.writeToCheckpoint(out);
+    }
+    assertTrue(Files.size(checkpointFile.toPath()) > 0);
+    writerCompletedLatch.countDown();
+
+    waitForReaders(futures);
+    stateCheckAfterReadersFinish.apply(errors, results);
+
+    // Verify that the RocksDB can still serve
+    ArrayBlockingQueue<Exception> errorsAgain = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    ArrayBlockingQueue<Integer> resultsAgain = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    List<Future<Void>> futuresAgain = reader.apply(errorsAgain, resultsAgain, null, null);
+    waitForReaders(futuresAgain);
+    stateCheckAfterReadersFinishAgain.apply(errorsAgain, resultsAgain);
+  }
+
+  private void testConcurrentReaderAndRestore(
+      QuadFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>,
+          CountDownLatch, CountDownLatch, List<Future<Void>>> reader,
+      BiFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>,
+          Void> stateCheckAfterReadersFinish,
+      BiFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>,
+          Void> stateCheckAfterReadersFinishAgain
+  ) throws Exception {
+    prepareFiles(FILE_NUMBER);
+    // Prepare a checkpoint file
+    File checkpointFile = File.createTempFile("checkpoint-for-recovery", "");
+    try (BufferedOutputStream out =
+             new BufferedOutputStream(new FileOutputStream(checkpointFile))) {
+      mStore.writeToCheckpoint(out);
+    }
+
+    CountDownLatch readerRunningLatch = new CountDownLatch(THREAD_NUMBER);
+    CountDownLatch writerCompletedLatch = new CountDownLatch(1);
+    ArrayBlockingQueue<Exception> errors = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    ArrayBlockingQueue<Integer> results = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    List<Future<Void>> futures =
+        reader.apply(errors, results, readerRunningLatch, writerCompletedLatch);
+
+    // Await for the 20 threads to be iterating in the middle, then trigger the shutdown event
+    readerRunningLatch.await();
+    try (CheckpointInputStream in = new CheckpointInputStream(
+        (new DataInputStream(new FileInputStream(checkpointFile))))) {
+      mStore.restoreFromCheckpoint(in);
+    }
+    writerCompletedLatch.countDown();
+    waitForReaders(futures);
+    stateCheckAfterReadersFinish.apply(errors, results);
+
+    // Verify that the RocksDB can still serve
+    ArrayBlockingQueue<Exception> errorsAgain = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    ArrayBlockingQueue<Integer> resultsAgain = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    List<Future<Void>> futuresAgain = reader.apply(errorsAgain, resultsAgain, null, null);
+    waitForReaders(futuresAgain);
+    stateCheckAfterReadersFinishAgain.apply(errorsAgain, resultsAgain);
+  }
+
+  private void testConcurrentReaderAndClear(
+      QuadFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>,
+          CountDownLatch, CountDownLatch, List<Future<Void>>> reader,
+      BiFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>,
+          Void> stateCheckAfterReadersFinish,
+      BiFunction<ArrayBlockingQueue<Exception>, ArrayBlockingQueue<Integer>,
+          Void> stateCheckAfterReadersFinishAgain
+  ) throws Exception {
+    prepareFiles(FILE_NUMBER);
+
+    CountDownLatch readerRunningLatch = new CountDownLatch(THREAD_NUMBER);
+    CountDownLatch writerCompletedLatch = new CountDownLatch(1);
+    ArrayBlockingQueue<Exception> errors = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    ArrayBlockingQueue<Integer> results = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    List<Future<Void>> futures =
+        reader.apply(errors, results, readerRunningLatch, writerCompletedLatch);
+
+    // Await for the 20 threads to be iterating in the middle, then trigger the shutdown event
+    readerRunningLatch.await();
+    mStore.clear();
+    writerCompletedLatch.countDown();
+
+    waitForReaders(futures);
+    stateCheckAfterReadersFinish.apply(errors, results);
+
+    // Verify that the RocksDB can still serve
+    ArrayBlockingQueue<Exception> errorsAgain = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    ArrayBlockingQueue<Integer> resultsAgain = new ArrayBlockingQueue<>(THREAD_NUMBER);
+    List<Future<Void>> futuresAgain = reader.apply(errorsAgain, resultsAgain, null, null);
+    waitForReaders(futuresAgain);
+    stateCheckAfterReadersFinishAgain.apply(errorsAgain, resultsAgain);
+  }
+
+  private void prepareFiles(int fileCount) throws Exception {
+    for (int i = 1; i < fileCount + 1; i++) {
+      MutableInodeDirectory dir = MutableInodeDirectory.create(i, 0, "dir" + i,
+          CreateDirectoryContext.defaults());
+      mStore.addChild(0, dir);
+      mStore.writeInode(dir);
+    }
+  }
+
+  @FunctionalInterface
+  interface QuadFunction<A, B, C, D, R> {
+    R apply(A a, B b, C c, D d);
   }
 }

--- a/dora/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksStoreTestUtils.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksStoreTestUtils.java
@@ -1,0 +1,29 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.metastore.rocks;
+
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+public class RocksStoreTestUtils {
+  public static void waitForReaders(List<Future<Void>> futures) {
+    futures.stream().forEach(f -> {
+      try {
+        f.get();
+      } catch (Exception e) {
+        fail("Met uncaught exception from iteration");
+      }
+    });
+  }
+}

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
@@ -93,7 +93,6 @@ public class RocksDBDoraMetaStore implements DoraMetaStore {
             .setMaxOpenFiles(-1);
 
     List<ColumnFamilyDescriptor> columns = new ArrayList<>();
-    // TODO(jiacheng): where is this HashLinkedListMemTableConfig handle closed?
     columns.add(new ColumnFamilyDescriptor(DORA_META_FILE_STATUS_COLUMN.getBytes(),
             new ColumnFamilyOptions()
                     .setMemTableConfig(new HashLinkedListMemTableConfig())

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
@@ -13,6 +13,8 @@ package alluxio.worker.dora;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
+import alluxio.master.metastore.rocks.RocksExclusiveLockHandle;
+import alluxio.master.metastore.rocks.RocksSharedLockHandle;
 import alluxio.proto.meta.DoraMeta;
 import alluxio.rocks.RocksStore;
 import alluxio.util.io.PathUtils;
@@ -33,6 +35,7 @@ import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,6 +47,7 @@ import java.util.stream.Collectors;
 /**
  * Dora Meta Store in RocksDB.
  */
+@ThreadSafe
 public class RocksDBDoraMetaStore implements DoraMetaStore {
   private static final Logger LOG = LoggerFactory.getLogger(RocksDBDoraMetaStore.class);
   private static final String DORA_META_DB_NAME = "DoraMeta";
@@ -76,20 +80,20 @@ public class RocksDBDoraMetaStore implements DoraMetaStore {
 
     // the rocksDB objects must be initialized after RocksDB.loadLibrary() is called
     mWriteOption = new WriteOptions().setDisableWAL(true);
+    mToClose.add(mWriteOption);
     mReadOption  = new ReadOptions();
+    mToClose.add(mReadOption);
     String dbPath = PathUtils.concatPath(baseDir, DORA_META_DB_NAME);
     String backupPath = PathUtils.concatPath(baseDir, DORA_META_DB_NAME + "-backup");
-
-    List<ColumnFamilyDescriptor> columns = new ArrayList<>();
     DBOptions opts = new DBOptions();
     mToClose.add(opts);
-    mToClose.add(mReadOption);
-    mToClose.add(mWriteOption);
-
     opts.setAllowConcurrentMemtableWrite(false) // not supported for hash mem tables
             .setCreateMissingColumnFamilies(true)
             .setCreateIfMissing(true)
             .setMaxOpenFiles(-1);
+
+    List<ColumnFamilyDescriptor> columns = new ArrayList<>();
+    // TODO(jiacheng): where is this HashLinkedListMemTableConfig handle closed?
     columns.add(new ColumnFamilyDescriptor(DORA_META_FILE_STATUS_COLUMN.getBytes(),
             new ColumnFamilyOptions()
                     .setMemTableConfig(new HashLinkedListMemTableConfig())
@@ -119,7 +123,7 @@ public class RocksDBDoraMetaStore implements DoraMetaStore {
   @Override
   public Optional<DoraMeta.FileStatus> getDoraMeta(String path) {
     byte[] status;
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       status = db().get(mFileStatusColumn.get(), path.getBytes());
     } catch (RocksDBException e) {
       throw new RuntimeException(e);
@@ -152,7 +156,7 @@ public class RocksDBDoraMetaStore implements DoraMetaStore {
    */
   @Override
   public void putDoraMeta(String path, DoraMeta.FileStatus meta) {
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       db().put(mFileStatusColumn.get(), mWriteOption, path.getBytes(),
               meta.toByteString().toByteArray());
     } catch (RocksDBException e) {
@@ -168,7 +172,7 @@ public class RocksDBDoraMetaStore implements DoraMetaStore {
    */
   @Override
   public void removeDoraMeta(String path) {
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       db().delete(mFileStatusColumn.get(), mWriteOption, path.getBytes());
     } catch (RocksDBException e) {
       LOG.error("Cannot remove {} : {}", path, e);
@@ -187,11 +191,13 @@ public class RocksDBDoraMetaStore implements DoraMetaStore {
    */
   @Override
   public void close() {
-    LOG.info("Closing " + DORA_META_DB_NAME + " and recycling all RocksDB JNI objects");
-    // Close the elements in the reverse order they were added
-    Collections.reverse(mToClose);
-    mToClose.forEach(RocksObject::close);
-    mRocksStore.close();
+    try (RocksExclusiveLockHandle lock = mRocksStore.lockForClosing()) {
+      LOG.info("Closing " + DORA_META_DB_NAME + " and recycling all RocksDB JNI objects");
+      // Close the elements in the reverse order they were added
+      Collections.reverse(mToClose);
+      mToClose.forEach(RocksObject::close);
+      mRocksStore.close();
+    }
     LOG.info(DORA_META_DB_NAME + " closed");
   }
 
@@ -203,12 +209,12 @@ public class RocksDBDoraMetaStore implements DoraMetaStore {
    */
   @Override
   public Optional<Long> size() {
-    try {
+    try (RocksSharedLockHandle lock = mRocksStore.checkAndAcquireSharedLock()) {
       String res = db().getProperty(mFileStatusColumn.get(), "rocksdb.estimate-num-keys");
       Long s = Long.parseLong(res);
       return Optional.of(s);
     } catch (RocksDBException e) {
-      LOG.error("Cannot getProperty for rocksdb.estimate-num-keys:" + e);
+      LOG.error("Cannot getProperty for rocksdb.estimate-num-keys:", e);
       return Optional.empty();
     }
   }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
@@ -35,7 +35,6 @@ import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,6 +42,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Dora Meta Store in RocksDB.

--- a/dora/microbench/src/main/java/alluxio/inode/RocksBenchBase.java
+++ b/dora/microbench/src/main/java/alluxio/inode/RocksBenchBase.java
@@ -44,8 +44,10 @@ public class RocksBenchBase {
   static final String NO_SER_NO_ALLOC_READ = "noSerNoAllocRead";
 
   private final RocksInodeStore mRocksInodeStore;
+  // RocksDB resources managed by the RocksInodeStore, no need to close manually
   private final RocksDB mDB;
   private final AtomicReference<ColumnFamilyHandle> mInodesColumn;
+  // Created and managed in this class
   private final WriteOptions mDisableWAL;
 
   RocksBenchBase(String confType) throws IOException {
@@ -73,6 +75,7 @@ public class RocksBenchBase {
   void after() {
     mRocksInodeStore.clear();
     mRocksInodeStore.close();
+    mDisableWAL.close();
   }
 
   long getInodeReadId(long total, long nxt, long min, int threadCount, int threadId) {

--- a/dora/tests/src/test/java/alluxio/server/worker/WorkerAllMasterRegistrationTest.java
+++ b/dora/tests/src/test/java/alluxio/server/worker/WorkerAllMasterRegistrationTest.java
@@ -23,6 +23,7 @@ import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.runtime.UnavailableRuntimeException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.MultiMasterEmbeddedJournalLocalAlluxioCluster;
 import alluxio.master.block.BlockMaster;
@@ -75,7 +76,6 @@ public class WorkerAllMasterRegistrationTest {
         mNumMasters, mNumWorkers, PortCoordination.WORKER_ALL_MASTER_REGISTRATION);
     mCluster.initConfiguration(
         IntegrationTestUtils.getTestName(getClass().getSimpleName(), mTestName.getMethodName()));
-    Configuration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 5);
     Configuration.set(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, 100);
     Configuration.set(PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS, true);
     Configuration.set(PropertyKey.STANDBY_MASTER_GRPC_ENABLED, true);
@@ -85,7 +85,6 @@ public class WorkerAllMasterRegistrationTest {
     Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_TIMEOUT, "10sec");
     Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, "3s");
     Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, "6s");
-    Configuration.set(PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS, true);
 
     mCluster.start();
 
@@ -133,16 +132,28 @@ public class WorkerAllMasterRegistrationTest {
 
     // New blocks are added by committing journals
     CommonUtils.waitFor("wait for blocks being committed to all masters", () ->
-        mBlockMasters.stream().allMatch(
-            it -> it.getBlockMetaStore().getLocations(blockId).size() == 1),
-        mDefaultWaitForOptions);
+        mBlockMasters.stream().allMatch(it -> {
+          try {
+            return it.getBlockMetaStore().getLocations(blockId).size() == 1;
+          } catch (UnavailableRuntimeException e) {
+            // The RocksDB is unavailable due to events like checkpoint
+            // Just retry
+          }
+          return false;
+        }), mDefaultWaitForOptions);
 
     // Removed blocks are reported by worker-master heartbeats
     mWorker.removeBlock(new Random().nextLong(), blockId);
     CommonUtils.waitFor("wait for blocks being removed to all masters", () ->
-        mBlockMasters.stream().allMatch(
-            it -> it.getBlockMetaStore().getLocations(blockId).size() == 0),
-        mDefaultWaitForOptions);
+        mBlockMasters.stream().allMatch(it -> {
+          try {
+            return it.getBlockMetaStore().getLocations(blockId).size() == 0;
+          } catch (UnavailableRuntimeException e) {
+            // The RocksDB is unavailable due to events like checkpoint
+            // Just retry
+          }
+          return false;
+        }), mDefaultWaitForOptions);
 
     assertTrue(mWorker.getBlockSyncMasterGroup().isRegisteredToAllMasters());
 
@@ -189,9 +200,15 @@ public class WorkerAllMasterRegistrationTest {
     // so even if the heartbeat fails, standby are still in sync with primary.
     CommonUtils.waitFor("wait for blocks being committed to all masters by heartbeats",
         () ->
-        mBlockMasters.stream().allMatch(
-            it -> it.getBlockMetaStore().getLocations(blockId).size() == 1),
-        mDefaultWaitForOptions);
+        mBlockMasters.stream().allMatch(it -> {
+          try {
+            return it.getBlockMetaStore().getLocations(blockId).size() == 1;
+          } catch (UnavailableRuntimeException e) {
+            // The RocksDB is unavailable due to events like checkpoint
+            // Just retry
+          }
+          return false;
+        }), mDefaultWaitForOptions);
 
     // Remove a block
     mWorker.removeBlock(new Random().nextLong(), blockId);
@@ -201,9 +218,15 @@ public class WorkerAllMasterRegistrationTest {
     getBlockSyncOperators().values().forEach(TestSpecificMasterBlockSync::restoreHeartbeat);
     CommonUtils.waitFor("wait for blocks being removed on all masters by heartbeats",
         () ->
-            mBlockMasters.stream().allMatch(
-                it -> it.getBlockMetaStore().getLocations(blockId).size() == 0),
-        mDefaultWaitForOptions);
+            mBlockMasters.stream().allMatch(it -> {
+              try {
+                return it.getBlockMetaStore().getLocations(blockId).size() == 0;
+              } catch (UnavailableRuntimeException e) {
+                // The RocksDB is unavailable due to events like checkpoint
+                // Just retry
+              }
+              return false;
+            }), mDefaultWaitForOptions);
 
     // Make sure registration only happen once to each master
     assertTrue(getBlockSyncOperators().values().stream()
@@ -362,10 +385,17 @@ public class WorkerAllMasterRegistrationTest {
     // so the block meta store should not contain any block location
     blockIdsToRemove.add(testFileBlockId);
     CommonUtils.waitFor("wait for blocks propagated to masters by heartbeats",
-        () -> mBlockMasters.stream()
-            .allMatch(it ->
+        () -> mBlockMasters.stream().allMatch(it ->
                 blockIdsToRemove.stream()
-                    .allMatch(blockId -> it.getBlockMetaStore().getLocations(blockId).size() == 0)
+                    .allMatch(blockId -> {
+                      try {
+                        return it.getBlockMetaStore().getLocations(blockId).size() == 0;
+                      } catch (UnavailableRuntimeException e) {
+                        // The RocksDB is unavailable due to events like checkpoint
+                        // Just retry
+                      }
+                      return false;
+                    })
             ),
         mDefaultWaitForOptions);
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

We fixed some `RocksStore` thread safety issues where concurrent operations and RocksDB stopping may crash the master process. Those changes are only in `master-2.x` and therefore missing in the `main` branch. Therefore those changes are manually brought in, with fixes on conflicts. Those missing commits are:
https://github.com/Alluxio/alluxio/commit/9f152c554b737b7014a3c8ac1555d0a2d1e2e936
https://github.com/Alluxio/alluxio/commit/bf60aefc247f57708fd39dce1c440515712a54c1

Also in the Dora architecture the worker has its new `RocksDBDoraMetaStore`, which is missing the same thread safety control. Those are implemented in this PR too.

Honestly this change isn't as important on the Dora worker as it previously was in Alluxio 2.x master, because crashing a Dora worker while shutting down is not too critical (yet).

We did not apply the same fix to `RocksPageStore`. That falls under https://github.com/Alluxio/alluxio/issues/17131.

### Why are the changes needed?

Apply thread safety guarantee between concurrent start/stop and client operations.

### Does this PR introduce any user facing changes?

No. Based on our perf benchmark, the extra thread safety guarantee come at a very small cost, based on reference counting and bounded waiting.
