### PR TITLE
Fix worker policy race condition

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -111,7 +111,7 @@ public class WorkerLocationPolicy {
     // let one caller initialize the map while blocking all others.
     private void maybeInitialize(List<BlockWorkerInfo> workerInfos, int numVirtualNodes) {
       if (mActiveNodesByConsistentHashing == null) {
-        synchronized (mActiveNodesByConsistentHashing) {
+        synchronized (ConsistentHashProvider.class) {
           // only one thread should reach here
           // test again to skip re-initialization
           if (mActiveNodesByConsistentHashing == null) {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -70,7 +70,7 @@ public class WorkerLocationPolicy {
     private static final int MAX_ATTEMPTS = 100;
     private volatile List<BlockWorkerInfo> mLastWorkerInfos = ImmutableList.of();
     private final AtomicReference<NavigableMap<Integer, BlockWorkerInfo>>
-        mActiveNodesByConsistentHashing = new AtomicReference<>();
+        mActiveNodesByConsistentHashing = new AtomicReference<>(new TreeMap<>());
 
     private volatile long mLastUpdatedTimestamp = 0L;
 

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -79,6 +79,7 @@ public class WorkerLocationPolicy {
     @Nullable
     private volatile NavigableMap<Integer, BlockWorkerInfo> mActiveNodesByConsistentHashing;
     // Must use System.nanoTime to ensure monotonic increment
+    private final AtomicLong mUpdateCount = new AtomicLong(0);
 
     public ConsistentHashProvider(int maxAttempts, long workerListTtlMs) {
       mMaxAttempts = maxAttempts;
@@ -106,6 +107,7 @@ public class WorkerLocationPolicy {
           if (hasWorkerListChanged(workerInfos, mLastWorkerInfos)) {
             mActiveNodesByConsistentHashing = build(workerInfos, numVirtualNodes);
             mLastWorkerInfos = workerInfos;
+            mUpdateCount.incrementAndGet();
           }
         }
         // else, do nothing and proceed with stale worker list. on next access, the worker list
@@ -182,6 +184,11 @@ public class WorkerLocationPolicy {
     @VisibleForTesting
     NavigableMap<Integer, BlockWorkerInfo> getActiveNodesMap() {
       return mActiveNodesByConsistentHashing;
+    }
+
+    @VisibleForTesting
+    long getUpdateCount() {
+      return mUpdateCount.get();
     }
 
     @VisibleForTesting

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -80,6 +80,7 @@ public class WorkerLocationPolicy {
     private volatile NavigableMap<Integer, BlockWorkerInfo> mActiveNodesByConsistentHashing;
     // Must use System.nanoTime to ensure monotonic increment
     private final AtomicLong mUpdateCount = new AtomicLong(0);
+    private final Object mInitLock = new Object();
 
     public ConsistentHashProvider(int maxAttempts, long workerListTtlMs) {
       mMaxAttempts = maxAttempts;
@@ -120,7 +121,7 @@ public class WorkerLocationPolicy {
     // let one caller initialize the map while blocking all others.
     private void maybeInitialize(List<BlockWorkerInfo> workerInfos, int numVirtualNodes) {
       if (mActiveNodesByConsistentHashing == null) {
-        synchronized (ConsistentHashProvider.class) {
+        synchronized (mInitLock) {
           // only one thread should reach here
           // test again to skip re-initialization
           if (mActiveNodesByConsistentHashing == null) {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -16,6 +16,7 @@ import static java.lang.Math.ceil;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
@@ -28,9 +29,10 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * An impl of WorkerLocationPolicy.
@@ -68,33 +70,62 @@ public class WorkerLocationPolicy {
   private static class ConsistentHashProvider {
     private static final HashFunction HASH_FUNCTION = murmur3_32_fixed();
     private static final int MAX_ATTEMPTS = 100;
+    private static final long WORKER_INFO_UPDATE_INTERVAL_NS = Constants.SECOND_NANO;
     private volatile List<BlockWorkerInfo> mLastWorkerInfos = ImmutableList.of();
-    private final AtomicReference<NavigableMap<Integer, BlockWorkerInfo>>
-        mActiveNodesByConsistentHashing = new AtomicReference<>(new TreeMap<>());
+    // Can only be null before the first call to refresh
+    @Nullable
+    private volatile NavigableMap<Integer, BlockWorkerInfo> mActiveNodesByConsistentHashing;
+    private final Semaphore mInitLock = new Semaphore(1);
 
-    private volatile long mLastUpdatedTimestamp = 0L;
+    // Must use System.nanoTime to ensure monotonic increment
+    private final AtomicLong mLastUpdatedTimestamp = new AtomicLong(System.nanoTime());
 
-    private final AtomicBoolean mNeedUpdate = new AtomicBoolean(false);
-
-    private static final long WORKER_INFO_UPDATE_INTERVAL_MS = 1000L;
-
+    /**
+     * Initializes or refreshes the worker list using the given list of workers and number of
+     * virtual nodes.
+     */
     public void refresh(List<BlockWorkerInfo> workerInfos, int numVirtualNodes) {
-      // check if we need to update worker info
-      if (mLastUpdatedTimestamp <= 0L
-          || System.currentTimeMillis() - mLastUpdatedTimestamp > WORKER_INFO_UPDATE_INTERVAL_MS) {
-        mNeedUpdate.set(true);
-      }
-      // update worker info if needed
-      if (mNeedUpdate.compareAndSet(true, false)) {
-        if (isWorkerInfoUpdated(workerInfos, mLastWorkerInfos)) {
-          build(workerInfos, numVirtualNodes);
+      // When the active nodes map does not exist, the hash provider is not initialized yet.
+      // let one caller initialize the map while blocking all others.
+      if (mActiveNodesByConsistentHashing == null) {
+        mInitLock.acquireUninterruptibly();
+        // only one thread should reach here
+        // test again to skip re-initialization
+        if (mActiveNodesByConsistentHashing == null) {
+          try {
+            mActiveNodesByConsistentHashing = build(workerInfos, numVirtualNodes);
+          } finally {
+            mLastWorkerInfos = workerInfos;
+            mLastUpdatedTimestamp.set(System.nanoTime());
+            mInitLock.release();
+          }
         }
-        mLastUpdatedTimestamp = System.currentTimeMillis();
+      }
+      // check if the worker list has expired
+      long lastUpdateTs = mLastUpdatedTimestamp.get();
+      long currentTs = System.nanoTime();
+      if (currentTs - lastUpdateTs > WORKER_INFO_UPDATE_INTERVAL_NS) {
+        // use CAS to only allow one thread to actually update the timestamp
+        boolean casUpdated = mLastUpdatedTimestamp.compareAndSet(lastUpdateTs, currentTs);
+        // thread safety is valid provided that build() takes less than
+        // WORKER_INFO_UPDATE_INTERVAL_NS, so that before next update the current update has been
+        // finished
+        if (casUpdated) {
+          if (hasWorkerListChanged(workerInfos, mLastWorkerInfos)) {
+            try {
+              mActiveNodesByConsistentHashing = build(workerInfos, numVirtualNodes);
+            } finally {
+              mLastWorkerInfos = workerInfos;
+            }
+          }
+        }
+        // else, do nothing and proceed with stale worker list. on next access, the worker list
+        // will have been updated by another thread
       }
     }
 
-    private boolean isWorkerInfoUpdated(List<BlockWorkerInfo> workerInfoList,
-                                        List<BlockWorkerInfo> anotherWorkerInfoList) {
+    private boolean hasWorkerListChanged(List<BlockWorkerInfo> workerInfoList,
+                                         List<BlockWorkerInfo> anotherWorkerInfoList) {
       if (workerInfoList == anotherWorkerInfoList) {
         return false;
       }
@@ -117,16 +148,24 @@ public class WorkerLocationPolicy {
 
     public BlockWorkerInfo get(String key, int index) {
       int hashKey = HASH_FUNCTION.hashString(format("%s%d", key, index), UTF_8).asInt();
-      NavigableMap<Integer, BlockWorkerInfo> map = mActiveNodesByConsistentHashing.get();
+      NavigableMap<Integer, BlockWorkerInfo> map = mActiveNodesByConsistentHashing;
+      if (map == null) {
+        throw new IllegalStateException("Hash provider is not properly initialized");
+      }
       Map.Entry<Integer, BlockWorkerInfo> entry = map.ceilingEntry(hashKey);
       if (entry != null) {
         return entry.getValue();
       } else {
-        return map.firstEntry().getValue();
+        Map.Entry<Integer, BlockWorkerInfo> firstEntry = map.firstEntry();
+        if (firstEntry == null) {
+          throw new IllegalStateException("Hash provider is empty");
+        }
+        return firstEntry.getValue();
       }
     }
 
-    private void build(List<BlockWorkerInfo> workerInfos, int numVirtualNodes) {
+    private static NavigableMap<Integer, BlockWorkerInfo> build(
+        List<BlockWorkerInfo> workerInfos, int numVirtualNodes) {
       NavigableMap<Integer, BlockWorkerInfo> activeNodesByConsistentHashing = new TreeMap<>();
       int weight = (int) ceil(1.0 * numVirtualNodes / workerInfos.size());
       for (BlockWorkerInfo workerInfo : workerInfos) {
@@ -137,8 +176,7 @@ public class WorkerLocationPolicy {
               workerInfo);
         }
       }
-      mLastWorkerInfos = workerInfos;
-      mActiveNodesByConsistentHashing.set(activeNodesByConsistentHashing);
+      return activeNodesByConsistentHashing;
     }
   }
 }

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -20,6 +20,7 @@ import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.HashFunction;
 
@@ -60,7 +61,7 @@ public class WorkerLocationPolicy {
   public List<BlockWorkerInfo> getPreferredWorkers(List<BlockWorkerInfo> blockWorkerInfos,
                                                    String fileId,
                                                    int count) {
-    if (blockWorkerInfos.size() == 0) {
+    if (blockWorkerInfos.isEmpty()) {
       return ImmutableList.of();
     }
     HASH_PROVIDER.refresh(blockWorkerInfos, mNumVirtualNodes);
@@ -85,6 +86,8 @@ public class WorkerLocationPolicy {
      * virtual nodes.
      */
     public void refresh(List<BlockWorkerInfo> workerInfos, int numVirtualNodes) {
+      Preconditions.checkArgument(!workerInfos.isEmpty(),
+          "cannot refresh hash provider with empty worker list");
       // When the active nodes map does not exist, the hash provider is not initialized yet.
       // let one caller initialize the map while blocking all others.
       if (mActiveNodesByConsistentHashing == null) {
@@ -166,6 +169,7 @@ public class WorkerLocationPolicy {
 
     private static NavigableMap<Integer, BlockWorkerInfo> build(
         List<BlockWorkerInfo> workerInfos, int numVirtualNodes) {
+      Preconditions.checkArgument(!workerInfos.isEmpty(), "worker list is empty");
       NavigableMap<Integer, BlockWorkerInfo> activeNodesByConsistentHashing = new TreeMap<>();
       int weight = (int) ceil(1.0 * numVirtualNodes / workerInfos.size());
       for (BlockWorkerInfo workerInfo : workerInfos) {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -183,12 +183,13 @@ public class WorkerLocationPolicy {
     }
 
     public BlockWorkerInfo get(String key, int index) {
-      return get(mActiveNodesByConsistentHashing, key, index);
+      NavigableMap<Integer, BlockWorkerInfo> map = mActiveNodesByConsistentHashing;
+      Preconditions.checkState(map != null, "Hash provider is not properly initialized");
+      return get(map, key, index);
     }
 
     @VisibleForTesting
     static BlockWorkerInfo get(NavigableMap<Integer, BlockWorkerInfo> map, String key, int index) {
-      Preconditions.checkNotNull(map, "Hash provider is not properly initialized");
       int hashKey = HASH_FUNCTION.hashString(format("%s%d", key, index), UTF_8).asInt();
       Map.Entry<Integer, BlockWorkerInfo> entry = map.ceilingEntry(hashKey);
       if (entry != null) {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -94,14 +94,14 @@ public class WorkerLocationPolicy {
         mInitLock.acquireUninterruptibly();
         // only one thread should reach here
         // test again to skip re-initialization
-        if (mActiveNodesByConsistentHashing == null) {
-          try {
+        try {
+          if (mActiveNodesByConsistentHashing == null) {
             mActiveNodesByConsistentHashing = build(workerInfos, numVirtualNodes);
-          } finally {
             mLastWorkerInfos = workerInfos;
             mLastUpdatedTimestamp.set(System.nanoTime());
-            mInitLock.release();
           }
+        } finally {
+          mInitLock.release();
         }
       }
       // check if the worker list has expired

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/dora/WorkerLocationPolicyTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/dora/WorkerLocationPolicyTest.java
@@ -148,6 +148,7 @@ public class WorkerLocationPolicyTest {
     List<BlockWorkerInfo> workerList = generateRandomWorkerList(5);
     // set initial state
     provider.refresh(workerList, NUM_VIRTUAL_NODES);
+    long initialUpdateCount = provider.getUpdateCount();
     assertEquals(workerList, provider.getLastWorkerInfos());
     assertEquals(
         ConsistentHashProvider.build(workerList, NUM_VIRTUAL_NODES),
@@ -156,6 +157,7 @@ public class WorkerLocationPolicyTest {
     // before TTL is up, refresh does not change the internal states of the provider
     List<BlockWorkerInfo> newList = generateRandomWorkerList(5);
     provider.refresh(newList, NUM_VIRTUAL_NODES);
+    assertEquals(0, provider.getUpdateCount() - initialUpdateCount);
     assertNotEquals(newList, workerList);
     assertEquals(workerList, provider.getLastWorkerInfos());
     assertEquals(
@@ -165,6 +167,7 @@ public class WorkerLocationPolicyTest {
     // after TTL expires, refresh should change the worker list and the active nodes map
     Thread.sleep(WORKER_LIST_TTL_MS);
     provider.refresh(newList, NUM_VIRTUAL_NODES);
+    assertEquals(1, provider.getUpdateCount() - initialUpdateCount);
     assertEquals(newList, provider.getLastWorkerInfos());
     assertEquals(
         ConsistentHashProvider.build(newList, NUM_VIRTUAL_NODES),

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/dora/WorkerLocationPolicyTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/dora/WorkerLocationPolicyTest.java
@@ -1,0 +1,217 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file.dora;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import alluxio.Constants;
+import alluxio.client.block.BlockWorkerInfo;
+import alluxio.client.file.dora.WorkerLocationPolicy.ConsistentHashProvider;
+import alluxio.wire.TieredIdentity;
+import alluxio.wire.WorkerNetAddress;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class WorkerLocationPolicyTest {
+  private static final long WORKER_LIST_TTL_MS = 100;
+  private static final String OBJECT_KEY = "/path/to/object";
+  private static final int NUM_VIRTUAL_NODES = 100;
+
+  @Test
+  public void uninitializedThrowsException() {
+    ConsistentHashProvider provider = new ConsistentHashProvider(1, WORKER_LIST_TTL_MS);
+    Assert.assertThrows(IllegalStateException.class, () -> provider.get(OBJECT_KEY, 0));
+  }
+
+  @Test
+  public void concurrentInitialization() {
+    ConsistentHashProvider provider = new ConsistentHashProvider(1, WORKER_LIST_TTL_MS);
+    final int numThreads = Runtime.getRuntime().availableProcessors();
+    CountDownLatch startSignal = new CountDownLatch(numThreads);
+    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+    List<List<BlockWorkerInfo>> lists = IntStream.range(0, numThreads)
+        .mapToObj(i -> generateRandomWorkerList(5))
+        .collect(Collectors.toList());
+    List<Future<?>> futures = IntStream.range(0, numThreads)
+        .mapToObj(i -> {
+          List<BlockWorkerInfo> list = lists.get(i);
+          return executorService.submit(() -> {
+            startSignal.countDown();
+            try {
+              startSignal.await();
+            } catch (InterruptedException e) {
+              fail("interrupted");
+            }
+            provider.refresh(list, NUM_VIRTUAL_NODES);
+          });
+        })
+        .collect(Collectors.toList());
+    futures.forEach(future -> {
+      try {
+        future.get();
+      } catch (InterruptedException interruptedException) {
+        fail("interrupted" + interruptedException);
+      } catch (ExecutionException e) {
+        fail("failed to run thread" + e);
+      }
+    });
+
+    // check if the worker list is one of the lists provided by the threads
+    List<BlockWorkerInfo> workerInfoListUsedByPolicy = provider.getLastWorkerInfos();
+    assertTrue(lists.contains(workerInfoListUsedByPolicy));
+    assertEquals(
+        ConsistentHashProvider.build(workerInfoListUsedByPolicy, NUM_VIRTUAL_NODES),
+        provider.getActiveNodesMap());
+  }
+
+  @Test
+  public void concurrentRefresh() throws Exception {
+    ConsistentHashProvider provider = new ConsistentHashProvider(1, WORKER_LIST_TTL_MS);
+    provider.refresh(generateRandomWorkerList(5), NUM_VIRTUAL_NODES);
+    NavigableMap<Integer, BlockWorkerInfo> initialMap = provider.getActiveNodesMap();
+    assertNotNull(initialMap);
+    Thread.sleep(WORKER_LIST_TTL_MS);
+
+    final int numThreads = Runtime.getRuntime().availableProcessors();
+    CountDownLatch startSignal = new CountDownLatch(numThreads);
+    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+
+    // generate a list of distinct maps for each thread
+    List<List<BlockWorkerInfo>> listsPerThread = IntStream.range(0, numThreads)
+        .mapToObj(i -> generateRandomWorkerList(5))
+        .collect(Collectors.toList());
+    List<Future<NavigableMap<Integer, BlockWorkerInfo>>> futures = IntStream.range(0, numThreads)
+        .mapToObj(i -> {
+          List<BlockWorkerInfo> list = listsPerThread.get(i);
+          return executorService.submit(() -> {
+            startSignal.countDown();
+            try {
+              startSignal.await();
+            } catch (InterruptedException e) {
+              fail("interrupted");
+            }
+            provider.refresh(list, NUM_VIRTUAL_NODES);
+            return provider.getActiveNodesMap();
+          });
+        })
+        .collect(Collectors.toList());
+    int numOfThreadsWhichUpdatedMap = 0;
+    Set<NavigableMap<Integer, BlockWorkerInfo>> distinctMaps = new HashSet<>();
+    for (int i = 0; i < futures.size(); i++) {
+      final NavigableMap<Integer, BlockWorkerInfo> map;
+      try {
+        map = futures.get(i).get();
+      } catch (InterruptedException interruptedException) {
+        throw new AssertionError("interrupted" + interruptedException);
+      } catch (ExecutionException e) {
+        throw new AssertionError("failed to run thread" + e);
+      }
+      distinctMaps.add(map);
+      // the map returned by the i-th thread can be one of the 3 cases:
+      // 1. the refresh call returns before the writer thread could finish updating the map,
+      //    so the map is the same as the initial map
+      // 2. this thread is the one that gets to update the map, so the map is the i-th
+      //    map in map lists
+      // 3. the refresh call executes after the writer finishes updating the map, so this thread
+      //    sees the up-to-date map set by the writer, which is not the i-th map
+      // in summary, if only one thread gets to update the map, then case 2 can occur only
+      // once.
+
+      if (initialMap.equals(map)) { // case 1
+        numOfThreadsWhichUpdatedMap += 0;
+      } else if (ConsistentHashProvider.build(
+          listsPerThread.get(i), NUM_VIRTUAL_NODES).equals(map)) { // case 2
+        numOfThreadsWhichUpdatedMap += 1;
+      } else { // case 3
+        numOfThreadsWhichUpdatedMap += 0;
+      }
+    }
+
+    assertTrue("at most two possible outcomes about the active nodes map should be visible, "
+        + "but got " + distinctMaps.size(),
+        distinctMaps.size() >= 1 && distinctMaps.size() <= 2);
+    // check only one thread updated the worker map
+    assertEquals(1, numOfThreadsWhichUpdatedMap);
+  }
+
+  @Test
+  public void workerListTtl() throws Exception {
+    ConsistentHashProvider provider = new ConsistentHashProvider(1, WORKER_LIST_TTL_MS);
+    List<BlockWorkerInfo> workerList = generateRandomWorkerList(5);
+    // set initial state
+    provider.refresh(workerList, NUM_VIRTUAL_NODES);
+    assertEquals(workerList, provider.getLastWorkerInfos());
+    assertEquals(
+        ConsistentHashProvider.build(workerList, NUM_VIRTUAL_NODES),
+        provider.getActiveNodesMap());
+
+    // before TTL is up, refresh does not change the internal states of the provider
+    List<BlockWorkerInfo> newList = generateRandomWorkerList(5);
+    provider.refresh(newList, NUM_VIRTUAL_NODES);
+    assertNotEquals(newList, workerList);
+    assertEquals(workerList, provider.getLastWorkerInfos());
+    assertEquals(
+        ConsistentHashProvider.build(workerList, NUM_VIRTUAL_NODES),
+        provider.getActiveNodesMap());
+
+    // after TTL expires, refresh should change the worker list and the active nodes map
+    Thread.sleep(WORKER_LIST_TTL_MS);
+    provider.refresh(newList, NUM_VIRTUAL_NODES);
+    assertEquals(newList, provider.getLastWorkerInfos());
+    assertEquals(
+        ConsistentHashProvider.build(newList, NUM_VIRTUAL_NODES),
+        provider.getActiveNodesMap());
+  }
+
+  private List<BlockWorkerInfo> generateRandomWorkerList(int count) {
+    ThreadLocalRandom rng = ThreadLocalRandom.current();
+    ImmutableList.Builder<BlockWorkerInfo> builder = ImmutableList.builder();
+    while (count-- > 0) {
+      WorkerNetAddress netAddress = new WorkerNetAddress();
+      netAddress.setHost(RandomStringUtils.randomAlphanumeric(10));
+      netAddress.setContainerHost(RandomStringUtils.randomAlphanumeric(10));
+      netAddress.setDomainSocketPath(RandomStringUtils.randomAlphanumeric(10));
+      netAddress.setRpcPort(rng.nextInt(0, 65536));
+      netAddress.setDataPort(rng.nextInt(0, 65536));
+      netAddress.setNettyDataPort(rng.nextInt(0, 65536));
+      netAddress.setSecureRpcPort(rng.nextInt(0, 65536));
+      netAddress.setWebPort(rng.nextInt(0, 65536));
+      netAddress.setTieredIdentity(
+          new TieredIdentity(ImmutableList.of(new TieredIdentity.LocalityTier("tier", "loc"))));
+
+      BlockWorkerInfo workerInfo = new BlockWorkerInfo(netAddress,
+          rng.nextLong(0, Constants.GB), rng.nextLong(0, Constants.GB));
+      builder.add(workerInfo);
+    }
+    return builder.build();
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix a race condition between refreshing the map and retrieving worker info from the map.

### Why are the changes needed?

This cause a NPE where the requested entry can be `null`.

### Does this PR introduce any user facing changes?
No.
