### PR TITLE
[SMALLFIX] Use field property for 'AbstractCmdRunner'

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/tracker/DistLoadCliRunner.java
+++ b/job/server/src/main/java/alluxio/master/job/tracker/DistLoadCliRunner.java
@@ -156,7 +156,7 @@ public class DistLoadCliRunner extends AbstractCmdRunner {
                               Set<String> workerSet, Set<String> excludedWorkerSet,
                               Set<String> localityIds, Set<String> excludedLocalityIds,
                               boolean directCache, CmdInfo cmdInfo) {
-    if (mSubmitted.size() >= DEFAULT_ACTIVE_JOBS) {
+    if (mSubmitted.size() >= mActiveJobs) {
       waitForCmdJob();
     }
 

--- a/job/server/src/main/java/alluxio/master/job/tracker/MigrateCliRunner.java
+++ b/job/server/src/main/java/alluxio/master/job/tracker/MigrateCliRunner.java
@@ -124,7 +124,7 @@ public class MigrateCliRunner extends AbstractCmdRunner {
   // Submit a child job within a distributed command job.
   private void submitDistCp(List<Pair<String, String>> pool, boolean overwrite,
          WriteType writeType, CmdInfo cmdInfo) {
-    if (mSubmitted.size() >= DEFAULT_ACTIVE_JOBS) {
+    if (mSubmitted.size() >= mActiveJobs) {
       waitForCmdJob();
     }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Use field property 'mActiveJobs' for 'AbstractCmdRunner' instead of the default value DEFAULT_ACTIVE_JOBS which is hardcoded with 3000.

### Why are the changes needed?

Currently, the number of active jobs are limited at 3000 which is not enough when we have lots of loading tasks on huge cluster. We will add command line args to allow user pass the limit of active jobs (set the value of 'mActiveJobs') the  in the future.

### Does this PR introduce any user facing changes?

N/A