### PR TITLE
Enable Dora write through worker to UFS

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -81,6 +81,8 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
   private final boolean mUfsFallbackEnabled;
   private final long mDefaultVirtualBlockSize;
 
+  private final boolean mClientWriteToUFSEnabled;
+
   /**
    * DoraCacheFileSystem Factory.
    */
@@ -122,6 +124,8 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
         .getBoolean(PropertyKey.DORA_CLIENT_UFS_FALLBACK_ENABLED);
     mDefaultVirtualBlockSize = context.getClusterConf()
         .getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
+    mClientWriteToUFSEnabled = context.getClusterConf()
+        .getBoolean(PropertyKey.CLIENT_WRITE_TO_UFS_ENABLED);
   }
 
   @Override
@@ -275,8 +279,16 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
       outStreamOptions.setMountId(status.getMountId());
       outStreamOptions.setAcl(status.getAcl());
 
+      FileOutStream ufsOutStream;
+      if (mClientWriteToUFSEnabled) {
+        // create an output stream to UFS.
+        ufsOutStream = mDelegatedFileSystem.createFile(ufsFullPath, options);
+      } else {
+        ufsOutStream = null;
+      }
+
       FileOutStream doraOutStream = mDoraClient.getOutStream(ufsFullPath, mFsContext,
-          outStreamOptions, uuid);
+          outStreamOptions, ufsOutStream, uuid);
 
       return doraOutStream;
     } catch (Exception e) {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -275,10 +275,8 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
       outStreamOptions.setMountId(status.getMountId());
       outStreamOptions.setAcl(status.getAcl());
 
-      FileOutStream ufsOutStream = mDelegatedFileSystem.createFile(ufsFullPath, options);
-
       FileOutStream doraOutStream = mDoraClient.getOutStream(ufsFullPath, mFsContext,
-          outStreamOptions, ufsOutStream, uuid);
+          outStreamOptions, uuid);
 
       return doraOutStream;
     } catch (Exception e) {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraFileOutStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraFileOutStream.java
@@ -155,12 +155,10 @@ public class DoraFileOutStream extends FileOutStream {
 
       if (mUnderStorageType.isSyncPersist()) {
         try {
-          if (mCanceled) {
-            if (mUnderStorageOutputStream != null) {
+          if (mUnderStorageOutputStream != null) {
+            if (mCanceled) {
               mUnderStorageOutputStream.cancel();
-            }
-          } else {
-            if (mUnderStorageOutputStream != null) {
+            } else {
               mUnderStorageOutputStream.flush();
             }
           }

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraFileOutStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraFileOutStream.java
@@ -99,7 +99,6 @@ public class DoraFileOutStream extends FileOutStream {
       mCanceled = false;
       mWriteToAlluxio = mAlluxioStorageType.isStore();
       mBytesWritten = 0;
-
     } catch (Throwable t) {
       throw CommonUtils.closeAndRethrow(mCloser, t);
     }
@@ -187,7 +186,6 @@ public class DoraFileOutStream extends FileOutStream {
       if (mWriteToAlluxio) {
         mNettyDataWriter.writeChunk(b, off, len);
         Metrics.BYTES_WRITTEN_ALLUXIO.inc(len);
-        System.out.println("Writing @" + off + " len=" + len);
       }
       mBytesWritten += len;
     } catch (IOException e) {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
@@ -20,6 +20,7 @@ import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.client.block.stream.GrpcDataReader;
 import alluxio.client.file.DoraFileOutStream;
+import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.PositionReadFileInStream;
 import alluxio.client.file.URIStatus;
@@ -64,6 +65,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Dora cache client.
@@ -118,16 +120,18 @@ public class DoraCacheClient {
    * @param alluxioPath the alluxio path to be written
    * @param fsContext the file system context
    * @param outStreamOptions the output stream options
+   * @param ufsOutStream the UfsOutStream for writing data to UFS
    * @param uuid the UUID for a certain FileOutStream
    * @return the output stream
    */
   public DoraFileOutStream getOutStream(AlluxioURI alluxioPath, FileSystemContext fsContext,
-      OutStreamOptions outStreamOptions, String uuid) throws IOException {
+      OutStreamOptions outStreamOptions, @Nullable FileOutStream ufsOutStream,
+      String uuid) throws IOException {
     WorkerNetAddress workerNetAddress = getWorkerNetAddress(alluxioPath.toString());
     NettyDataWriter writer = NettyDataWriter.create(
         fsContext, workerNetAddress, Long.MAX_VALUE, RequestType.ALLUXIO_BLOCK, outStreamOptions);
     return new DoraFileOutStream(this, writer, alluxioPath,
-        outStreamOptions, fsContext, uuid);
+        outStreamOptions, fsContext, ufsOutStream, uuid);
   }
 
   protected long getChunkSize() {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
@@ -20,7 +20,6 @@ import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.client.block.stream.GrpcDataReader;
 import alluxio.client.file.DoraFileOutStream;
-import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.PositionReadFileInStream;
 import alluxio.client.file.URIStatus;

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
@@ -119,18 +119,16 @@ public class DoraCacheClient {
    * @param alluxioPath the alluxio path to be written
    * @param fsContext the file system context
    * @param outStreamOptions the output stream options
-   * @param ufsOutStream the UfsOutStream for writing data to UFS
    * @param uuid the UUID for a certain FileOutStream
    * @return the output stream
    */
   public DoraFileOutStream getOutStream(AlluxioURI alluxioPath, FileSystemContext fsContext,
-      OutStreamOptions outStreamOptions, FileOutStream ufsOutStream,
-      String uuid) throws IOException {
+      OutStreamOptions outStreamOptions, String uuid) throws IOException {
     WorkerNetAddress workerNetAddress = getWorkerNetAddress(alluxioPath.toString());
     NettyDataWriter writer = NettyDataWriter.create(
         fsContext, workerNetAddress, Long.MAX_VALUE, RequestType.ALLUXIO_BLOCK, outStreamOptions);
     return new DoraFileOutStream(this, writer, alluxioPath,
-        outStreamOptions, fsContext, ufsOutStream, uuid);
+        outStreamOptions, fsContext, uuid);
   }
 
   protected long getChunkSize() {

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -7877,6 +7877,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.WORKER)
           .build();
 
+  public static final PropertyKey CLIENT_WRITE_TO_UFS_ENABLED =
+      booleanBuilder(Name.CLIENT_WRITE_TO_UFS_ENABLED)
+          .setDescription("Whether or not to enable client writing data directly to UFS. "
+              + "If enabled, client writes data to worker (to be cached in Paging Store) and "
+              + "to UFS (to be stored permanently). Client need UFS credentials in this case. "
+              + "Enabled by default.")
+          .setDefaultValue(true)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.ALL)
+          .build();
+
   //
   // Extra class to be loaded
   //
@@ -9511,6 +9522,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String DORA_UFS_LIST_STATUS_CACHE_NR_FILES =
         "alluxio.dora.ufs.list.status.cache.nr.files";
 
+    public static final String CLIENT_WRITE_TO_UFS_ENABLED =
+        "alluxio.client.write.to.ufs.enabled";
     //
     // Extra class to be loaded
     //

--- a/dora/core/common/src/main/java/alluxio/worker/dora/OpenFileHandle.java
+++ b/dora/core/common/src/main/java/alluxio/worker/dora/OpenFileHandle.java
@@ -11,6 +11,7 @@
 
 package alluxio.worker.dora;
 
+import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.FileInfo;
 
 import java.io.IOException;
@@ -30,13 +31,17 @@ public class OpenFileHandle {
   private OutputStream   mOutStream; //outstream from UFS
   private boolean        mClosed;
 
+  private final CreateFilePOptions mOptions;
+
   /**
    * Construct a new open file handle.
-   * @param path
-   * @param info
-   * @param outStream
+   * @param path the path of the file
+   * @param info the FileInfo of this file
+   * @param options the options of create
+   * @param outStream the UFS output stream of this file
    */
-  public OpenFileHandle(String path, FileInfo info, @Nullable OutputStream outStream) {
+  public OpenFileHandle(String path, FileInfo info, CreateFilePOptions options,
+                        @Nullable OutputStream outStream) {
     mPath = path;
     mInfo = info;
     // TODO(Hua): The operation of generating UUID is SLOW. We can replace it in other way.
@@ -45,6 +50,7 @@ public class OpenFileHandle {
     mPos = 0L;
     mLastAccessTimeMs = System.currentTimeMillis();
     mClosed = false;
+    mOptions = options;
   }
 
   /**
@@ -93,6 +99,14 @@ public class OpenFileHandle {
    */
   public OutputStream getOutStream() {
     return mOutStream;
+  }
+
+  /**
+   * Get Alluxio create file options.
+   * @return the CreateFilePOptions of this operation
+   */
+  public CreateFilePOptions getOptions() {
+    return mOptions;
   }
 
   /**

--- a/dora/core/common/src/main/java/alluxio/worker/dora/OpenFileHandle.java
+++ b/dora/core/common/src/main/java/alluxio/worker/dora/OpenFileHandle.java
@@ -28,7 +28,7 @@ public class OpenFileHandle {
   private final UUID     mUUID;
   private long           mPos;
   private long           mLastAccessTimeMs;
-  private OutputStream   mOutStream; //outstream from UFS
+  private OutputStream   mUfsOutStream; //outstream from UFS
   private boolean        mClosed;
 
   private final CreateFilePOptions mOptions;
@@ -38,15 +38,15 @@ public class OpenFileHandle {
    * @param path the path of the file
    * @param info the FileInfo of this file
    * @param options the options of create
-   * @param outStream the UFS output stream of this file
+   * @param ufsOutStream the UFS output stream of this file
    */
   public OpenFileHandle(String path, FileInfo info, CreateFilePOptions options,
-                        @Nullable OutputStream outStream) {
+                        @Nullable OutputStream ufsOutStream) {
     mPath = path;
     mInfo = info;
     // TODO(Hua): The operation of generating UUID is SLOW. We can replace it in other way.
     mUUID = UUID.randomUUID();
-    mOutStream = outStream;
+    mUfsOutStream = ufsOutStream;
     mPos = 0L;
     mLastAccessTimeMs = System.currentTimeMillis();
     mClosed = false;
@@ -98,7 +98,7 @@ public class OpenFileHandle {
    * @return UFS out stream of this handle
    */
   public OutputStream getOutStream() {
-    return mOutStream;
+    return mUfsOutStream;
   }
 
   /**
@@ -122,10 +122,10 @@ public class OpenFileHandle {
    */
   public void close() {
     mClosed = true;
-    if (mOutStream != null) {
+    if (mUfsOutStream != null) {
       try {
-        mOutStream.close();
-        mOutStream = null;
+        mUfsOutStream.close();
+        mUfsOutStream = null;
       } catch (IOException e) {
         //Ignored
       }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -332,7 +332,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
     if (fileLength > 0) {
       cachedPercentage = (int) (bytesInCache * 100 / fileLength);
     } else {
-      cachedPercentage = 0;
+      cachedPercentage = 100;
     }
     return cachedPercentage;
   }
@@ -383,8 +383,9 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
       if (fileLength > 0) {
         cachedPercentage = (int) (bytesInCache * 100 / fileLength);
       } else {
-        cachedPercentage = 0;
+        cachedPercentage = 100;
       }
+
       infoBuilder.setInAlluxioPercentage(cachedPercentage)
           .setInMemoryPercentage(cachedPercentage);
     }
@@ -678,7 +679,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
     }
     OutputStream outStream = mUfs.create(path, createOption);
 
-    OpenFileHandle handle = new OpenFileHandle(path, info, outStream);
+    OpenFileHandle handle = new OpenFileHandle(path, info, options, outStream);
     //add to map.
     mOpenFileHandleContainer.add(path, handle);
 

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -101,6 +101,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -427,7 +428,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
   @Override
   public BlockWriter createFileWriter(String fileId, String ufsPath)
       throws AccessControlException, IOException {
-    return new PagedFileWriter(mCacheManager, fileId, mPageSize);
+    return new PagedFileWriter(this, ufsPath, mCacheManager, fileId, mPageSize);
   }
 
   @Override
@@ -672,8 +673,9 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+    OutputStream outStream = mUfs.create(path, createOption);
 
-    OpenFileHandle handle = new OpenFileHandle(path, info, null);
+    OpenFileHandle handle = new OpenFileHandle(path, info, outStream);
     //add to map.
     mOpenFileHandleContainer.add(path, handle);
 

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -645,6 +645,9 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
     if (options.hasMode()) {
       createOption.setMode(new Mode(ModeUtils.protoToShort(options.getMode())));
     }
+    if (options.hasRecursive() && options.getRecursive()) {
+      createOption.setCreateParent(true);
+    }
 
     try {
       // Check if the target file already exists. If yes, return by throwing error.

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileWriter.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileWriter.java
@@ -97,8 +97,10 @@ public class PagedFileWriter extends BlockWriter {
       }
       // Now writes data to UFS.
       if (handle != null) {
-        OutputStream outputStream = Preconditions.checkNotNull(handle.getOutStream());
-        outputStream.write(page);
+        OutputStream outputStream = handle.getOutStream();
+        if (outputStream != null) {
+          outputStream.write(page);
+        }
       } else {
         throw new IOException("Cannot write data to UFS for " + mUfsPath + " @" + mPosition);
       }

--- a/dora/tests/src/test/java/alluxio/client/fs/DoraFileSystemIntegrationTest.java
+++ b/dora/tests/src/test/java/alluxio/client/fs/DoraFileSystemIntegrationTest.java
@@ -59,17 +59,6 @@ public final class DoraFileSystemIntegrationTest extends BaseIntegrationTest {
       .withCredentials("_", "_")
       .build();
 
-  private static final String TEST_BUCKET = "test-bucket";
-  private static final String TEST_FILE = "test-file";
-  private static final AlluxioURI TEST_FILE_URI = new AlluxioURI("/" + "test-file");
-  private static final String TEST_CONTENT = "test-content";
-  private static final String UPDATED_TEST_CONTENT = "updated-test-content";
-
-  private FileSystem mFileSystem = null;
-  @Rule
-  public ExpectedException mThrown = ExpectedException.none();
-  private AmazonS3 mS3Client = null;
-
   LocalAlluxioClusterResource.Builder mLocalAlluxioClusterResourceBuilder =
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS, "10ms")
@@ -94,6 +83,17 @@ public final class DoraFileSystemIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.S3A_SECRET_KEY, mS3Proxy.getSecretKey())
           .setNumWorkers(2)
           .setStartCluster(false);
+
+  private static final String TEST_BUCKET = "test-bucket";
+  private static final String TEST_FILE = "test-file";
+  private static final AlluxioURI TEST_FILE_URI = new AlluxioURI("/" + "test-file");
+  private static final String TEST_CONTENT = "test-content";
+  private static final String UPDATED_TEST_CONTENT = "updated-test-content";
+
+  private FileSystem mFileSystem = null;
+  @Rule
+  public ExpectedException mThrown = ExpectedException.none();
+  private AmazonS3 mS3Client = null;
 
   @Before
   public void before() throws Exception {

--- a/dora/tests/src/test/java/alluxio/client/fs/DoraFileSystemIntegrationTest.java
+++ b/dora/tests/src/test/java/alluxio/client/fs/DoraFileSystemIntegrationTest.java
@@ -59,8 +59,18 @@ public final class DoraFileSystemIntegrationTest extends BaseIntegrationTest {
       .withCredentials("_", "_")
       .build();
 
+  private static final String TEST_BUCKET = "test-bucket";
+  private static final String TEST_FILE = "test-file";
+  private static final AlluxioURI TEST_FILE_URI = new AlluxioURI("/" + "test-file");
+  private static final String TEST_CONTENT = "test-content";
+  private static final String UPDATED_TEST_CONTENT = "updated-test-content";
+
+  private FileSystem mFileSystem = null;
   @Rule
-  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
+  public ExpectedException mThrown = ExpectedException.none();
+  private AmazonS3 mS3Client = null;
+
+  LocalAlluxioClusterResource.Builder mLocalAlluxioClusterResourceBuilder =
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS, "10ms")
           .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "10ms")
@@ -83,36 +93,36 @@ public final class DoraFileSystemIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.S3A_ACCESS_KEY, mS3Proxy.getAccessKey())
           .setProperty(PropertyKey.S3A_SECRET_KEY, mS3Proxy.getSecretKey())
           .setNumWorkers(2)
-          .setStartCluster(false)
-          .build();
-
-  private static final String TEST_BUCKET = "test-bucket";
-  private static final String TEST_FILE = "test-file";
-  private static final AlluxioURI TEST_FILE_URI = new AlluxioURI("/" + "test-file");
-  private static final String TEST_CONTENT = "test-content";
-  private static final String UPDATED_TEST_CONTENT = "updated-test-content";
-
-  private FileSystem mFileSystem = null;
-  @Rule
-  public ExpectedException mThrown = ExpectedException.none();
-  private AmazonS3 mS3Client = null;
+          .setStartCluster(false);
 
   @Before
   public void before() throws Exception {
-    mLocalAlluxioClusterResource.start();
-    mFileSystem = mLocalAlluxioClusterResource.get().getClient();
+  }
 
-    mS3Client = AmazonS3ClientBuilder
-        .standard()
-        .withPathStyleAccessEnabled(true)
-        .withCredentials(
-            new AWSStaticCredentialsProvider(
-                new BasicAWSCredentials(mS3Proxy.getAccessKey(), mS3Proxy.getSecretKey())))
-        .withEndpointConfiguration(
-            new AwsClientBuilder.EndpointConfiguration(mS3Proxy.getUri().toString(),
-                Regions.US_WEST_2.getName()))
-        .build();
-    mS3Client.createBucket(TEST_BUCKET);
+  private void startCluster(LocalAlluxioClusterResource cluster) throws Exception
+  {
+    cluster.start();
+    mFileSystem = cluster.get().getClient();
+
+    if (mS3Client == null) {
+      mS3Client = AmazonS3ClientBuilder
+          .standard()
+          .withPathStyleAccessEnabled(true)
+          .withCredentials(
+              new AWSStaticCredentialsProvider(
+                  new BasicAWSCredentials(mS3Proxy.getAccessKey(), mS3Proxy.getSecretKey())))
+          .withEndpointConfiguration(
+              new AwsClientBuilder.EndpointConfiguration(mS3Proxy.getUri().toString(),
+                  Regions.US_WEST_2.getName()))
+          .build();
+      mS3Client.createBucket(TEST_BUCKET);
+    }
+  }
+
+  private void stopCluster(LocalAlluxioClusterResource cluster) throws Exception
+  {
+    mFileSystem = null;
+    cluster.stop();
   }
 
   /**
@@ -120,8 +130,13 @@ public final class DoraFileSystemIntegrationTest extends BaseIntegrationTest {
    * Read the file with sync interval setting to -1 should give the cached file.
    * Read the file with sync interval setting to 0 should return error.
    */
-  @Test
-  public void writeThenDeleteFromUfs() throws IOException, AlluxioException {
+  private void writeThenDeleteFromUfs(boolean clientWriteToUFS)
+      throws IOException, AlluxioException, Exception {
+    mLocalAlluxioClusterResourceBuilder.setProperty(PropertyKey.CLIENT_WRITE_TO_UFS_ENABLED,
+                                                    clientWriteToUFS);
+    LocalAlluxioClusterResource clusterResource = mLocalAlluxioClusterResourceBuilder.build();
+    startCluster(clusterResource);
+
     FileOutStream fos = mFileSystem.createFile(TEST_FILE_URI,
         CreateFilePOptions.newBuilder().setOverwrite(true).build());
     fos.write(TEST_CONTENT.getBytes());
@@ -144,6 +159,8 @@ public final class DoraFileSystemIntegrationTest extends BaseIntegrationTest {
     assertThrows(FileDoesNotExistException.class, () ->
         mFileSystem.getStatus(TEST_FILE_URI, GetStatusPOptions.newBuilder()
             .setCommonOptions(optionNoSync()).build()));
+
+    stopCluster(clusterResource);
   }
 
   /**
@@ -151,8 +168,13 @@ public final class DoraFileSystemIntegrationTest extends BaseIntegrationTest {
    * Read the file with sync interval setting to -1 should give the cached file.
    * Read the file with sync interval setting to 0 should return the updated file content.
    */
-  @Test
-  public void writeThenUpdateFromUfs() throws IOException, AlluxioException {
+  private void writeThenUpdateFromUfs(boolean clientWriteToUFS)
+      throws IOException, AlluxioException, Exception {
+    mLocalAlluxioClusterResourceBuilder.setProperty(PropertyKey.CLIENT_WRITE_TO_UFS_ENABLED,
+                                                    clientWriteToUFS);
+    LocalAlluxioClusterResource clusterResource = mLocalAlluxioClusterResourceBuilder.build();
+    startCluster(clusterResource);
+
     FileOutStream fos = mFileSystem.createFile(TEST_FILE_URI,
         CreateFilePOptions.newBuilder().setOverwrite(true).build());
     fos.write(TEST_CONTENT.getBytes());
@@ -180,6 +202,8 @@ public final class DoraFileSystemIntegrationTest extends BaseIntegrationTest {
       String content = IOUtils.toString(fis);
       assertEquals(UPDATED_TEST_CONTENT, content);
     }
+
+    stopCluster(clusterResource);
   }
 
   private FileSystemMasterCommonPOptions optionNoSync() {
@@ -190,5 +214,27 @@ public final class DoraFileSystemIntegrationTest extends BaseIntegrationTest {
   private FileSystemMasterCommonPOptions optionSync() {
     return FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(0)
             .build();
+  }
+
+  /**
+   * Writes a file through alluxio into UFS. Deletes the file from UFS.
+   * Read the file with sync interval setting to -1 should give the cached file.
+   * Read the file with sync interval setting to 0 should return error.
+   */
+  @Test
+  public void testWriteThenDeleteFromUfs() throws Exception {
+    writeThenDeleteFromUfs(true);
+    writeThenDeleteFromUfs(false);
+  }
+
+  /**
+   * Writes a file through alluxio into UFS, then updates the file from UFS.
+   * Read the file with sync interval setting to -1 should give the cached file.
+   * Read the file with sync interval setting to 0 should return the updated file content.
+   */
+  @Test
+  public void testWriteThenUpdateFromUfs() throws Exception {
+    writeThenUpdateFromUfs(true);
+    writeThenUpdateFromUfs(false);
   }
 }

--- a/dora/tests/src/test/java/alluxio/client/fs/UnderStorageReadIntegrationTest.java
+++ b/dora/tests/src/test/java/alluxio/client/fs/UnderStorageReadIntegrationTest.java
@@ -32,7 +32,6 @@ import alluxio.util.io.PathUtils;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -83,12 +82,16 @@ public class UnderStorageReadIntegrationTest extends BaseIntegrationTest {
    * Tests single byte reads from the underfs.
    */
   @Test
-  @Ignore
   public void read() throws Exception {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       AlluxioURI uri = new AlluxioURI(uniqPath + "/file_" + k);
       FileSystemTestUtils.createByteFile(mFileSystem, uri, mWriteUnderStore, k);
+      if (k == 0) {
+        Assert.assertEquals(100, mFileSystem.getStatus(uri).getInAlluxioPercentage());
+      } else {
+        Assert.assertNotEquals(100, mFileSystem.getStatus(uri).getInAlluxioPercentage());
+      }
 
       FileInStream is = mFileSystem.openFile(uri, mReadNoCache);
       byte[] ret = new byte[k];
@@ -106,7 +109,8 @@ public class UnderStorageReadIntegrationTest extends BaseIntegrationTest {
       if (k == 0) {
         Assert.assertEquals(100, mFileSystem.getStatus(uri).getInAlluxioPercentage());
       } else {
-        Assert.assertNotEquals(100, mFileSystem.getStatus(uri).getInAlluxioPercentage());
+        // At this moment, Alluxio has not handled the ReadPType.NO_CACHE
+        Assert.assertEquals(100, mFileSystem.getStatus(uri).getInAlluxioPercentage());
       }
 
       FileInStream isCache = mFileSystem.openFile(uri, mReadCache);


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Clients write data to worker and worker write data to local paging cache and UFS. 
   Added a switch to control this. The default way is client writing directly to UFS.
- WriteType.THROUGH is handled.
- InAlluxioPercentage and inMemoryPercentage is set to 100 when file length is zero.

### Why are the changes needed?

So Alluxio workers can do some control, e.g. security, flow, quota, on worker. This also avoid managing UFS access tokens on clients, minimize performance bottles on client.
TODO: worker decides writing data to local paging cache or remote UFS based on different write types.
For example, for CACHE_THROUGH, data is going to local paging store and UFS.
For THROUGH, data is ONLY going to UFS.
### Does this PR introduce any user facing changes?

N/A
