### PR TITLE
Fix the bug that worker doesn't check size when writing temp pages

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -324,6 +324,13 @@ public interface CacheManager extends AutoCloseable, CacheStatus {
   void deleteFile(String fileId);
 
   /**
+   * Deletes all temporary pages of the given file.
+   *
+   * @param fileId the file id of the target file
+   */
+  void deleteTempFile(String fileId);
+
+  /**
    * Deletes a page from the cache.
    *
    * @param pageId page identifier

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerWithShadowCache.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerWithShadowCache.java
@@ -169,6 +169,11 @@ public class CacheManagerWithShadowCache implements CacheManager {
   }
 
   @Override
+  public void deleteTempFile(String fileId) {
+    mCacheManager.deleteTempFile(fileId);
+  }
+
+  @Override
   public Optional<CacheUsage> getUsage() {
     return mCacheManager.getUsage();
   }

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -838,6 +838,15 @@ public class LocalCacheManager implements CacheManager {
   }
 
   @Override
+  public void deleteTempFile(String fileId) {
+    Set<PageInfo> pages;
+    try (LockResource r = new LockResource(mPageMetaStore.getLock().readLock())) {
+      pages = mPageMetaStore.getAllPagesByFileId(fileId);
+    }
+    pages.forEach(page -> delete(page.getPageId(), true));
+  }
+
+  @Override
   public void invalidate(Predicate<PageInfo> predicate) {
     mPageStoreDirs.forEach(dir -> {
       try {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
@@ -213,6 +213,15 @@ public class NoExceptionCacheManager implements CacheManager {
   }
 
   @Override
+  public void deleteTempFile(String fileId) {
+    try {
+      mCacheManager.deleteTempFile(fileId);
+    } catch (Exception e) {
+      LOG.error("Failed to deleteFile for {}", fileId, e);
+    }
+  }
+
+  @Override
   public Optional<CacheUsage> getUsage() {
     return mCacheManager.getUsage();
   }

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/store/QuotaManagedPageStoreDir.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/store/QuotaManagedPageStoreDir.java
@@ -21,7 +21,6 @@ import alluxio.resource.LockResource;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +41,6 @@ abstract class QuotaManagedPageStoreDir implements PageStoreDir {
   @GuardedBy("mTempFileIdSetLock")
   private final Set<String> mTempFileIdSet = new HashSet<>();
 
-  // TODO(JiamingMai): is HashMap enough?
   private final Map<String, List<PageInfo>> mTempFileToPageInfoListMap = new ConcurrentHashMap<>();
 
   private final Path mRootPath;

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/netty/NettyDataWriter.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/netty/NettyDataWriter.java
@@ -260,7 +260,10 @@ public class NettyDataWriter implements DataWriter {
       mChannel.writeAndFlush(new RPCProtoMessage(new ProtoMessage(writeRequest), dataBuffer))
           .addListener(new WriteListener(offset + len)).sync();
     } catch (InterruptedException e) {
-      // ignore
+      if (mPacketWriteException != null) {
+        Throwables.propagateIfPossible(mPacketWriteException, IOException.class);
+        throw AlluxioStatusException.fromCheckedException(mPacketWriteException);
+      }
     }
   }
 
@@ -417,6 +420,14 @@ public class NettyDataWriter implements DataWriter {
     } else {
       mPacketWriteException.addSuppressed(e);
     }
+  }
+
+  /**
+   * Get the exception object that created during packet writing.
+   * @return the exception object
+   */
+  public Throwable getPacketWriteException() {
+    return mPacketWriteException;
   }
 
   /**

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
@@ -292,6 +292,11 @@ public final class CacheManagerWithShadowCacheTest {
     }
 
     @Override
+    public void deleteTempFile(String fileId) {
+      // no-op
+    }
+
+    @Override
     public Optional<CacheUsage> getUsage() {
       return Optional.empty();
     }

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -732,6 +732,11 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
+    public void deleteTempFile(String fileId) {
+      // no-op
+    }
+
+    @Override
     public Optional<CacheUsage> getUsage() {
       return Optional.of(new Usage());
     }

--- a/dora/core/common/src/main/java/alluxio/worker/block/io/BlockWriter.java
+++ b/dora/core/common/src/main/java/alluxio/worker/block/io/BlockWriter.java
@@ -71,4 +71,9 @@ public abstract class BlockWriter extends BlockClient {
    * Commit the file.
    */
   public abstract void commitFile();
+
+  /**
+   * Abort writing.
+   */
+  public abstract void abort();
 }

