### PR TITLE
Add generate subcommand to CLI

### DIFF
--- a/cli/src/alluxio.org/cli/cmd/generate/docs.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/docs.go
@@ -12,12 +12,11 @@
 package generate
 
 import (
-	"alluxio.org/cli/env"
-	"alluxio.org/log"
-	"bytes"
 	"fmt"
-	"github.com/palantir/stacktrace"
+
 	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
 )
 
 var Docs = &DocsCommand{
@@ -50,18 +49,4 @@ func (c *DocsCommand) ToCommand() *cobra.Command {
 
 func (c *DocsCommand) Run(args []string) error {
 	return c.Base().Run(args)
-}
-
-func (c *DocsCommand) FetchValue(key string) (string, error) {
-	cmd := c.RunJavaClassCmd([]string{key})
-
-	errBuf := &bytes.Buffer{}
-	cmd.Stderr = errBuf
-
-	log.Logger.Debugln(cmd.String())
-	out, err := cmd.Output()
-	if err != nil {
-		return "", stacktrace.Propagate(err, "error getting conf for %v\nstderr: %v", key, errBuf.String())
-	}
-	return string(out), nil
 }

--- a/cli/src/alluxio.org/cli/cmd/generate/docs.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/docs.go
@@ -39,7 +39,7 @@ func (c *DocsCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   fmt.Sprintf("%v", Docs.CommandName),
 		Short: "Generate docs automatically.",
-		Args:  cobra.MaximumNArgs(0),
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.Run(args)
 		},

--- a/cli/src/alluxio.org/cli/cmd/generate/docs.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/docs.go
@@ -1,0 +1,67 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package generate
+
+import (
+	"alluxio.org/cli/env"
+	"alluxio.org/log"
+	"bytes"
+	"fmt"
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+)
+
+var Docs = &DocsCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "docs",
+		JavaClassName: "alluxio.cli.DocGenerator",
+		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
+	},
+}
+
+type DocsCommand struct {
+	*env.BaseJavaCommand
+}
+
+func (c *DocsCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *DocsCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   fmt.Sprintf("%v", Docs.CommandName),
+		Short: "Generate docs automatically.",
+		Args:  cobra.MaximumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	return cmd
+}
+
+func (c *DocsCommand) Run(args []string) error {
+	return c.Base().Run(args)
+}
+
+func (c *DocsCommand) FetchValue(key string) (string, error) {
+	cmd := c.RunJavaClassCmd([]string{key})
+
+	errBuf := &bytes.Buffer{}
+	cmd.Stderr = errBuf
+
+	log.Logger.Debugln(cmd.String())
+	out, err := cmd.Output()
+	if err != nil {
+		return "", stacktrace.Propagate(err, "error getting conf for %v\nstderr: %v", key, errBuf.String())
+	}
+	return string(out), nil
+}

--- a/cli/src/alluxio.org/cli/cmd/generate/docs.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/docs.go
@@ -37,7 +37,7 @@ func (c *DocsCommand) Base() *env.BaseJavaCommand {
 
 func (c *DocsCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
-		Use:   fmt.Sprintf("%v", Docs.CommandName),
+		Use:   Docs.CommandName,
 		Short: "Generate docs automatically.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/generate/generate.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/generate.go
@@ -1,0 +1,23 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package generate
+
+import "alluxio.org/cli/env"
+
+var Service = &env.Service{
+	Name:        "generate",
+	Description: "Generate docs or a config file automatically if one doesn't exist.",
+	Commands: []env.Command{
+		Docs,
+		Template,
+	},
+}

--- a/cli/src/alluxio.org/cli/cmd/generate/template.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/template.go
@@ -12,11 +12,14 @@
 package generate
 
 import (
-	"alluxio.org/cli/env"
-	"fmt"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+	"alluxio.org/log"
 )
 
 var Template = &TemplateCommand{}
@@ -31,26 +34,26 @@ func (c *TemplateCommand) ToCommand() *cobra.Command {
 		Short: "Generate a config file if one doesn't exist.",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
-				fmt.Println("Usage: template <alluxio_master_hostname>")
+				log.Logger.Infoln("Usage: template <alluxio_master_hostname>")
 				return
 			}
-			targetDir := env.ConfAlluxioConfDir.EnvVar + "alluxio-site.properties"
+			targetDir := filepath.Join(env.ConfAlluxioConfDir.EnvVar, "alluxio-site.properties")
 			content := "alluxio.master.hostname=" + args[0]
 			if _, err := os.Stat(targetDir); err != nil {
 				if os.IsNotExist(err) {
 					e := ioutil.WriteFile(targetDir, []byte(content), 0644)
 					if e != nil {
-						fmt.Println("Error writing file:", e)
+						log.Logger.Errorln("Error writing file:", e)
 						return
 					}
-					fmt.Println(targetDir + " is created.")
+					log.Logger.Infoln(targetDir + " is created.")
 					return
 				} else {
-					fmt.Println("File read error:", err)
+					log.Logger.Errorln("File read error:", err)
 					return
 				}
 			} else {
-				fmt.Println(targetDir + " already exists")
+				log.Logger.Warnln(targetDir + " already exists")
 				return
 			}
 		},

--- a/cli/src/alluxio.org/cli/cmd/generate/template.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/template.go
@@ -1,0 +1,59 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package generate
+
+import (
+	"alluxio.org/cli/env"
+	"fmt"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"os"
+)
+
+var Template = &TemplateCommand{}
+
+type TemplateCommand struct {
+	conf string
+}
+
+func (c *TemplateCommand) ToCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "template --conf",
+		Short: "Generate a config file if one doesn't exist.",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				fmt.Println("Usage: template <alluxio_master_hostname>")
+				return
+			}
+			targetDir := env.ConfAlluxioConfDir.EnvVar + "alluxio-site.properties"
+			content := "alluxio.master.hostname=" + args[0]
+			if _, err := os.Stat(targetDir); err != nil {
+				if os.IsNotExist(err) {
+					e := ioutil.WriteFile(targetDir, []byte(content), 0644)
+					if e != nil {
+						fmt.Println("Error writing file:", e)
+						return
+					}
+					fmt.Println(targetDir + " is created.")
+					return
+				} else {
+					fmt.Println("File read error:", err)
+					return
+				}
+			} else {
+				fmt.Println(targetDir + " already exists")
+				return
+			}
+		},
+	}
+	return cmd
+}

