### PR TITLE
[DOCFIX] Fix table format issue for Properties-List page

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -6,6 +6,7 @@ a.dropdown-item.active {
     color: white;
 }
 
+
 .version {
     line-height: 23px;
     vertical-align: middle;

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -6,6 +6,12 @@ a.dropdown-item.active {
     color: white;
 }
 
+.table{
+    table-layout: fixed;
+}
+.table td{
+    word-break: break-word;
+}
 
 .version {
     line-height: 23px;


### PR DESCRIPTION
 the table exceeds its own div on current the page:
![image](https://github.com/Alluxio/alluxio/assets/107361923/a0d024f6-03fe-45b7-ab00-9997cf1f745d)

fixed example without format:
![image](https://github.com/Alluxio/alluxio/assets/107361923/bbfdaa86-515a-4512-95c0-39ac7a3a4776)

with format:
![image](https://github.com/Alluxio/alluxio/assets/107361923/b5cba6d9-d8e5-42fe-b822-3025e406b62f)
