### PR TITLE
Fix list files RESTful API

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
@@ -93,12 +93,17 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
         response.headers().set(CONNECTION, CLOSE);
       }
 
-      ctx.write(response);
-      ctx.write(responseContext.getFileRegion());
-      ChannelFuture f = ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+      ChannelFuture channelFuture;
+      if (response instanceof FullHttpResponse) {
+        channelFuture = ctx.write(response);
+      } else {
+        ctx.write(response);
+        ctx.write(responseContext.getFileRegion());
+        channelFuture = ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+      }
 
       if (!keepAlive) {
-        f.addListener(ChannelFutureListener.CLOSE);
+        channelFuture.addListener(ChannelFutureListener.CLOSE);
       }
     }
   }


### PR DESCRIPTION
Fix the bug that list files RESTful API doesn't work caused by the code doesn't handle `FullHttpResponse`.