### PR TITLE
Fix to support alluxio version other than xxx.yyy

### DIFF
--- a/dora/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/dora/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -30,11 +30,10 @@ public final class RuntimeConstants {
       ALLUXIO_DOCS_URL = "https://docs.alluxio.io/os/user/edge";
       ALLUXIO_JAVADOC_URL = "https://docs.alluxio.io/os/javadoc/edge";
     } else {
-      String[] majorMinor = VERSION.split("\\.");
       ALLUXIO_DOCS_URL =
-          String.format("https://docs.alluxio.io/os/user/%s.%s", majorMinor[0], majorMinor[1]);
+          "https://docs.alluxio.io/os/user/" + VERSION;
       ALLUXIO_JAVADOC_URL =
-          String.format("https://docs.alluxio.io/os/javadoc/%s.%s", majorMinor[0], majorMinor[1]);
+          "https://docs.alluxio.io/os/javadoc/" + VERSION;
     }
   }
 

--- a/dora/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/dora/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -26,7 +26,7 @@ public final class RuntimeConstants {
   public static final String VERSION = ProjectConstants.VERSION;
 
   static {
-    if (VERSION.endsWith("SNAPSHOT") || !VERSION.contains("\\.")) {
+    if (VERSION.endsWith("SNAPSHOT")) {
       ALLUXIO_DOCS_URL = "https://docs.alluxio.io/os/user/edge";
       ALLUXIO_JAVADOC_URL = "https://docs.alluxio.io/os/javadoc/edge";
     } else {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix to support alluxio version other than xxx.yyy

### Why are the changes needed?

Without these changes, users from alluxio open source community who want to build a package with their version name under their community version name rule, but it doesn't contains any `.` within version name, it wouldn't start alluxio cluster successfully.

### Does this PR introduce any user facing changes?

No
