### PR TITLE
fix the way to calculate content md5 in localUnderFileSystem

### DIFF
--- a/dora/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/dora/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -39,9 +39,9 @@ import alluxio.util.network.NetworkAddressUtils.ServiceType;
 import com.google.common.base.Strings;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
-import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteSource;
 import com.google.common.io.ByteStreams;
+import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -294,7 +294,7 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
     if (isRealContentHash) {
       ByteSource byteSource = com.google.common.io.Files.asByteSource(file);
       HashCode hashCode = byteSource.hash(Hashing.md5());
-      contentHash = BaseEncoding.base64().encode(hashCode.asBytes());
+      contentHash = Hex.encodeHexString(hashCode.asBytes());
     }
     else {
       contentHash =


### PR DESCRIPTION
### What changes are proposed in this pull request?
change the way to calculate the content hash of files from localUnderFileSystem to get the md5 of content.

### Why are the changes needed?


### Does this PR introduce any user facing changes?
no