--- a/dora/core/common/src/main/java/alluxio/worker/block/io/LocalFileBlockWriter.java
+++ b/dora/core/common/src/main/java/alluxio/worker/block/io/LocalFileBlockWriter.java
@@ -59,6 +59,10 @@ public class LocalFileBlockWriter extends BlockWriter {
   }
 
   @Override
+  public void abort() {
+  }
+
+  @Override
   public long append(ByteBuffer inputBuf) {
     long bytesWritten;
 

--- a/dora/core/common/src/test/java/alluxio/worker/block/io/MockBlockWriter.java
+++ b/dora/core/common/src/test/java/alluxio/worker/block/io/MockBlockWriter.java
@@ -38,6 +38,10 @@ public final class MockBlockWriter extends BlockWriter {
   }
 
   @Override
+  public void abort() {
+  }
+
+  @Override
   public void close() throws IOException {
     mOutputStream.close();
     mPosition = -1;

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileWriter.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileWriter.java
@@ -46,6 +46,11 @@ public class PagedFileWriter extends BlockWriter {
   }
 
   @Override
+  public void abort() {
+    mCacheManager.deleteTempFile(mFileId);
+  }
+
+  @Override
   public void commitFile() {
     mCacheManager.commitFile(mFileId);
   }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/netty/AbstractWriteHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/netty/AbstractWriteHandler.java
@@ -193,7 +193,7 @@ abstract class AbstractWriteHandler<T extends WriteRequestContext<?>>
 
   @Override
   public void channelUnregistered(ChannelHandlerContext ctx) {
-    pushAbortPacket(ctx.channel(), new Error(new InternalException("channel unregistered"), false));
+    //pushAbortPacket(ctx.channel(), new Error(new InternalException("channel unregistered"), false));
     ctx.fireChannelUnregistered();
   }
 

--- a/dora/core/server/worker/src/main/java/alluxio/worker/netty/AbstractWriteHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/netty/AbstractWriteHandler.java
@@ -14,7 +14,6 @@ package alluxio.worker.netty;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.AlluxioStatusException;
-import alluxio.exception.status.InternalException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.network.protocol.RPCMessage;
 import alluxio.network.protocol.RPCProtoMessage;
@@ -193,7 +192,6 @@ abstract class AbstractWriteHandler<T extends WriteRequestContext<?>>
 
   @Override
   public void channelUnregistered(ChannelHandlerContext ctx) {
-    //pushAbortPacket(ctx.channel(), new Error(new InternalException("channel unregistered"), false));
     ctx.fireChannelUnregistered();
   }
 

--- a/dora/core/server/worker/src/main/java/alluxio/worker/netty/FileWriteHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/netty/FileWriteHandler.java
@@ -128,6 +128,7 @@ public class FileWriteHandler extends AbstractWriteHandler<BlockWriteRequestCont
     protected void cleanupRequest(BlockWriteRequestContext context) throws Exception {
       WriteRequest request = context.getRequest();
       mWorker.cleanupSession(request.getSessionId());
+      context.getBlockWriter().abort();
     }
 
     @Override

--- a/dora/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockWriter.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockWriter.java
@@ -46,6 +46,10 @@ public class PagedBlockWriter extends BlockWriter {
   }
 
   @Override
+  public void abort() {
+  }
+
+  @Override
   public long append(ByteBuffer inputBuf) {
     long bytesWritten = 0;
     while (inputBuf.hasRemaining()) {

--- a/dora/core/server/worker/src/test/java/alluxio/worker/page/ByteArrayCacheManager.java
+++ b/dora/core/server/worker/src/test/java/alluxio/worker/page/ByteArrayCacheManager.java
@@ -104,6 +104,11 @@ class ByteArrayCacheManager implements CacheManager {
   }
 
   @Override
+  public void deleteTempFile(String fileId) {
+    mPages.keySet().removeIf(pageId -> pageId.getFileId().equals(fileId));
+  }
+
+  @Override
   public Optional<CacheUsage> getUsage() {
     return Optional.of(new Usage());
   }


### PR DESCRIPTION
## Background ##
We found that there is a bug that worker doesn't check the size when writing temp pages. This leads the fact that the pages' size stored in Alluxio Worker exceeds the capacity limitation, as shown in the following snapshot. This makes worker easy to crash.

<img width="1785" alt="image" src="https://github.com/Alluxio/alluxio/assets/6129818/5e53f928-732c-43e6-b55f-3bd4855e8031">

This PR fixes this bug by checking the temp page size to write.