### PR TITLE
Use a more efficient way to store content hash

### DIFF
--- a/common/transport/src/main/proto/grpc/file_system_master.proto
+++ b/common/transport/src/main/proto/grpc/file_system_master.proto
@@ -401,7 +401,7 @@ message FileInfo {
   map<string, bytes> xattr = 32;
   repeated string mediumType = 33;
   optional string contentHash = 34;
-  optional string ufsName = 35;
+  optional string ufsType = 35;
 }
 
 message GetFilePathPResponse {

--- a/common/transport/src/main/proto/grpc/file_system_master.proto
+++ b/common/transport/src/main/proto/grpc/file_system_master.proto
@@ -400,6 +400,8 @@ message FileInfo {
   optional int64 lastAccessTimeMs = 31;
   map<string, bytes> xattr = 32;
   repeated string mediumType = 33;
+  optional string contentHash = 34;
+  optional string ufsName = 35;
 }
 
 message GetFilePathPResponse {

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -7920,17 +7920,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.WORKER)
           .build();
-  public static final PropertyKey DORA_WORKER_POPULATE_METADATA_FINGERPRINT =
-      booleanBuilder(Name.DORA_WORKER_POPULATE_METADATA_FINGERPRINT)
-          .setDescription("Populate the fingerprint for file metadata fetched from UFS "
-              + "If set, when the file metadata is updated, the fingerprints will be compared. "
-              + "If the file metadata is updated but the data part does not change, "
-              + "we can skip invalidating the page cache, at the expense of having extra overhead "
-              + "on computing the fingerprint for UFS files.")
-          .setDefaultValue(false)
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
 
   public static final PropertyKey DORA_UFS_LIST_STATUS_CACHE_TTL =
       durationBuilder(Name.DORA_UFS_LIST_STATUS_CACHE_TTL)
@@ -9593,9 +9582,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.dora.worker.metastore.rocksdb.block.index";
     public static final String DORA_WORKER_METASTORE_ROCKSDB_INDEX =
         "alluxio.dora.worker.metastore.rocksdb.index";
-
-    public static final String DORA_WORKER_POPULATE_METADATA_FINGERPRINT =
-        "alluxio.dora.worker.populate.metadata.fingerprint";
 
     public static final String DORA_UFS_LIST_STATUS_CACHE_TTL =
         "alluxio.dora.ufs.list.status.cache.ttl";

--- a/dora/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
+++ b/dora/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
@@ -257,7 +257,9 @@ public final class GrpcUtils {
                 : DefaultAccessControlList.EMPTY_DEFAULT_ACL)
         .setReplicationMax(pInfo.getReplicationMax()).setReplicationMin(pInfo.getReplicationMin())
         .setXAttr(pInfo.getXattrMap().entrySet().stream().collect(Collectors.toMap(Map
-            .Entry::getKey, e -> e.getValue().toByteArray())));
+            .Entry::getKey, e -> e.getValue().toByteArray())))
+        .setUfsName(pInfo.getUfsName())
+        .setContentHash(pInfo.getContentHash());
     return fileInfo;
   }
 

--- a/dora/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
+++ b/dora/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
@@ -258,7 +258,7 @@ public final class GrpcUtils {
         .setReplicationMax(pInfo.getReplicationMax()).setReplicationMin(pInfo.getReplicationMin())
         .setXAttr(pInfo.getXattrMap().entrySet().stream().collect(Collectors.toMap(Map
             .Entry::getKey, e -> e.getValue().toByteArray())))
-        .setUfsName(pInfo.getUfsName())
+        .setUfsType(pInfo.getUfsType())
         .setContentHash(pInfo.getContentHash());
     return fileInfo;
   }
