### PR TITLE
Fix base docker image for alluxio-maven jdk17

### DIFF
--- a/dev/github/Dockerfile-jdk17
+++ b/dev/github/Dockerfile-jdk17
@@ -11,7 +11,7 @@
 
 # See https://hub.docker.com/r/alluxio/alluxio-maven for instructions on running the image.
 
-FROM maven:3.8.6-jdk-17
+FROM maven:3.8.6
 
 # reference: https://github.com/docker-library/openjdk/blob/master/8/jdk/buster/Dockerfile
 # we need jdk 8 in jdk 17 so that we can compile with jdk 8 and test with jdk 17

--- a/dev/github/Dockerfile-jdk17
+++ b/dev/github/Dockerfile-jdk17
@@ -11,7 +11,7 @@
 
 # See https://hub.docker.com/r/alluxio/alluxio-maven for instructions on running the image.
 
-FROM maven:3.8.6
+FROM maven:3.8.6-eclipse-temurin-17
 
 # reference: https://github.com/docker-library/openjdk/blob/master/8/jdk/buster/Dockerfile
 # we need jdk 8 in jdk 17 so that we can compile with jdk 8 and test with jdk 17


### PR DESCRIPTION
no maven openjdk image for 17 according to https://hub.docker.com/_/maven/tags?page=1&name=3.8.6-open but the default 3.8.6 is available as an eclipse-temurin flavor of java17: [3.8.6-eclipse-temurin-17](https://hub.docker.com/layers/library/maven/3.8.6-eclipse-temurin-17/images/sha256-d9035c93956cda1f067a6fe5d120c6c3575830dd651802e72c8e9376b78563b9?context=explore)