### PR TITLE
Fix lib jar copy dst path

### DIFF
--- a/dora/integration/tools/hms/pom.xml
+++ b/dora/integration/tools/hms/pom.xml
@@ -144,7 +144,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}.jar</argument>
-                <argument>${basedir}/../../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -155,7 +155,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/integration/tools/validation/pom.xml
+++ b/dora/integration/tools/validation/pom.xml
@@ -93,7 +93,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}.jar</argument>
-                <argument>${basedir}/../../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -104,7 +104,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/table/server/underdb/glue/pom.xml
+++ b/dora/table/server/underdb/glue/pom.xml
@@ -128,7 +128,7 @@
                           <arguments>
                               <argument>${project.artifactId}</argument>
                               <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                              <argument>${basedir}/../../../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                              <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
                           </arguments>
                       </configuration>
                   </execution>
@@ -139,7 +139,7 @@
               <configuration>
                   <filesets>
                       <fileset>
-                          <directory>${basedir}/../../../../../lib</directory>
+                          <directory>${build.path}/../lib</directory>
                           <includes>
                               <include>**/${project.artifactId}-*.jar</include>
                           </includes>

--- a/dora/table/server/underdb/hive/pom.xml
+++ b/dora/table/server/underdb/hive/pom.xml
@@ -143,7 +143,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -154,7 +154,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/abfs/pom.xml
+++ b/dora/underfs/abfs/pom.xml
@@ -112,7 +112,7 @@
                             <arguments>
                                 <argument>${project.artifactId}</argument>
                                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -123,7 +123,7 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>${basedir}/../../../lib</directory>
+                            <directory>${build.path}/../lib</directory>
                             <includes>
                                 <include>**/${project.artifactId}-*.jar</include>
                             </includes>

--- a/dora/underfs/adl/pom.xml
+++ b/dora/underfs/adl/pom.xml
@@ -119,7 +119,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -130,7 +130,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/cephfs-hadoop/pom.xml
+++ b/dora/underfs/cephfs-hadoop/pom.xml
@@ -97,7 +97,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -108,7 +108,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/cephfs/pom.xml
+++ b/dora/underfs/cephfs/pom.xml
@@ -84,7 +84,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -95,7 +95,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/cos/pom.xml
+++ b/dora/underfs/cos/pom.xml
@@ -79,7 +79,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -90,7 +90,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/cosn/pom.xml
+++ b/dora/underfs/cosn/pom.xml
@@ -116,7 +116,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -127,7 +127,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/gcs/pom.xml
+++ b/dora/underfs/gcs/pom.xml
@@ -83,7 +83,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -94,7 +94,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/hdfs/pom.xml
+++ b/dora/underfs/hdfs/pom.xml
@@ -167,7 +167,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${ufs.hadoop.version}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${ufs.hadoop.version}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -178,7 +178,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/kodo/pom.xml
+++ b/dora/underfs/kodo/pom.xml
@@ -77,7 +77,7 @@
                             <arguments>
                                 <argument>${project.artifactId}</argument>
                                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -88,7 +88,7 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>${basedir}/../../../lib</directory>
+                            <directory>${build.path}/../lib</directory>
                             <includes>
                                 <include>**/${project.artifactId}-*.jar</include>
                             </includes>

--- a/dora/underfs/local/pom.xml
+++ b/dora/underfs/local/pom.xml
@@ -67,7 +67,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -78,7 +78,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/obs/pom.xml
+++ b/dora/underfs/obs/pom.xml
@@ -87,7 +87,7 @@
                             <arguments>
                                 <argument>${project.artifactId}</argument>
                                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -98,7 +98,7 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>${basedir}/../../../lib</directory>
+                            <directory>${build.path}/../lib</directory>
                             <includes>
                                 <include>**/${project.artifactId}-*.jar</include>
                             </includes>

--- a/dora/underfs/oss/pom.xml
+++ b/dora/underfs/oss/pom.xml
@@ -83,7 +83,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -94,7 +94,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/ozone/pom.xml
+++ b/dora/underfs/ozone/pom.xml
@@ -187,7 +187,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -198,7 +198,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/s3a/pom.xml
+++ b/dora/underfs/s3a/pom.xml
@@ -105,7 +105,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -116,7 +116,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/swift/pom.xml
+++ b/dora/underfs/swift/pom.xml
@@ -74,7 +74,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -85,7 +85,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/wasb/pom.xml
+++ b/dora/underfs/wasb/pom.xml
@@ -119,7 +119,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -130,7 +130,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>

--- a/dora/underfs/web/pom.xml
+++ b/dora/underfs/web/pom.xml
@@ -66,7 +66,7 @@
               <arguments>
                 <argument>${project.artifactId}</argument>
                 <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                <argument>${basedir}/../../../lib/${project.artifactId}-${project.version}.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
               </arguments>
             </configuration>
           </execution>
@@ -77,7 +77,7 @@
         <configuration>
           <filesets>
             <fileset>
-              <directory>${basedir}/../../../lib</directory>
+              <directory>${build.path}/../lib</directory>
               <includes>
                 <include>**/${project.artifactId}-*.jar</include>
               </includes>


### PR DESCRIPTION
less ambiguous to define the dst path from project root rather than from module root. the lib/ directory is more simple to define as `build.path/../lib/`, rather than `module.root/../<some variable number of parent directories>/lib/`