### PR TITLE
Fix Maven warnings on plugin declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,11 +322,6 @@
         <version>1.2</version>
       </dependency>
       <dependency>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
-        <version>4.0.5</version>
-      </dependency>
-      <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
         <version>${metrics.version}</version>
@@ -933,6 +928,11 @@
           <version>4.2</version>
         </plugin>
         <plugin>
+          <groupId>pl.project13.maven</groupId>
+          <artifactId>git-commit-id-plugin</artifactId>
+          <version>4.0.5</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>3.0.0</version>
@@ -1348,12 +1348,12 @@
         </executions>
       </plugin>
 
-      <!-- Prevent Windows line endings -->
       <plugin>
         <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
         <inherited>false</inherited>
         <executions>
+          <!-- Prevent Windows line endings -->
           <execution>
             <id>Check that there are no Windows line endings</id>
             <phase>compile</phase>
@@ -1364,15 +1364,7 @@
               <executable>${build.path}/style/check_no_windows_line_endings.sh</executable>
             </configuration>
           </execution>
-        </executions>
-      </plugin>
-
-      <!-- Create libexec/version.sh -->
-      <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
-        <groupId>org.codehaus.mojo</groupId>
-        <inherited>false</inherited>
-        <executions>
+          <!-- Create libexec/version.sh -->
           <execution>
             <id>Write version string in generated packaged script</id>
             <phase>compile</phase>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix Maven warnings on plugin declaration:

```
[WARNING] Some problems were encountered while building the effective model for org.alluxio:alluxio-assembly-client:jar:302-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for pl.project13.maven:git-commit-id-plugin is missing. @ org.alluxio:alluxio-parent:302-SNAPSHOT, /Users/binfan/projects/alluxio/alluxio/pom.xml, line 1174, column 15

[WARNING] Some problems were encountered while building the effective model for org.alluxio:alluxio-assembly:pom:302-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.codehaus.mojo:exec-maven-plugin @ org.alluxio:alluxio-parent:302-SNAPSHOT, /Users/binfan/projects/alluxio/alluxio/pom.xml, line 1371, column 15
[WARNING] 'build.plugins.plugin.version' for pl.project13.maven:git-commit-id-plugin is missing. @ org.alluxio:alluxio-parent:302-SNAPSHOT, /Users/binfan/projects/alluxio/alluxio/pom.xml, line 1174, column 15
```


### Why are the changes needed?

Bugs cause maven to complain 

### Does this PR introduce any user facing changes?

N/A
