### PR TITLE
Improve HTTP RESTful API performance

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -210,6 +210,12 @@ public class LocalPageStore implements PageStore {
     if (!pageFile.exists()) {
       throw new PageNotFoundException(pagePath.toString());
     }
+
+    long fileLength = pageFile.length();
+    if (pageOffset + bytesToRead > fileLength) {
+      bytesToRead = (int) (fileLength - (long) pageOffset);
+    }
+
     DataFileChannel dataFileChannel = new DataFileChannel(pageFile, pageOffset, bytesToRead);
     return dataFileChannel;
   }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpResponseContext.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpResponseContext.java
@@ -1,0 +1,35 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.http;
+
+import io.netty.channel.FileRegion;
+import io.netty.handler.codec.http.HttpResponse;
+
+public class HttpResponseContext {
+
+  private final HttpResponse mHttpResponse;
+
+  private final FileRegion mFileRegion;
+
+  public HttpResponseContext(HttpResponse httpResponse, FileRegion fileRegion) {
+    mHttpResponse = httpResponse;
+    mFileRegion = fileRegion;
+  }
+
+  public HttpResponse getHttpResponse() {
+    return mHttpResponse;
+  }
+
+  public FileRegion getFileRegion() {
+    return mFileRegion;
+  }
+}

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpResponseContext.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpResponseContext.java
@@ -14,21 +14,37 @@ package alluxio.worker.http;
 import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.HttpResponse;
 