@@ -494,7 +494,9 @@ public final class GrpcUtils {
         .setInMemoryPercentage(fileInfo.getInMemoryPercentage())
         .setUfsFingerprint(fileInfo.getUfsFingerprint())
         .setReplicationMax(fileInfo.getReplicationMax())
-        .setReplicationMin(fileInfo.getReplicationMin());
+        .setReplicationMin(fileInfo.getReplicationMin())
+        .setContentHash(fileInfo.getContentHash())
+        .setUfsType(fileInfo.getUfsType());
 
     if (!fileInfo.getAcl().equals(AccessControlList.EMPTY_ACL)) {
       builder.setAcl(toProto(fileInfo.getAcl()));

--- a/dora/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/dora/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -74,6 +74,8 @@ public final class FileInfo implements Serializable {
   private AccessControlList mAcl = AccessControlList.EMPTY_ACL;
   private DefaultAccessControlList mDefaultAcl = DefaultAccessControlList.EMPTY_DEFAULT_ACL;
   private Map<String, byte[]> mXAttr;
+  private String mUfsName;
+  private String mContentHash;
 
   /**
    * Creates a new instance of {@link FileInfo}.
@@ -334,6 +336,22 @@ public final class FileInfo implements Serializable {
   @Nullable
   public Map<String, byte[]> getXAttr() {
     return mXAttr;
+  }
+
+  /**
+   * @return the ufs name
+   */
+  @Nullable
+  public String getUfsName() {
+    return mUfsName;
+  }
+
+  /**
+   * @return the content hash
+   */
+  @Nullable
+  public String getContentHash() {
+    return mContentHash;
   }
 
   /**
@@ -643,6 +661,24 @@ public final class FileInfo implements Serializable {
     return this;
   }
 
+  /**
+   * @param ufsName the ufs name
+   * @return the updated {@link FileInfo}
+   */
+  public FileInfo setUfsName(String ufsName) {
+    mUfsName = ufsName;
+    return this;
+  }
+
+  /**
+   * @param contentHash the content hash
+   * @return the updated {@link FileInfo}
+   */
+  public FileInfo setContentHash(String contentHash) {
+    mContentHash = contentHash;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -668,7 +704,9 @@ public final class FileInfo implements Serializable {
         && mUfsFingerprint.equals(that.mUfsFingerprint)
         && Objects.equal(mAcl, that.mAcl)
         && Objects.equal(mDefaultAcl, that.mDefaultAcl)
-        && Objects.equal(mMediumTypes, that.mMediumTypes);
+        && Objects.equal(mMediumTypes, that.mMediumTypes)
+        && Objects.equal(mContentHash, that.mContentHash)
+        && Objects.equal(mUfsName, that.mUfsName);
   }
 
   @Override
@@ -677,7 +715,8 @@ public final class FileInfo implements Serializable {
         mCreationTimeMs, mCompleted, mFolder, mPinned, mCacheable, mPersisted, mBlockIds,
         mInMemoryPercentage, mLastModificationTimeMs, mLastAccessTimeMs, mTtl, mOwner, mGroup,
         mMode, mReplicationMax, mReplicationMin, mPersistenceState, mMountPoint, mFileBlockInfoList,
-        mTtlAction, mInAlluxioPercentage, mUfsFingerprint, mAcl, mDefaultAcl, mMediumTypes);
+        mTtlAction, mInAlluxioPercentage, mUfsFingerprint, mAcl, mDefaultAcl, mMediumTypes,
+        mUfsName, mContentHash);
   }
 
   @Override
@@ -701,6 +740,8 @@ public final class FileInfo implements Serializable {
         .add("ufsFingerprint", mUfsFingerprint)
         .add("acl", mAcl.toString())
         .add("defaultAcl", mDefaultAcl.toString())
+        .add("ufsName", mUfsName)
+        .add("contentHash", mContentHash)
         .add("xattr", "[" + (mXAttr == null ? null : mXAttr.entrySet().stream()
             .map(entry -> entry.getKey() + ":"
                 + (entry.getValue() == null ? null : new String(entry.getValue())))

--- a/dora/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/dora/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -75,7 +75,7 @@ public final class FileInfo implements Serializable {
   private DefaultAccessControlList mDefaultAcl = DefaultAccessControlList.EMPTY_DEFAULT_ACL;
   private Map<String, byte[]> mXAttr;
   private String mUfsType = "";
-  private String mContentHash = "s";
+  private String mContentHash = "";
 
   /**
    * Creates a new instance of {@link FileInfo}.

--- a/dora/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/dora/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -74,8 +74,8 @@ public final class FileInfo implements Serializable {
   private AccessControlList mAcl = AccessControlList.EMPTY_ACL;
   private DefaultAccessControlList mDefaultAcl = DefaultAccessControlList.EMPTY_DEFAULT_ACL;
   private Map<String, byte[]> mXAttr;
-  private String mUfsName;
-  private String mContentHash;
+  private String mUfsType = "";
+  private String mContentHash = "s";
 
   /**
    * Creates a new instance of {@link FileInfo}.
@@ -342,8 +342,8 @@ public final class FileInfo implements Serializable {
    * @return the ufs name
    */
   @Nullable
-  public String getUfsName() {
-    return mUfsName;
+  public String getUfsType() {
+    return mUfsType;
   }
 
   /**
@@ -662,11 +662,11 @@ public final class FileInfo implements Serializable {
   }
 
   /**
-   * @param ufsName the ufs name
+   * @param ufsType the ufs name
    * @return the updated {@link FileInfo}
    */
-  public FileInfo setUfsName(String ufsName) {
-    mUfsName = ufsName;
+  public FileInfo setUfsType(String ufsType) {
+    mUfsType = ufsType;
     return this;
   }
 
@@ -706,7 +706,7 @@ public final class FileInfo implements Serializable {
         && Objects.equal(mDefaultAcl, that.mDefaultAcl)
         && Objects.equal(mMediumTypes, that.mMediumTypes)
         && Objects.equal(mContentHash, that.mContentHash)
-        && Objects.equal(mUfsName, that.mUfsName);
+        && Objects.equal(mUfsType, that.mUfsType);
   }
 
   @Override
@@ -716,7 +716,7 @@ public final class FileInfo implements Serializable {
         mInMemoryPercentage, mLastModificationTimeMs, mLastAccessTimeMs, mTtl, mOwner, mGroup,
         mMode, mReplicationMax, mReplicationMin, mPersistenceState, mMountPoint, mFileBlockInfoList,
         mTtlAction, mInAlluxioPercentage, mUfsFingerprint, mAcl, mDefaultAcl, mMediumTypes,
-        mUfsName, mContentHash);
+        mUfsType, mContentHash);
   }
 
   @Override
@@ -740,7 +740,7 @@ public final class FileInfo implements Serializable {
         .add("ufsFingerprint", mUfsFingerprint)
         .add("acl", mAcl.toString())
         .add("defaultAcl", mDefaultAcl.toString())
-        .add("ufsName", mUfsName)
+        .add("ufsName", mUfsType)
         .add("contentHash", mContentHash)
         .add("xattr", "[" + (mXAttr == null ? null : mXAttr.entrySet().stream()
             .map(entry -> entry.getKey() + ":"

--- a/dora/core/common/src/test/java/alluxio/wire/FileInfoTest.java
+++ b/dora/core/common/src/test/java/alluxio/wire/FileInfoTest.java
@@ -186,6 +186,8 @@ public class FileInfoTest {
     result.setDefaultAcl((DefaultAccessControlList) AccessControlList
         .fromStringEntries(userName, groupName, defaultStringEntries));
     result.setXAttr(xttrs);
+    result.setContentHash("content_hash");
+    result.setUfsType("s3");
     return result;
   }
 }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -416,7 +416,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
     }
 
     alluxio.grpc.FileInfo.Builder infoBuilder = alluxio.grpc.FileInfo.newBuilder()
-        .setUfsName(mUfs.getUnderFSType())
+        .setUfsType(mUfs.getUnderFSType())
         .setFileId(ufsFullPath.hashCode())
         .setName(filename)
         .setPath(relativePath)

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -132,8 +132,6 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
   private final BlockMasterClientPool mBlockMasterClientPool;
   private final String mRootUFS;
   private FileSystemContext mFsContext;
-  private boolean mPopulateMetadataFingerprint =
-      Configuration.getBoolean(PropertyKey.DORA_WORKER_POPULATE_METADATA_FINGERPRINT);
 
   private static class ListStatusResult {
     public long mTimeStamp;

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -65,7 +65,6 @@ import alluxio.retry.RetryUtils;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.authorization.Mode;
 import alluxio.security.user.ServerUserState;
-import alluxio.underfs.Fingerprint;
 import alluxio.underfs.UfsFileStatus;
 import alluxio.underfs.UfsInputStreamCache;
 import alluxio.underfs.UfsManager;
@@ -419,6 +418,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
     }
 
     alluxio.grpc.FileInfo.Builder infoBuilder = alluxio.grpc.FileInfo.newBuilder()
+        .setUfsName(mUfs.getUnderFSType())
         .setFileId(ufsFullPath.hashCode())
         .setName(filename)
         .setPath(relativePath)
@@ -427,14 +427,16 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
         .setFolder(status.isDirectory())
         .setOwner(status.getOwner())
         .setGroup(status.getGroup())
-        .setCompleted(true);
+        .setCompleted(true)
+        .setPersisted(true);
     if (status instanceof UfsFileStatus) {
       UfsFileStatus fileStatus = (UfsFileStatus) status;
       infoBuilder.setLength(fileStatus.getContentLength())
           .setLastModificationTimeMs(status.getLastModifiedTime())
           .setBlockSizeBytes(fileStatus.getBlockSize());
-      if (mPopulateMetadataFingerprint) {
-        infoBuilder.setUfsFingerprint(Fingerprint.create(filename, status).serialize());
+      String contentHash = ((UfsFileStatus) status).getContentHash();
+      if (contentHash != null) {
+        infoBuilder.setContentHash(contentHash);
       }
 
       // get cached percentage
@@ -889,12 +891,6 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
     public void close() {
       // do nothing
     }
-  }
-
-  @VisibleForTesting
-  void setPopulateMetadataFingerprint(boolean value) {
-    mPopulateMetadataFingerprint = value;
-    mMetaManager.setPopulateMetadataFingerprint(value);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### What changes are proposed in this pull request?

Instead of comparing the fingerprint, we compare the fields in the file info object directly, to make it more efficient.

### Why are the changes needed?

In https://github.com/Alluxio/alluxio/pull/17458, we introduced a mechanism that populates fingerprint and persists that into metastore so that we can skip invalidating unnecessary page caches when the metadata is updated. 

Such mechanism is protected under a property key as it does not perform good. Now after the discussion with @dbw9580 , we came up with a more efficient way where we just leverage the fields in the file info object and we believe we are able to get rid of such switch. 

### Does this PR introduce any user facing changes?

N/A