### PR TITLE
Use full ufs path instead of status as file identity

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -453,8 +453,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
   @Override
   public List<BlockLocationInfo> getBlockLocations(URIStatus status)
       throws IOException, AlluxioException {
-    AlluxioURI ufsPath = convertAlluxioPathToUFSPath(new AlluxioURI(status.getUfsPath()));
-    WorkerNetAddress workerNetAddress = mDoraClient.getWorkerNetAddress(ufsPath.toString());
+    WorkerNetAddress workerNetAddress = mDoraClient.getWorkerNetAddress(status.getUfsPath());
     // Dora does not have blocks; to apps who need block location info, we split multiple virtual
     // blocks from a file according to a fixed size
     long blockSize = mDefaultVirtualBlockSize;
@@ -472,7 +471,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
           .setLocations(ImmutableList.of(blockLocation));
 
       FileBlockInfo fbi = new FileBlockInfo()
-          .setUfsLocations(ImmutableList.of(ufsPath.toString()))
+          .setUfsLocations(ImmutableList.of(status.getUfsPath()))
           .setBlockInfo(bi)
           .setOffset(offset);
 

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
@@ -146,7 +146,7 @@ public class DoraCacheClient {
   public DoraCachePositionReader createNettyPositionReader(URIStatus status,
       Protocol.OpenUfsBlockOptions ufsOptions,
       CloseableSupplier<PositionReader> externalPositionReader) {
-    WorkerNetAddress workerNetAddress = getWorkerNetAddress(status.toString());
+    WorkerNetAddress workerNetAddress = getWorkerNetAddress(status.getUfsPath());
     // Construct the partial read request
     NettyDataReader reader = createNettyDataReader(workerNetAddress, ufsOptions);
     return new DoraCachePositionReader(reader, status.getLength(), externalPositionReader);


### PR DESCRIPTION
Fix the code to ufs full ufs path as file identity instead of complicated URIStatus.toString()