### PR TITLE
Support for setting the owner after closing the new file

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -7081,6 +7081,18 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "will drop the metadata cache of path '/mnt/alluxio-fuse/path/to/be/cleaned/'")
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey FUSE_SET_USER_GROUP_AFTER_NEW_FILE_CLOSED =
+      booleanBuilder(Name.FUSE_SET_USER_GROUP_AFTER_NEW_FILE_CLOSED)
+          .setDefaultValue(false)
+          .setDescription("Whether the owner and group are set only after the new file is closed "
+              + "when writing new data to the Alluxio cluster via FUSE. "
+              + "This is crucial for maintaining consistency "
+              + "between the owner of the UFS and Alluxio files, "
+              + "especially when the write type is CACHE_THROUGH or THROUGH.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.CLIENT)
+          .build();
+
   //
   // Standalone FUSE process related properties
   //
@@ -9104,6 +9116,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.fuse.user.group.translation.enabled";
     public static final String FUSE_SPECIAL_COMMAND_ENABLED =
         "alluxio.fuse.special.command.enabled";
+    public static final String FUSE_SET_USER_GROUP_AFTER_NEW_FILE_CLOSED =
+        "alluxio.fuse.set.user.group.after.new.file.closed";
     //
     // Standalone FUSE process related properties
     //

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -37,6 +37,7 @@ import alluxio.exception.runtime.NotFoundRuntimeException;
 import alluxio.exception.runtime.PermissionDeniedRuntimeException;
 import alluxio.exception.runtime.UnavailableRuntimeException;
 import alluxio.fuse.auth.AuthPolicy;
+import alluxio.fuse.file.CloseWithActionsFileOutStream;
 import alluxio.fuse.file.CreateFileStatus;
 import alluxio.fuse.options.FuseOptions;
 import alluxio.grpc.CreateFilePOptions;
@@ -131,6 +132,10 @@ public final class AlluxioFuseUtils {
     try {
       FileOutStream out = fileSystem.createFile(uri,
           optionsBuilder.build());
+      if (Configuration.getBoolean(PropertyKey.FUSE_SET_USER_GROUP_AFTER_NEW_FILE_CLOSED)) {
+        return new CloseWithActionsFileOutStream(out,
+            () -> authPolicy.setUserGroup(uri, fileStatus.getUid(), fileStatus.getGid()));
+      }
       authPolicy.setUserGroup(uri, fileStatus.getUid(), fileStatus.getGid());
       return out;
     } catch (FileAlreadyExistsException e) {

--- a/integration/fuse/src/main/java/alluxio/fuse/file/CloseWithActionsFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/CloseWithActionsFileOutStream.java
@@ -1,0 +1,78 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.fuse.file;
+
+import alluxio.client.file.FileOutStream;
+
+import java.io.IOException;
+
+/**
+ * A wrapper class for FileOutStream that performs some operations after the FileInputStream is
+ * closed.
+ */
+public class CloseWithActionsFileOutStream extends FileOutStream {
+
+  private final FileOutStream mFileOutStream;
+  private final Runnable[] mActions;
+
+  /**
+   *
+   * @param fileOutStream
+   * @param actions
+   */
+  public CloseWithActionsFileOutStream(FileOutStream fileOutStream, Runnable... actions) {
+    mFileOutStream = fileOutStream;
+    mActions = actions;
+  }
+
+  @Override
+  public long getBytesWritten() {
+    return mFileOutStream.getBytesWritten();
+  }
+
+  @Override
+  public void cancel() throws IOException {
+    mFileOutStream.cancel();
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    mFileOutStream.write(b);
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    mFileOutStream.write(b);
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    mFileOutStream.write(b, off, len);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    mFileOutStream.flush();
+  }
+
+  @Override
+  public void close() throws IOException {
+    mFileOutStream.close();
+    if (mActions == null) {
+      return;
+    }
+    for (Runnable action : mActions) {
+      action.run();
+    }
+  }
+}
+


### PR DESCRIPTION
### What changes are proposed in this pull request?

We have found that when writing files to Alluxio via FUSE with write type set to CACHE_THROUGH or THROUGH, it can lead to situations where the owner and group of the Alluxio and UFS files differ.

See `alluxio.fuse.AlluxioFuseUtils#createFile`:
<img width="784" alt="image" src="https://github.com/Alluxio/alluxio/assets/45056332/8563897a-a0c9-451d-9322-031825fe2eba">

When setting the owner, the file is not yet created in the UFS, so this code snippet only applies to the file on Alluxio. The file on UFS will be created later, and the change in owner will not take effect.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs NO
  2. addition or removal of property keys YES
  3. webui NO
