### PR TITLE
Define configurability of update checker

### DIFF
--- a/dora/core/common/src/main/java-templates/alluxio/ProjectConstants.java
+++ b/dora/core/common/src/main/java-templates/alluxio/ProjectConstants.java
@@ -21,8 +21,8 @@ public final class ProjectConstants {
   public static final String REVISION = "${git.revision}";
   /* Hadoop version, specified in maven property. **/
   public static final String HADOOP_VERSION = "${hadoop.version}";
-  /* Whether update check is enabled. **/
-  public static final String UPDATE_CHECK_ENABLED = "${update.check.enabled}";
+  /* Whether update check is configurable. **/
+  public static final String UPDATE_CHECK_CONFIGURABLE = "${update.check.configurable}";
   /* Update check host. **/
   public static final String UPDATE_CHECK_HOST = "${update.check.host}";
   /* Update check auth string. **/

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3617,9 +3617,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_UPDATE_CHECK_ENABLED =
       booleanBuilder(Name.MASTER_UPDATE_CHECK_ENABLED)
-          .setDefaultValue(Boolean.parseBoolean(ProjectConstants.UPDATE_CHECK_ENABLED))
-          .setDescription("Whether to check for update availability.")
+          .setDefaultValue(true)
+          .setDescription("Whether to check for update availability")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setIsHidden(true)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_UPDATE_CHECK_INTERVAL =
@@ -3627,6 +3628,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue("7day")
           .setDescription("The interval to check for update availability.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setIsHidden(true)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_UNSAFE_DIRECT_PERSIST_OBJECT_ENABLED =

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
     <surefire.rerunFailingTestsCount>1</surefire.rerunFailingTestsCount>
     <test.output.redirect>true</test.output.redirect>
     <update.check.auth.string>YWxsdXhpbzp0YWNoeW9u</update.check.auth.string>
-    <update.check.enabled>true</update.check.enabled>
+    <update.check.configurable>true</update.check.configurable>
     <update.check.host>https://diagnostics.alluxio.io</update.check.host>
     <findbugs.skip>false</findbugs.skip>
     <create.dependency.reduced.pom>false</create.dependency.reduced.pom>


### PR DESCRIPTION
define new property for configurability of update checker, to be used in conjunction with the update checker enabled property. previously the enabled property has its default value set as a build time constant, but the value could be overridden if set in configuration. now the configurability value, which is set at build time, determines if the enabled property can be configured, and if it is, uses its corresponding value. this pattern allows us to lock the enabled value at build time such that a published jar cannot override this enabled property.
