### PR TITLE
Add recursive create/delete

### DIFF
--- a/dora/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
+++ b/dora/core/common/src/main/java/alluxio/underfs/options/DeleteOptions.java
@@ -24,6 +24,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 @PublicApi
 @NotThreadSafe
 public final class DeleteOptions {
+  public static final DeleteOptions NON_RECURSIVE = defaults();
+  public static final DeleteOptions RECURSIVE = defaults().setRecursive(true);
+
   // Whether to delete a directory with children
   private boolean mRecursive;
 

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -30,6 +30,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.runtime.AlluxioRuntimeException;
+import alluxio.exception.runtime.NotFoundRuntimeException;
 import alluxio.exception.status.NotFoundException;
 import alluxio.file.FileId;
 import alluxio.grpc.Command;
@@ -771,6 +772,8 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
 
       // TODO(hua) Close the open file handle?
 
+      // By being a cache, Dora assume the file exists in UFS when a delete is issued
+      // So if the file does not exist in UFS, an IOException will be thrown here
       UfsStatus status = mUfs.getStatus(path);
       if (status.isFile()) {
         mUfs.deleteFile(path);

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -30,7 +30,6 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.runtime.AlluxioRuntimeException;
-import alluxio.exception.runtime.NotFoundRuntimeException;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.Command;
 import alluxio.grpc.CommandType;
@@ -73,7 +72,6 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
-import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.ModeUtils;
@@ -688,7 +686,6 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
         if (status.isFile()) {
           mUfs.deleteFile(path);
         } else {
-          // TODO(jiacheng): Add UT for this
           if (options.hasRecursive() && options.getRecursive()) {
             mUfs.deleteDirectory(path, DeleteOptions.RECURSIVE);
           } else {

--- a/dora/core/server/worker/src/test/java/alluxio/worker/dora/PagedDoraWorkerTest.java
+++ b/dora/core/server/worker/src/test/java/alluxio/worker/dora/PagedDoraWorkerTest.java
@@ -26,6 +26,9 @@ import alluxio.client.file.cache.PageMetaStore;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AccessControlException;
+import alluxio.grpc.CompleteFilePOptions;
+import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.FileInfo;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
@@ -485,6 +488,81 @@ public class PagedDoraWorkerTest {
   }
 
   @Test
+  public void testCreateDeleteFile() throws Exception {
+    File testDir = mTestFolder.newFolder("testDir");
+    testDir.mkdirs();
+    File testFile = new File(testDir, "a");
+    int fileLength = 1024;
+    createDummyFile(testFile, fileLength);
+
+    assertTrue(testFile.exists());
+    alluxio.wire.FileInfo fileInfo = mWorker.getFileInfo(testFile.getPath(),
+        GetStatusPOptions.getDefaultInstance());
+    assertEquals(fileInfo.getLength(), fileLength);
+
+    mWorker.delete(testFile.getPath(), DeletePOptions.getDefaultInstance());
+    assertThrows(FileNotFoundException.class, () -> {
+      mWorker.getFileInfo(testFile.getPath(), GetStatusPOptions.getDefaultInstance());
+    });
+    assertFalse(testFile.exists());
+  }
+
+  @Test
+  public void testCreateDeleteDirectory() throws Exception {
+    File testBaseDir = mTestFolder.newFolder("testBaseDir");
+    // Prepare the base dir in UFS because we create the dir without recursive=true
+    testBaseDir.mkdirs();
+    File testDir = new File(testBaseDir, "testDir");
+    mWorker.createDirectory(testDir.getPath(), CreateDirectoryPOptions.getDefaultInstance());
+    // The test dir should be created by Alluxio in UFS
+    assertTrue(testDir.exists());
+    alluxio.wire.FileInfo fileInfo = mWorker.getFileInfo(testDir.getPath(),
+        GetStatusPOptions.getDefaultInstance());
+    assertTrue(fileInfo.isFolder());
+
+    mWorker.delete(testDir.getPath(), DeletePOptions.getDefaultInstance());
+    assertThrows(FileNotFoundException.class, () -> {
+      mWorker.getFileInfo(testDir.getPath(), GetStatusPOptions.getDefaultInstance());
+    });
+  }
+
+  @Test
+  public void testRecursiveCreateDeleteDirectory() throws Exception {
+    File testBaseDir = mTestFolder.newFolder("testDir");
+    File testDir = new File(testBaseDir, "a");
+    File testNestedDir = new File(testDir, "b");
+    // Through Alluxio, create the nested path recursively
+    mWorker.createDirectory(testNestedDir.getPath(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    // Both directories should be created by Alluxio
+    assertTrue(testNestedDir.exists());
+    assertTrue(testDir.exists());
+    alluxio.wire.FileInfo nestedDirInfo = mWorker.getFileInfo(testNestedDir.getPath(),
+        GetStatusPOptions.getDefaultInstance());
+    assertTrue(nestedDirInfo.isFolder());
+
+    // Can create files under the nested dir, meaning the dir is created in UFS
+    File testFile = new File(testNestedDir, "testFile");
+    createDummyFile(testFile, 1024);
+    alluxio.wire.FileInfo nestedFileInfo = mWorker.getFileInfo(testFile.getPath(),
+        GetStatusPOptions.getDefaultInstance());
+    assertEquals(nestedFileInfo.getLength(), 1024);
+
+    // Delete the dir (containing nested files), the dir and nested files should all be gone
+    mWorker.delete(testNestedDir.getPath(), DeletePOptions.newBuilder().setRecursive(true).build());
+    assertThrows(FileNotFoundException.class, () -> {
+      mWorker.getFileInfo(testNestedDir.getPath(), GetStatusPOptions.getDefaultInstance());
+    });
+
+    assertThrows(FileNotFoundException.class, () -> {
+      // https://github.com/Alluxio/alluxio/issues/17741
+      // Children under a recursively deleted directory may exist in cache for a while
+      // So we need to manually ignore the cache
+      mWorker.getFileInfo(testFile.getPath(), GET_STATUS_OPTIONS_MUST_SYNC);
+    });
+  }
+
+  @Test
   public void testListCacheConsistency()
       throws IOException, AccessControlException, ExecutionException, InterruptedException,
       TimeoutException {
@@ -533,5 +611,16 @@ public class PagedDoraWorkerTest {
                 .build());
     List<LoadFileFailure> fileFailures = load.get(30, TimeUnit.SECONDS);
     assertEquals(0, fileFailures.size());
+  }
+
+  private void createDummyFile(File testFile, int length) throws Exception {
+    OpenFileHandle handle = mWorker.createFile(testFile.getPath(),
+        CreateFilePOptions.getDefaultInstance());
+    // create file and write some data directly to this file in UFS.
+    byte[] buffer = BufferUtils.getIncreasingByteArray(length);
+    BufferUtils.writeBufferToFile(testFile.getAbsolutePath(), buffer);
+
+    mWorker.completeFile(testFile.getPath(), CompleteFilePOptions.getDefaultInstance(),
+        handle.getUUID().toString());
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

The delete/create options are currently not passed to the UFS. By passing them to the UFS correctly, we should be able to achieve recursive create/delete.

However, note that under Dora structure, when we delete `/a/`, we can't also remove all `/a/*` cache from all workers immediately. https://github.com/Alluxio/alluxio/issues/17741