### PR TITLE
Return if dst folder exists in distCp

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/task/CopyHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/task/CopyHandler.java
@@ -81,10 +81,13 @@ public final class CopyHandler {
     } catch (Exception e) {
       throw AlluxioRuntimeException.from(e);
     }
-    if (dstStatus != null && !writeOptions.getOverwrite()) {
+    if (dstStatus != null && dstStatus.isFolder() && sourceStatus.isFolder()) {
+      // skip copy if it's already a folder there
+      return;
+    }
+    if (dstStatus != null && !dstStatus.isFolder() && !writeOptions.getOverwrite()) {
       throw new FailedPreconditionRuntimeException("File " + route.getDst() + " is already in UFS");
     }
-
     if (dstStatus != null && (dstStatus.isFolder() != sourceStatus.isFolder())) {
       throw new InvalidArgumentRuntimeException(
           "Can't replace target because type is not compatible. Target is " + dstStatus


### PR DESCRIPTION
address corner case when rerunning the copy operation of a directory

results in worker log error:
```
2023-07-02 04:28:45,565 ERROR PagedDoraWorker - Failed to move s3://jul02-vvrz-1/Compatibility-TestTool-1.1-alpha/lib to s3://jul02-vvrz-0/TEST1/lib
alluxio.exception.runtime.FailedPreconditionRuntimeException: File s3://jul02-vvrz-0/TEST1/lib is already in UFS
	at alluxio.worker.task.CopyHandler.copy(CopyHandler.java:85)
	at alluxio.worker.dora.PagedDoraWorker.lambda$move$11(PagedDoraWorker.java:631)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at alluxio.worker.grpc.GrpcExecutors$ImpersonateThreadPoolExecutor.lambda$execute$0(GrpcExecutors.java:180)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```