--- a/cli/src/alluxio.org/cli/cmd/generate/template.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/template.go
@@ -30,7 +30,8 @@ type TemplateCommand struct {
 
 func (c *TemplateCommand) ToCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "template --conf",
+		Use:   "templateConf [alluxioMasterHostname]",
+		Args:  cobra.ExactArgs(1),
 		Short: "Generate a config file if one doesn't exist.",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {

--- a/cli/src/alluxio.org/cli/cmd/generate/template.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/template.go
@@ -36,20 +36,21 @@ func (c *TemplateCommand) ToCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			targetDir := filepath.Join(env.ConfAlluxioConfDir.EnvVar, "alluxio-site.properties")
 			content := "alluxio.master.hostname=" + args[0]
-			if _, err := os.Stat(targetDir); err != nil {
-				if os.IsNotExist(err) {
-					if err := ioutil.WriteFile(targetDir, []byte(content), 0644); err != nil {
-						log.Logger.Errorln("Error writing file:", e)
-						return
-					}
-					log.Logger.Infoln(targetDir + " is created.")
-					return
-				} else {
-					log.Logger.Errorln("File read error:", err)
+
+			_, statErr := os.Stat(targetDir)
+			if os.IsExist(statErr) {
+				log.Logger.Warnln(targetDir + " already exists")
+				return
+			} else if os.IsNotExist(statErr) {
+				writeErr := ioutil.WriteFile(targetDir, []byte(content), 0644)
+				if writeErr != nil {
+					log.Logger.Errorln("Error writing file:", writeErr)
 					return
 				}
+				log.Logger.Infoln(targetDir + " is created.")
+				return
 			} else {
-				log.Logger.Warnln(targetDir + " already exists")
+				log.Logger.Errorln("File read error:", statErr)
 				return
 			}
 		},

--- a/cli/src/alluxio.org/cli/cmd/generate/template.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/template.go
@@ -34,10 +34,6 @@ func (c *TemplateCommand) ToCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Short: "Generate a config file if one doesn't exist.",
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 0 {
-				log.Logger.Infoln("Usage: template <alluxio_master_hostname>")
-				return
-			}
 			targetDir := filepath.Join(env.ConfAlluxioConfDir.EnvVar, "alluxio-site.properties")
 			content := "alluxio.master.hostname=" + args[0]
 			if _, err := os.Stat(targetDir); err != nil {

--- a/cli/src/alluxio.org/cli/cmd/generate/template.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/template.go
@@ -38,8 +38,7 @@ func (c *TemplateCommand) ToCommand() *cobra.Command {
 			content := "alluxio.master.hostname=" + args[0]
 			if _, err := os.Stat(targetDir); err != nil {
 				if os.IsNotExist(err) {
-					e := ioutil.WriteFile(targetDir, []byte(content), 0644)
-					if e != nil {
+					if err := ioutil.WriteFile(targetDir, []byte(content), 0644); err != nil {
 						log.Logger.Errorln("Error writing file:", e)
 						return
 					}

--- a/cli/src/alluxio.org/cli/env/env.go
+++ b/cli/src/alluxio.org/cli/env/env.go
@@ -75,7 +75,7 @@ func InitAlluxioEnv(rootPath string) error {
 	// set default values
 	for k, v := range map[string]string{
 		confAlluxioHome.EnvVar:        rootPath,
-		confAlluxioConfDir.EnvVar:     filepath.Join(rootPath, "conf"),
+		ConfAlluxioConfDir.EnvVar:     filepath.Join(rootPath, "conf"),
 		ConfAlluxioLogsDir.EnvVar:     filepath.Join(rootPath, "logs"),
 		confAlluxioUserLogsDir.EnvVar: filepath.Join(rootPath, "logs", "user"),
 		// TODO: add a go build flag to switch this to the finalized tarball path when building the tarball, ex. filepath.Join(rootPath, "assembly", fmt.Sprintf("alluxio-assembly-client-%v.jar", ver))
@@ -88,7 +88,7 @@ func InitAlluxioEnv(rootPath string) error {
 	// set user-specified environment variable values from alluxio-env.sh
 	{
 		// use ALLUXIO_CONF_DIR if set externally, otherwise default to above value
-		confPath := envVar.GetString(confAlluxioConfDir.EnvVar)
+		confPath := envVar.GetString(ConfAlluxioConfDir.EnvVar)
 		const alluxioEnv = "alluxio-env.sh"
 		log.Logger.Debugf("Loading %v configuration from directory %v", alluxioEnv, confPath)
 		v := viper.New()
@@ -111,13 +111,13 @@ func InitAlluxioEnv(rootPath string) error {
 
 	// set classpath variables which are dependent on user configurable values
 	envVar.Set(EnvAlluxioClientClasspath, strings.Join([]string{
-		envVar.GetString(confAlluxioConfDir.EnvVar) + "/",
+		envVar.GetString(ConfAlluxioConfDir.EnvVar) + "/",
 		envVar.GetString(confAlluxioClasspath.EnvVar),
 		envVar.GetString(envAlluxioAssemblyClientJar),
 		filepath.Join(envVar.GetString(confAlluxioHome.EnvVar), "lib", fmt.Sprintf("alluxio-integration-tools-validation-%v.jar", ver)),
 	}, ":"))
 	envVar.Set(EnvAlluxioServerClasspath, strings.Join([]string{
-		envVar.GetString(confAlluxioConfDir.EnvVar) + "/",
+		envVar.GetString(ConfAlluxioConfDir.EnvVar) + "/",
 		envVar.GetString(confAlluxioClasspath.EnvVar),
 		envVar.GetString(envAlluxioAssemblyServerJar),
 	}, ":"))
@@ -135,7 +135,7 @@ func InitAlluxioEnv(rootPath string) error {
 	if alluxioJavaOpts != "" {
 		// warn about setting configuration through java opts that should be set through environment variables instead
 		for _, c := range []*AlluxioConfigEnvVar{
-			confAlluxioConfDir,
+			ConfAlluxioConfDir,
 			ConfAlluxioLogsDir,
 			confAlluxioUserLogsDir,
 		} {
@@ -147,7 +147,7 @@ func InitAlluxioEnv(rootPath string) error {
 
 	for _, c := range []*AlluxioConfigEnvVar{
 		confAlluxioHome,
-		confAlluxioConfDir,
+		ConfAlluxioConfDir,
 		ConfAlluxioLogsDir,
 		confAlluxioUserLogsDir,
 	} {
@@ -163,7 +163,7 @@ func InitAlluxioEnv(rootPath string) error {
 		alluxioJavaOpts += c.ToJavaOpt(envVar, false) // optional user provided java opts
 	}
 
-	alluxioJavaOpts += fmt.Sprintf(JavaOptFormat, "log4j.configuration", "file:"+filepath.Join(envVar.GetString(confAlluxioConfDir.EnvVar), "log4j.properties"))
+	alluxioJavaOpts += fmt.Sprintf(JavaOptFormat, "log4j.configuration", "file:"+filepath.Join(envVar.GetString(ConfAlluxioConfDir.EnvVar), "log4j.properties"))
 	alluxioJavaOpts += fmt.Sprintf(JavaOptFormat, "org.apache.jasper.compiler.disablejsr199", true)
 	alluxioJavaOpts += fmt.Sprintf(JavaOptFormat, "java.net.preferIPv4Stack", true)
 	alluxioJavaOpts += fmt.Sprintf(JavaOptFormat, "org.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads", false)

--- a/cli/src/alluxio.org/cli/env/env_vars.go
+++ b/cli/src/alluxio.org/cli/env/env_vars.go
@@ -50,7 +50,7 @@ const (
 )
 
 var (
-	confAlluxioConfDir = &AlluxioConfigEnvVar{
+	ConfAlluxioConfDir = &AlluxioConfigEnvVar{
 		configKey: "alluxio.conf.dir",
 		EnvVar:    "ALLUXIO_CONF_DIR",
 	}

--- a/cli/src/alluxio.org/cli/main.go
+++ b/cli/src/alluxio.org/cli/main.go
@@ -16,6 +16,7 @@ import (
 
 	"alluxio.org/cli/cmd/conf"
 	"alluxio.org/cli/cmd/fs"
+	"alluxio.org/cli/cmd/generate"
 	"alluxio.org/cli/cmd/info"
 	"alluxio.org/cli/cmd/journal"
 	"alluxio.org/cli/cmd/process"
@@ -39,6 +40,7 @@ func main() {
 	for _, c := range []*env.Service{
 		conf.Service,
 		fs.Service,
+		generate.Service,
 		info.Service,
 		journal.Service,
 		process.Service,


### PR DESCRIPTION
Add generate commands to golang CLI as part of #17522 

bin/alluxio docGen -> bin/cli generate docs
bin/alluxio bootstrapConf -> bin/cli generate template

to read ALLUXIO_CONF_DIR, also conducted a minor change on env variables.


