### PR TITLE
Fix the GrpcUtils#contains logic to more reasonable

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
@@ -715,6 +715,15 @@ public final class GrpcUtils {
    * @return true if target enum is contained within the source
    */
   public static boolean contains(Scope source, Scope target) {
+    return (source.getNumber() | target.getNumber()) == source.getNumber();
+  }
+
+  /**
+   * @param source source enum
+   * @param target target enum
+   * @return true if source enum is contained within the target scope
+   */
+  public static boolean containsInScope(Scope source, Scope target) {
     return (source.getNumber() & target.getNumber()) != 0;
   }
 

--- a/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
@@ -715,7 +715,7 @@ public final class GrpcUtils {
    * @return true if target enum is contained within the source
    */
   public static boolean contains(Scope source, Scope target) {
-    return (source.getNumber() | target.getNumber()) == source.getNumber();
+    return (source.getNumber() & target.getNumber()) != 0;
   }
 
   /**

--- a/core/common/src/test/java/alluxio/grpc/GrpcUtilsTest.java
+++ b/core/common/src/test/java/alluxio/grpc/GrpcUtilsTest.java
@@ -55,7 +55,6 @@ public class GrpcUtilsTest {
     Assert.assertFalse(GrpcUtils.contains(Scope.SERVER, Scope.CLIENT));
     Assert.assertFalse(GrpcUtils.contains(Scope.NONE, Scope.CLIENT));
 
-    // Old behavior
     Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.SERVER));
     Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.SERVER));
     Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.SERVER));
@@ -101,7 +100,6 @@ public class GrpcUtilsTest {
     Assert.assertFalse(GrpcUtils.containsInScope(Scope.SERVER, Scope.CLIENT));
     Assert.assertFalse(GrpcUtils.containsInScope(Scope.NONE, Scope.CLIENT));
 
-    // New behavior
     Assert.assertTrue(GrpcUtils.containsInScope(Scope.ALL, Scope.SERVER));
     Assert.assertTrue(GrpcUtils.containsInScope(Scope.SERVER, Scope.SERVER));
     Assert.assertTrue(GrpcUtils.containsInScope(Scope.MASTER, Scope.SERVER));

--- a/core/common/src/test/java/alluxio/grpc/GrpcUtilsTest.java
+++ b/core/common/src/test/java/alluxio/grpc/GrpcUtilsTest.java
@@ -31,4 +31,51 @@ public class GrpcUtilsTest {
     Assert.assertEquals("localhost", inetSocketAddressList[0].getHostName());
     Assert.assertEquals(1, inetSocketAddressList[0].getPort());
   }
+
+  @Test
+  public void contains() throws Exception {
+    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.MASTER));
+    Assert.assertTrue(GrpcUtils.contains(Scope.MASTER, Scope.MASTER));
+    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.MASTER));
+    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.MASTER));
+    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.MASTER));
+
+    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.WORKER));
+    Assert.assertTrue(GrpcUtils.contains(Scope.WORKER, Scope.WORKER));
+    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.WORKER));
+    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.WORKER));
+    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.WORKER));
+
+    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.CLIENT));
+    Assert.assertTrue(GrpcUtils.contains(Scope.CLIENT, Scope.CLIENT));
+    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.CLIENT));
+    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.CLIENT));
+    Assert.assertFalse(GrpcUtils.contains(Scope.SERVER, Scope.CLIENT));
+
+    // Old behavior
+//    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.SERVER));
+//    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.SERVER));
+//    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.SERVER));
+//    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.SERVER));
+//    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.SERVER));
+//
+//    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.ALL));
+//    Assert.assertFalse(GrpcUtils.contains(Scope.SERVER, Scope.ALL));
+//    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.ALL));
+//    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.ALL));
+//    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.ALL));
+
+    // New behavior
+    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.SERVER));
+    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.SERVER));
+    Assert.assertTrue(GrpcUtils.contains(Scope.MASTER, Scope.SERVER));
+    Assert.assertTrue(GrpcUtils.contains(Scope.WORKER, Scope.SERVER));
+    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.SERVER));
+
+    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.ALL));
+    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.ALL));
+    Assert.assertTrue(GrpcUtils.contains(Scope.MASTER, Scope.ALL));
+    Assert.assertTrue(GrpcUtils.contains(Scope.WORKER, Scope.ALL));
+    Assert.assertTrue(GrpcUtils.contains(Scope.CLIENT, Scope.ALL));
+  }
 }

--- a/core/common/src/test/java/alluxio/grpc/GrpcUtilsTest.java
+++ b/core/common/src/test/java/alluxio/grpc/GrpcUtilsTest.java
@@ -33,49 +33,87 @@ public class GrpcUtilsTest {
   }
 
   @Test
-  public void contains() throws Exception {
+  public void contains() {
     Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.MASTER));
     Assert.assertTrue(GrpcUtils.contains(Scope.MASTER, Scope.MASTER));
     Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.MASTER));
     Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.MASTER));
     Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.MASTER));
+    Assert.assertFalse(GrpcUtils.contains(Scope.NONE, Scope.MASTER));
 
     Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.WORKER));
     Assert.assertTrue(GrpcUtils.contains(Scope.WORKER, Scope.WORKER));
     Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.WORKER));
     Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.WORKER));
     Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.WORKER));
+    Assert.assertFalse(GrpcUtils.contains(Scope.NONE, Scope.WORKER));
 
     Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.CLIENT));
     Assert.assertTrue(GrpcUtils.contains(Scope.CLIENT, Scope.CLIENT));
     Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.CLIENT));
     Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.CLIENT));
     Assert.assertFalse(GrpcUtils.contains(Scope.SERVER, Scope.CLIENT));
+    Assert.assertFalse(GrpcUtils.contains(Scope.NONE, Scope.CLIENT));
 
     // Old behavior
-//    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.SERVER));
-//    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.SERVER));
-//    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.SERVER));
-//    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.SERVER));
-//    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.SERVER));
-//
-//    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.ALL));
-//    Assert.assertFalse(GrpcUtils.contains(Scope.SERVER, Scope.ALL));
-//    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.ALL));
-//    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.ALL));
-//    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.ALL));
-
-    // New behavior
     Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.SERVER));
     Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.SERVER));
-    Assert.assertTrue(GrpcUtils.contains(Scope.MASTER, Scope.SERVER));
-    Assert.assertTrue(GrpcUtils.contains(Scope.WORKER, Scope.SERVER));
+    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.SERVER));
+    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.SERVER));
     Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.SERVER));
+    Assert.assertFalse(GrpcUtils.contains(Scope.NONE, Scope.SERVER));
 
     Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.ALL));
-    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.ALL));
-    Assert.assertTrue(GrpcUtils.contains(Scope.MASTER, Scope.ALL));
-    Assert.assertTrue(GrpcUtils.contains(Scope.WORKER, Scope.ALL));
-    Assert.assertTrue(GrpcUtils.contains(Scope.CLIENT, Scope.ALL));
+    Assert.assertFalse(GrpcUtils.contains(Scope.SERVER, Scope.ALL));
+    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.ALL));
+    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.ALL));
+    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.ALL));
+    Assert.assertFalse(GrpcUtils.contains(Scope.NONE, Scope.ALL));
+
+    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.NONE));
+    Assert.assertTrue(GrpcUtils.contains(Scope.NONE, Scope.NONE));
+    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.NONE));
+    Assert.assertTrue(GrpcUtils.contains(Scope.MASTER, Scope.NONE));
+    Assert.assertTrue(GrpcUtils.contains(Scope.WORKER, Scope.NONE));
+    Assert.assertTrue(GrpcUtils.contains(Scope.CLIENT, Scope.NONE));
+  }
+
+  @Test
+  public void containsInScope() {
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.ALL, Scope.MASTER));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.MASTER, Scope.MASTER));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.SERVER, Scope.MASTER));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.CLIENT, Scope.MASTER));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.WORKER, Scope.MASTER));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.NONE, Scope.MASTER));
+
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.ALL, Scope.WORKER));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.WORKER, Scope.WORKER));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.SERVER, Scope.WORKER));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.CLIENT, Scope.WORKER));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.MASTER, Scope.WORKER));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.NONE, Scope.WORKER));
+
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.ALL, Scope.CLIENT));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.CLIENT, Scope.CLIENT));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.MASTER, Scope.CLIENT));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.WORKER, Scope.CLIENT));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.SERVER, Scope.CLIENT));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.NONE, Scope.CLIENT));
+
+    // New behavior
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.ALL, Scope.SERVER));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.SERVER, Scope.SERVER));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.MASTER, Scope.SERVER));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.WORKER, Scope.SERVER));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.CLIENT, Scope.SERVER));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.NONE, Scope.SERVER));
+
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.ALL, Scope.ALL));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.SERVER, Scope.ALL));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.MASTER, Scope.ALL));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.WORKER, Scope.ALL));
+    Assert.assertTrue(GrpcUtils.containsInScope(Scope.CLIENT, Scope.ALL));
+    Assert.assertFalse(GrpcUtils.containsInScope(Scope.NONE, Scope.ALL));
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

The original behavior of GrpcUtils#contains is wired, the following ut is passed

```java
    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.MASTER));
    Assert.assertTrue(GrpcUtils.contains(Scope.MASTER, Scope.MASTER));
    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.MASTER));
    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.MASTER));
    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.MASTER));

    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.WORKER));
    Assert.assertTrue(GrpcUtils.contains(Scope.WORKER, Scope.WORKER));
    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.WORKER));
    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.WORKER));
    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.WORKER));

    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.CLIENT));
    Assert.assertTrue(GrpcUtils.contains(Scope.CLIENT, Scope.CLIENT));
    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.CLIENT));
    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.CLIENT));
    Assert.assertFalse(GrpcUtils.contains(Scope.SERVER, Scope.CLIENT));

    // Old behavior
    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.SERVER));
    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.SERVER));
    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.SERVER));
    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.SERVER));
    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.SERVER));

    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.ALL));
    Assert.assertFalse(GrpcUtils.contains(Scope.SERVER, Scope.ALL));
    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.ALL));
    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.ALL));
    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.ALL));
```

After this PR

```java
    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.MASTER));
    Assert.assertTrue(GrpcUtils.contains(Scope.MASTER, Scope.MASTER));
    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.MASTER));
    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.MASTER));
    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.MASTER));

    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.WORKER));
    Assert.assertTrue(GrpcUtils.contains(Scope.WORKER, Scope.WORKER));
    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.WORKER));
    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.WORKER));
    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.WORKER));

    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.CLIENT));
    Assert.assertTrue(GrpcUtils.contains(Scope.CLIENT, Scope.CLIENT));
    Assert.assertFalse(GrpcUtils.contains(Scope.MASTER, Scope.CLIENT));
    Assert.assertFalse(GrpcUtils.contains(Scope.WORKER, Scope.CLIENT));
    Assert.assertFalse(GrpcUtils.contains(Scope.SERVER, Scope.CLIENT));

    // New behavior
    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.SERVER));
    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.SERVER));
    Assert.assertTrue(GrpcUtils.contains(Scope.MASTER, Scope.SERVER));
    Assert.assertTrue(GrpcUtils.contains(Scope.WORKER, Scope.SERVER));
    Assert.assertFalse(GrpcUtils.contains(Scope.CLIENT, Scope.SERVER));

    Assert.assertTrue(GrpcUtils.contains(Scope.ALL, Scope.ALL));
    Assert.assertTrue(GrpcUtils.contains(Scope.SERVER, Scope.ALL));
    Assert.assertTrue(GrpcUtils.contains(Scope.MASTER, Scope.ALL));
    Assert.assertTrue(GrpcUtils.contains(Scope.WORKER, Scope.ALL));
    Assert.assertTrue(GrpcUtils.contains(Scope.CLIENT, Scope.ALL));
```

Let's see some caller of this method

```java
  private static Properties filterAndLoadProperties(List<ConfigProperty> properties,
      Scope scope, BiFunction<PropertyKey, String, String> logMessage) {
    Properties props = new Properties();
    for (ConfigProperty property : properties) {
      String name = property.getName();
      // TODO(binfan): support propagating unsetting properties from master
      if (PropertyKey.isValid(name) && property.hasValue()) {
        PropertyKey key = PropertyKey.fromString(name);
        if (!GrpcUtils.contains(key.getScope(), scope)) {
          // Only propagate properties contains the target scope
          continue;
        }
        String value = property.getValue();
        props.put(key, value);
        LOG.debug(logMessage.apply(key, value));
      }
    }
    return props;
  }


  /**
   * Gets all configuration properties filtered by the specified scope.
   *
   * @param scope the scope to filter by
   * @return the properties
   */
  public static List<ConfigProperty> getConfiguration(Scope scope) {
    AlluxioConfiguration conf = global();
    ConfigurationValueOptions useRawDisplayValue =
        ConfigurationValueOptions.defaults().useDisplayValue(true);

    return conf.keySet().stream()
            .filter(key -> GrpcUtils.contains(key.getScope(), scope))
            .map(key -> {
              ConfigProperty.Builder configProp = ConfigProperty.newBuilder().setName(key.getName())
                  .setSource(conf.getSource(key).toString());
              if (conf.isSet(key)) {
                configProp.setValue(String.valueOf(conf.get(key, useRawDisplayValue)));
              }
              return configProp.build();
            })
            .collect(ImmutableList.toImmutableList());
  }
```

Let's think about if we call `getConfiguration(Scope.SERVER) ` or `getConfiguration(Scope.ALL) `, what kind of propertykey should be returned?

### Why are the changes needed?

Change to more reasonable.

### Does this PR introduce any user facing changes?

No
