### PR TITLE
Remove dependency on com.igormaznitsa:jcp

### DIFF
--- a/build/checkstyle/suppressions.xml
+++ b/build/checkstyle/suppressions.xml
@@ -3,16 +3,15 @@
 <suppressions>
     <!-- Suppresses files in the src/test folder. To be used for rules which only apply to
          production code. -->
-    <suppress files="[\\/]src[\\/]test[\\/].*|[\\/]generated-test-sources[\\/].*"
-              id="ProductionScope" />
+    <suppress files="[\\/]src[\\/]test[\\/].*" id="ProductionScope" />
     <!-- Suppresses files in the src/main folder. To be used for rules which only apply to test
          code. -->
-    <suppress files="[\\/]src[\\/]main[\\/].*|[\\/]generated-sources[\\/].*" id="TestScope" />
+    <suppress files="[\\/]src[\\/]main[\\/].*" id="TestScope" />
     <!-- Excludes test files from having Javadocs for classes and methods (a lot do not have those) -->
     <suppress files="[\\/]*[\\/]test[\\/].*" checks="MissingJavadocMethod" />
     <suppress files="[\\/]*[\\/]test[\\/].*" checks="MissingJavadocType" />
-    <suppress files="[\\/]src[\\/]test[\\/].*|[\\/]generated-test-sources[\\/].*" checks="MissingJavadocMethod" />
-    <suppress files="[\\/]src[\\/]test[\\/].*|[\\/]generated-test-sources[\\/].*" checks="MissingJavadocType" />
+    <suppress files="[\\/]src[\\/]test[\\/].*" checks="MissingJavadocMethod" />
+    <suppress files="[\\/]src[\\/]test[\\/].*" checks="MissingJavadocType" />
     <!-- Micro bench does not require java doc on methods and types, as they are typically benchmark methods and params. -->
     <suppress files="[\\/]microbench[\\/]src[\\/]main[\\/].*" checks="MissingJavadocMethod" />
     <suppress files="[\\/]microbench[\\/]src[\\/]main[\\/].*" checks="MissingJavadocType" />

--- a/dora/tests/pom.xml
+++ b/dora/tests/pom.xml
@@ -389,26 +389,6 @@
         </executions>
       </plugin>
 
-      <plugin>
-        <groupId>com.igormaznitsa</groupId>
-        <artifactId>jcp</artifactId>
-        <executions>
-          <execution>
-            <id>preprocessSources</id>
-            <phase>generate-test-sources</phase>
-            <goals>
-              <goal>preprocessTests</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>clearGeneratedFolders</id>
-            <goals>
-              <goal>clear</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <!-- Export test classes in a test-jar so that other projects can use them for testing -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/dora/underfs/hdfs/pom.xml
+++ b/dora/underfs/hdfs/pom.xml
@@ -202,25 +202,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>com.igormaznitsa</groupId>
-        <artifactId>jcp</artifactId>
-        <executions>
-          <execution>
-            <id>preprocessSources</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>preprocess</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>clearGeneratedFolders</id>
-            <goals>
-              <goal>clear</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -923,11 +923,6 @@
           <version>1.0</version>
         </plugin>
         <plugin>
-          <groupId>com.igormaznitsa</groupId>
-          <artifactId>jcp</artifactId>
-          <version>6.1.2</version>
-        </plugin>
-        <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>4.2</version>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Cleanup maven build process by removing "com.igormaznitsa:jcp", which is used to create generated-source and generated-test-source due to **incompatible** APIs of Hadoop-1 and Hadoop-2 client source code.

### Why are the changes needed?

  1. jcp is no longer used after 300. Still running jcp for generate-sources during compilation is meaningless and time-wasting.
  2. maintaining generated-test-source and generated-source for dev really complicates the IDE environment: most of the classes in generated source or test source will be identified as duplicates by IDE. 
  3. In general, having duplicated classes complicates build process too. For certain plugin, the compiler is also confused by which class to use.

### Does this PR introduce any user facing changes?

 N/A