### PR TITLE
Remove shading for alluxio-test module

### DIFF
--- a/dora/integration/tools/validation/src/main/java/alluxio/cli/S3ASpecificOperations.java
+++ b/dora/integration/tools/validation/src/main/java/alluxio/cli/S3ASpecificOperations.java
@@ -160,4 +160,15 @@ public final class S3ASpecificOperations {
       throw new IOException("The in progress multipart upload did not be aborted.");
     }
   }
+
+  /**
+   * Test for listing status of the root directory of the UFS.
+   */
+  @RelatedS3Operations(operations = {"putObject", "listObjectsV2", "getObjectMetadata"})
+  public void listStatusS3RootTest() throws IOException {
+    UfsStatus[] rootList = mUfs.listStatus("/");
+    if (rootList == null || rootList.length == 0) {
+      throw new IOException("Unable to list UFS root path");
+    }
+  }
 }

--- a/dora/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemCommonOperations.java
+++ b/dora/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemCommonOperations.java
@@ -611,17 +611,6 @@ public final class UnderFileSystemCommonOperations {
   }
 
   /**
-   * Test for listing status of the root directory of the UFS.
-   */
-  @RelatedS3Operations(operations = {"putObject", "listObjectsV2", "getObjectMetadata"})
-  public void listStatusRootTest() throws IOException {
-    UfsStatus[] rootList = mUfs.listStatus("/");
-    if (rootList == null || rootList.length == 0) {
-      throw new IOException("Unable to list UFS root path");
-    }
-  }
-
-  /**
    * Test for listing status.
    */
   @RelatedS3Operations(operations = {"putObject", "listObjectsV2", "getObjectMetadata"})

--- a/dora/tests/pom.xml
+++ b/dora/tests/pom.xml
@@ -358,37 +358,6 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>uber-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
-              <filters>
-                <filter>
-                  <artifact>*:* </artifact>
-                  <excludes>
-                    <exclude>LICENSE</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <!-- Export test classes in a test-jar so that other projects can use them for testing -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Stop shading alluxio-test.

### Why are the changes needed?

Shading a module is slow and error-prone. The shading of the `alluxio-test` module was previously introduced in https://github.com/Alluxio/alluxio/pull/7765 for journal-related tests. There is no longer a need to shade this module.

As part of this PR, `listStatusRootTest` (introduced in https://github.com/Alluxio/alluxio/pull/15361/) has been moved to the S3 specific tests. This move was made because the test failed after the shading was removed on my local MacOS (although it passes CI on Linux), likely due to an unusual setting of the root directory on MacOS. I am unsure why removing shading on `alluxio-test` also impacts `alluxio-integration-tools-validation`. However, based on the description of https://github.com/Alluxio/alluxio/pull/15361, it does seem to fit better in the S3 specific tests.

### Does this PR introduce any user facing changes?

n/a