+/**
+ * Http response context for wrapping useful information.
+ */
 public class HttpResponseContext {
 
   private final HttpResponse mHttpResponse;
 
   private final FileRegion mFileRegion;
 
+  /**
+   * Http response context for wrapping useful information.
+   * @param httpResponse the http response to client
+   * @param fileRegion the file region to read from the worker side
+   */
   public HttpResponseContext(HttpResponse httpResponse, FileRegion fileRegion) {
     mHttpResponse = httpResponse;
     mFileRegion = fileRegion;
   }
 
+  /**
+   * Get the http response.
+   * @return the http response
+   */
   public HttpResponse getHttpResponse() {
     return mHttpResponse;
   }
 
+  /**
+   * Get the file region to read from the worker side.
+   * @return the file region
+   */
   public FileRegion getFileRegion() {
     return mFileRegion;
   }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServer.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServer.java
@@ -62,7 +62,8 @@ public final class HttpServer {
 
   private void startHttpServer() {
     // Configure the server.
-    EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+    int threadsNum = Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_WORKER_THREADS);
+    EventLoopGroup bossGroup = new NioEventLoopGroup(threadsNum);
     EventLoopGroup workerGroup = new NioEventLoopGroup();
     try {
       ServerBootstrap b = new ServerBootstrap();

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
@@ -26,22 +26,25 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
+import alluxio.exception.PageNotFoundException;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.gson.Gson;
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.FileRegion;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,10 +77,11 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
   }
 
   @Override
-  public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) {
+  public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) throws PageNotFoundException {
     if (msg instanceof HttpRequest) {
       HttpRequest req = (HttpRequest) msg;
-      FullHttpResponse response = dispatch(ctx.channel(), req);
+      HttpResponseContext responseContext = dispatch(req);
+      HttpResponse response = responseContext.getHttpResponse();
 
       boolean keepAlive = HttpUtil.isKeepAlive(req);
       if (keepAlive) {
@@ -89,7 +93,9 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
         response.headers().set(CONNECTION, CLOSE);
       }
 
-      ChannelFuture f = ctx.write(response);
+      ctx.write(response);
+      ctx.write(responseContext.getFileRegion());
+      ChannelFuture f = ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
 
       if (!keepAlive) {
         f.addListener(ChannelFutureListener.CLOSE);
@@ -108,7 +114,8 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
     return parametersMap;
   }
 
-  private FullHttpResponse dispatch(Channel channel, HttpRequest httpRequest) {
+  private HttpResponseContext dispatch(HttpRequest httpRequest)
+      throws PageNotFoundException {
     String requestUri = httpRequest.uri();
     // parse the request uri to get the parameters
     String requestMapping = getRequestMapping(requestUri);
@@ -117,31 +124,32 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
     // parse the URI and dispatch it to different methods
     switch (requestMapping) {
       case "page":
-        return doGetPage(parametersMap, channel, httpRequest);
+        return doGetPage(parametersMap, httpRequest);
       case "files":
-        return doListFiles(parametersMap, channel, httpRequest);
+        return doListFiles(parametersMap, httpRequest);
       default:
         // TODO(JiamingMai): this should not happen, we should throw an exception here
         return null;
     }
   }
 
-  private FullHttpResponse doGetPage(Map<String, String> parametersMap,
-                                     Channel channel, HttpRequest httpRequest) {
+  private HttpResponseContext doGetPage(
+      Map<String, String> parametersMap, HttpRequest httpRequest)
+      throws PageNotFoundException {
     String fileId = parametersMap.get("fileId");
     long pageIndex = Long.parseLong(parametersMap.get("pageIndex"));
 
-    ByteBuf byteBuf = mPagedService.getPage(fileId, pageIndex, channel);
-    FullHttpResponse response = new DefaultFullHttpResponse(httpRequest.protocolVersion(), OK,
-        byteBuf);
+    FileRegion fileRegion = mPagedService.getPageFileRegion(fileId, pageIndex);
+    HttpResponse response = new DefaultHttpResponse(httpRequest.protocolVersion(), OK);
+    HttpResponseContext httpResponseContext = new HttpResponseContext(response, fileRegion);
     response.headers()
         .set(CONTENT_TYPE, TEXT_PLAIN)
-        .setInt(CONTENT_LENGTH, response.content().readableBytes());
-    return response;
+        .setInt(CONTENT_LENGTH, (int) fileRegion.count());
+    return httpResponseContext;
   }
 
-  private FullHttpResponse doListFiles(Map<String, String> parametersMap,
-                           Channel channel, HttpRequest httpRequest) {
+  private HttpResponseContext doListFiles(Map<String, String> parametersMap,
+                           HttpRequest httpRequest) {
     String path = parametersMap.get("path");
     ListStatusPOptions options = FileSystemOptionsUtils.listStatusDefaults(
         Configuration.global()).toBuilder().build();
@@ -166,7 +174,7 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
       response.headers()
           .set(CONTENT_TYPE, APPLICATION_JSON)
           .setInt(CONTENT_LENGTH, response.content().readableBytes());
-      return response;
+      return new HttpResponseContext(response, null);
     } catch (IOException | AlluxioException e) {
       LOG.error("Failed to list files of path {}", path, e);
       return null;

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
@@ -15,8 +15,6 @@ import com.google.inject.Inject;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.codec.compression.CompressionOptions;
-import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerExpectContinueHandler;
@@ -42,7 +40,6 @@ public class HttpServerInitializer extends ChannelInitializer<SocketChannel> {
     ChannelPipeline p = ch.pipeline();
     p.addLast(new HttpServerCodec());
     p.addLast(new HttpObjectAggregator(1024 * 10));
-    p.addLast(new HttpContentCompressor((CompressionOptions[]) null));
     p.addLast(new HttpServerExpectContinueHandler());
     p.addLast(new HttpServerHandler(mPagedService));
   }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
@@ -20,11 +20,12 @@ import alluxio.exception.PageNotFoundException;
 import alluxio.file.NettyBufTargetBuffer;
 import alluxio.network.protocol.databuffer.DataFileChannel;
 
-import java.util.Optional;
 import com.google.inject.Inject;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.FileRegion;
+
+import java.util.Optional;
 
 /**
  * {@link PagedService} is used for providing page related RESTful API service.
@@ -37,6 +38,7 @@ public class PagedService {
 
   /**
    * {@link PagedService} is used for providing page related RESTful API service.
+   *
    * @param cacheManager The interface for managing cached pages
    */
   @Inject
@@ -47,9 +49,10 @@ public class PagedService {
 
   /**
    * Get page bytes given fileId, pageIndex, and channel which is used for allocating ByteBuf.
-   * @param fileId the file ID
+   *
+   * @param fileId    the file ID
    * @param pageIndex the page index
-   * @param channel the Netty channel which is used for allocating ByteBuf
+   * @param channel   the Netty channel which is used for allocating ByteBuf
    * @return the ByteBuf object that wraps page bytes
    */
   public ByteBuf getPage(String fileId, long pageIndex, Channel channel) {
@@ -62,24 +65,24 @@ public class PagedService {
     return targetBuffer.getTargetBuffer();
   }
 
-
   /**
-   * Get {@link FileRegion} object given fileId, pageIndex, and channel
-   * @param fileId the file ID
+   * Get {@link FileRegion} object given fileId, pageIndex, and channel.
+   *
+   * @param fileId    the file ID
    * @param pageIndex the page index
    * @return the ByteBuf object that wraps page bytes
    * @throws PageNotFoundException
    */
   public FileRegion getPageFileRegion(String fileId, long pageIndex)
       throws PageNotFoundException {
-      PageId pageId = new PageId(fileId, pageIndex);
-      Optional<DataFileChannel> dataFileChannel = mCacheManager.getDataFileChannel(pageId,
-          0, (int) mPageSize, CacheContext.defaults());
-      if (!dataFileChannel.isPresent()) {
-        throw new PageNotFoundException("page not found: fileId " + fileId
-            + ", pageIndex " + pageIndex);
-      }
-      return (FileRegion) dataFileChannel.get().getNettyOutput();
+    PageId pageId = new PageId(fileId, pageIndex);
+    Optional<DataFileChannel> dataFileChannel = mCacheManager.getDataFileChannel(pageId,
+        0, (int) mPageSize, CacheContext.defaults());
+    if (!dataFileChannel.isPresent()) {
+      throw new PageNotFoundException("page not found: fileId " + fileId
+          + ", pageIndex " + pageIndex);
+    }
+    return (FileRegion) dataFileChannel.get().getNettyOutput();
   }
   // TODO(JiamingMai): do we need to implement a method for reading file directly?
 }


### PR DESCRIPTION
1. Remove compression encoder for faster data transmission.
2. Use bigger thread pool to serve the HTTP clients.
3. Use Netty's zero-copy feature to avoid data copying in Alluxio Worker.