### PR TITLE
Change to use the new way to get the ETag of the file

### DIFF
--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5952,6 +5952,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_FILE_METADATA_LOAD_REAL_CONTENT_HASH =
+      booleanBuilder(Name.USER_FILE_METADATA_LOAD_REAL_CONTENT_HASH)
+          .setDefaultValue(false)
+          .setDescription("Whether to get real content hash of file when the file is loaded "
+              + "from UFS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey USER_FILE_PASSIVE_CACHE_ENABLED =
       booleanBuilder(Name.USER_FILE_PASSIVE_CACHE_ENABLED)
           .setDefaultValue(true)
@@ -9192,6 +9200,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.file.metadata.load.type";
     public static final String USER_FILE_METADATA_SYNC_INTERVAL =
         "alluxio.user.file.metadata.sync.interval";
+    public static final String USER_FILE_METADATA_LOAD_REAL_CONTENT_HASH =
+        "alluxio.user.file.metadata.real.content.hash";
     public static final String USER_FILE_PASSIVE_CACHE_ENABLED =
         "alluxio.user.file.passive.cache.enabled";
     public static final String USER_FILE_READ_TYPE_DEFAULT = "alluxio.user.file.readtype.default";

--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -544,12 +544,12 @@ public final class S3RestUtils {
    * @return the entityTag String, or null if it does not exist
    */
   public static String getEntityTag(URIStatus status) {
-    if (status.getXAttr() == null
-        || !status.getXAttr().containsKey(S3Constants.ETAG_XATTR_KEY)) {
+    String contenthash = status.getFileInfo().getContentHash();
+    if (StringUtils.isNotEmpty(contenthash)) {
+      return contenthash;
+    } else {
       return null;
     }
-    return new String(status.getXAttr().get(S3Constants.ETAG_XATTR_KEY),
-        S3Constants.XATTR_STR_CHARSET);
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Using the content hash of the file to be the ETag in the s3 api. Add a property key to decide whether to get real content hash when loading file meta from ufs.

### Why are the changes needed?
Now we no longer use Xattr to store the etag of the file. And alluxio adds a new option to get real content hash.

### Does this PR introduce any user facing changes?
No
