### PR TITLE
[DOCFIX] Delete mount command links, Add resources to Get Started

### DIFF
--- a/docs/en/Get-Started.md
+++ b/docs/en/Get-Started.md
@@ -210,16 +210,14 @@ Congratulations on getting Alluxio started! This guide covered how to
 download and install Alluxio locally with examples of basic interactions via the Alluxio
 shell.
 
-There are several next steps available. 
+There are several next steps available:
 * Learn more about the various features of Alluxio in
 our documentation, such as [Data Caching]({{ '/en/core-services/Data-Caching.html' | relativize_url }}) and [Metadata Caching]({{ '/en/core-services/Metadata-Caching.html' | relativize_url }}). 
 * See how you can [Install an Alluxio Cluster with High Availability (HA)]({{ '/en/deploy/Install-Alluxio-Cluster-with-HA.html' | relativize_url }})
    * You can also [Install Alluxio on Kubernetes]({{ '/en/kubernetes/Install-Alluxio-On-Kubernetes.html' | relativize_url }}) with Alluxio K8s Helm Chart or Alluxio K8s Operator
 * Connect a compute engine such as [Presto]({{ '/en/compute/Presto.html' | relativize_url }}), [Trino]({{ '/en/compute/Trino.html' | relativize_url }}), or [Apache Spark]({{ '/en/compute/Spark.html' | relativize_url }})
 * Connect an under file storage such as [Amazon AWS S3]({{ '/en/ufs/S3.html' | relativize_url }}), [HDFS]({{ '/en/ufs/HDFS.html' | relativize_url }}), or [Google Cloud Storage]({{ '/en/ufs/GCS.html' | relativize_url }})
-
-The resources below detail deploying Alluxio in various ways,
-mounting existing storage systems, and configuring existing applications to interact with Alluxio.
+* Check out our [Contribution Guide]({{ '/en/contributor/Contribution-Guide.html' | relativize_url }}) if you're interested in becoming a contributor!
 
 ## FAQ
 

--- a/docs/en/Get-Started.md
+++ b/docs/en/Get-Started.md
@@ -10,6 +10,7 @@ The guide will cover the following tasks:
 * Start Alluxio locally
 * Perform basic tasks via Alluxio Shell
 * **[Bonus]** Mount a public Amazon S3 bucket in Alluxio
+* **[Bonus]** Mount HDFS under storage in Alluxio
 * Stop Alluxio
 
 **[Bonus]** This guide contains optional tasks that use credentials from an
@@ -105,10 +106,10 @@ $ echo "s3a.accessKeyId=<AWS_ACCESS_KEY_ID>" >> conf/alluxio-site.properties
 $ echo "s3a.secretKey=<AWS_SECRET_ACCESS_KEY>" >> conf/alluxio-site.properties
 ```
 
-Replace **`s3://<BUCKET_NAME>/<DIR>`**, **`<AWS_ACCESS_KEY_ID>`** and **`<AWS_SECRET_ACCESS_KEY>`** with
+Replace `s3://<BUCKET_NAME>/<DIR>`, `<AWS_ACCESS_KEY_ID>` and `<AWS_SECRET_ACCESS_KEY>` with
 a valid AWS S3 address, AWS access key ID and AWS secret access key respectively.
 
-For more information, please refer to the [S3 configuration docs]({{ '/en/ufs/S3.html' | relativize_url }}.
+For more information, please refer to the [S3 configuration docs]({{ '/en/ufs/S3.html' | relativize_url }}).
 
 ### [Bonus] Configuration for HDFS
 
@@ -119,9 +120,9 @@ $ echo "alluxio.dora.client.ufs.root=hdfs://nameservice/<DIR>" >> conf/alluxio-s
 $ echo "alluxio.underfs.hdfs.configuration=/path/to/hdfs/conf/core-site.xml:/path/to/hdfs/conf/hdfs-site.xml" >> conf/alluxio-site.properties
 ```
 
-Replace the url and configuration with the actual value.
+Replace `nameservice/<DIR>` and `/path/to/hdfs/conf` with the actual values.
 
-For more information, please refer to the [HDFS configuration docs]({{ '/en/ufs/HDFS.html' | relativize_url }}.
+For more information, please refer to the [HDFS configuration docs]({{ '/en/ufs/HDFS.html' | relativize_url }}).
 
 ## Starting Alluxio
 

--- a/docs/en/Get-Started.md
+++ b/docs/en/Get-Started.md
@@ -7,7 +7,6 @@ This quick start guide goes over how to run Alluxio on a local machine.
 The guide will cover the following tasks:
 
 * Download and configure Alluxio
-* Validate the Alluxio environment
 * Start Alluxio locally
 * Perform basic tasks via Alluxio Shell
 * **[Bonus]** Mount a public Amazon S3 bucket in Alluxio
@@ -204,14 +203,21 @@ $ ./bin/alluxio-stop.sh master
 $ ./bin/alluxio-stop.sh worker
 ```
 
-## Conclusion
+## Next Steps
 
-Congratulations on completing the quick start guide for Alluxio! This guide covered how to
+Congratulations on getting Alluxio started! This guide covered how to
 download and install Alluxio locally with examples of basic interactions via the Alluxio
-shell. This was a simple example on how to get started with Alluxio.
+shell.
 
-There are several next steps available. Learn more about the various features of Alluxio in
-our documentation. The resources below detail deploying Alluxio in various ways,
+There are several next steps available. 
+* Learn more about the various features of Alluxio in
+our documentation, such as [Data Caching]({{ '/en/core-services/Data-Caching.html' | relativize_url }}) and [Metadata Caching]({{ '/en/core-services/Metadata-Caching.html' | relativize_url }}). 
+* See how you can [Install an Alluxio Cluster with High Availability (HA)]({{ '/en/deploy/Install-Alluxio-Cluster-with-HA.html' | relativize_url }})
+   * You can also [Install Alluxio on Kubernetes]({{ '/en/kubernetes/Install-Alluxio-On-Kubernetes.html' | relativize_url }}) with Alluxio Helm Chart
+* Connect a compute engine such as [Presto]({{ '/en/compute/Presto.html' | relativize_url }}), [Trino]({{ '/en/compute/Trino.html' | relativize_url }}), or [Spark]({{ '/en/compute/Spark.html' | relativize_url }})
+* Connect an under file storage such as [Amazon AWS S3]({{ '/en/ufs/S3.html' | relativize_url }}), [HDFS]({{ '/en/ufs/HDFS.html' | relativize_url }}), or [Google Cloud Storage]({{ '/en/ufs/GCS.html' | relativize_url }})
+
+The resources below detail deploying Alluxio in various ways,
 mounting existing storage systems, and configuring existing applications to interact with Alluxio.
 
 ## FAQ

--- a/docs/en/Get-Started.md
+++ b/docs/en/Get-Started.md
@@ -214,8 +214,8 @@ There are several next steps available.
 * Learn more about the various features of Alluxio in
 our documentation, such as [Data Caching]({{ '/en/core-services/Data-Caching.html' | relativize_url }}) and [Metadata Caching]({{ '/en/core-services/Metadata-Caching.html' | relativize_url }}). 
 * See how you can [Install an Alluxio Cluster with High Availability (HA)]({{ '/en/deploy/Install-Alluxio-Cluster-with-HA.html' | relativize_url }})
-   * You can also [Install Alluxio on Kubernetes]({{ '/en/kubernetes/Install-Alluxio-On-Kubernetes.html' | relativize_url }}) with Alluxio Helm Chart
-* Connect a compute engine such as [Presto]({{ '/en/compute/Presto.html' | relativize_url }}), [Trino]({{ '/en/compute/Trino.html' | relativize_url }}), or [Spark]({{ '/en/compute/Spark.html' | relativize_url }})
+   * You can also [Install Alluxio on Kubernetes]({{ '/en/kubernetes/Install-Alluxio-On-Kubernetes.html' | relativize_url }}) with Alluxio K8s Helm Chart or Alluxio K8s Operator
+* Connect a compute engine such as [Presto]({{ '/en/compute/Presto.html' | relativize_url }}), [Trino]({{ '/en/compute/Trino.html' | relativize_url }}), or [Apache Spark]({{ '/en/compute/Spark.html' | relativize_url }})
 * Connect an under file storage such as [Amazon AWS S3]({{ '/en/ufs/S3.html' | relativize_url }}), [HDFS]({{ '/en/ufs/HDFS.html' | relativize_url }}), or [Google Cloud Storage]({{ '/en/ufs/GCS.html' | relativize_url }})
 
 The resources below detail deploying Alluxio in various ways,

--- a/docs/en/Overview.md
+++ b/docs/en/Overview.md
@@ -7,11 +7,11 @@ Welcome to Alluxio Documentation! You will find resources regarding deploying Al
 
 ## Get Started with Alluxio
 
-Check out our [Quick Start Guide]({{ '/en/Get-Started.html' | relativize_url }}) for step-by-step guidance on how to download Alluxio, run Alluxio on a local machine, and perform basic tasks via Alluxio Shell.
+Check out our [Quick Start Guide]({{ '/en/Get-Started.html' | relativize_url }}) for step-by-step guidance on how to download and configure Alluxio, run Alluxio on a local machine, and perform basic tasks via Alluxio Shell.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/5YQvvznT5cI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-Follow [Install Alluxio Cluster with HA]({{ '/en/deploy/Install-Alluxio-Cluster-with-HA.html' | relativize_url }}) to deploy an Alluxio cluster with High Availability (HA) by running multiple Alluxio master processes on different nodes in the system.
+Follow [Install Alluxio Cluster with HA]({{ '/en/deploy/Install-Alluxio-Cluster-with-HA.html' | relativize_url }}) to deploy an Alluxio cluster with High Availability (HA), which is achieved by running multiple Alluxio master processes on different nodes in the system.
 
 ## Kubernetes
 See [Install Alluxio on Kubernetes]({{ '/en/kubernetes/Install-Alluxio-On-Kubernetes.html' | relativize_url }}) on how to install Alluxio on Kubernetes via 

--- a/docs/en/Overview.md
+++ b/docs/en/Overview.md
@@ -28,7 +28,7 @@ Check out these 2 short videos on deployment and best practices with configurati
 
 * [Running Trino with Alluxio]({{ '/en/compute/Trino.html' | relativize_url }})
 
-* [Running Spark with Alluxio]({{ '/en/compute/Spark.html' | relativize_url }})
+* [Running Apache Spark with Alluxio]({{ '/en/compute/Spark.html' | relativize_url }})
 
 ## Storage Integrations
 * [Amazon AWS S3]({{ '/en/ufs/S3.html' | relativize_url }})

--- a/docs/en/compute/Hadoop-MapReduce.md
+++ b/docs/en/compute/Hadoop-MapReduce.md
@@ -1,9 +1,9 @@
 ---
 layout: global
-title: Running Hadoop MapReduce on Alluxio
+title: Running Apache Hadoop MapReduce on Alluxio
 ---
 
-This guide describes how to configure Alluxio with Apache Hadoop MapReduce, so that your
+This guide describes how to configure Alluxio with [Apache Hadoop MapReduce](https://hadoop.apache.org/docs/stable/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html), so that your
 MapReduce programs can read+write data stored in Alluxio.
 
 ## Prerequisites

--- a/docs/en/compute/Presto.md
+++ b/docs/en/compute/Presto.md
@@ -3,6 +3,9 @@ layout: global
 title: Running Presto with Alluxio
 ---
 
+This guide describes how to configure [Presto](https://prestodb.io/) to access Alluxio.
+
+## Overview
 [Presto](https://prestodb.io/)
 is an open source distributed SQL query engine for running interactive analytic queries
 on data at a large scale.

--- a/docs/en/compute/Spark.md
+++ b/docs/en/compute/Spark.md
@@ -1,6 +1,6 @@
 ---
 layout: global
-title: Running Spark on Alluxio
+title: Running Apache Spark on Alluxio
 ---
 
 This guide describes how to configure [Apache Spark](http://spark-project.org/)

--- a/docs/en/compute/Trino.md
+++ b/docs/en/compute/Trino.md
@@ -118,7 +118,8 @@ directly).
 Run a single query (replace `localhost:8080` with your actual Trino server hostname and port):
 
 ```shell
-$ ./trino --server localhost:8080 --execute "use default; select * from u_user limit 10;" --catalog hive --debug
+$ ./trino --server localhost:8080 --execute "use default; select * from u_user limit 10;" \
+    --catalog hive --debug
 ```
 
 ## Advanced Setup

--- a/docs/en/compute/Trino.md
+++ b/docs/en/compute/Trino.md
@@ -3,6 +3,9 @@ layout: global
 title: Running Trino with Alluxio
 ---
 
+This guide describes how to configure [Trino](https://trino.io/) to access Alluxio.
+
+## Overview
 [Trino](https://trino.io/)
 is an open source distributed SQL query engine for running interactive analytic queries
 on data at a large scale.

--- a/docs/en/contributor/Contribution-Guide.md
+++ b/docs/en/contributor/Contribution-Guide.md
@@ -7,7 +7,7 @@ We warmly welcome you to the Alluxio community. We are excited for your contribu
 engagement with our project! This guide aims to give you step by step instructions on how
 to get started becoming a contributor to the Alluxio open source project.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/5YQvvznT5cI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/0KyxKd-swHw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ## Prerequisites
 

--- a/docs/en/contributor/Contribution-Guide.md
+++ b/docs/en/contributor/Contribution-Guide.md
@@ -244,14 +244,14 @@ PR description, adapted from
 `Alluxio/new-contributor-tasks`, like `Fixes Alluxio/new-contributor-tasks#1234`.
 
 Once everything is set, click on the **Create pull request** button. Congratulations! Your first
-pull request for Alluxio has been submitted!
+pull request for Alluxio has been submitted! After the pull request has been submitted, it can be found on the
+[Pull Request page of the Alluxio repository](https://github.com/Alluxio/alluxio/pulls).
+
+Make sure to sign the [Contributor License Agreement (CLA)](https://www.alluxio.io/app/uploads/2022/07/Contribution-License-Agreement-2022-Template.pdf) and email back to [cla@alluxio.org](mailto:cla@alluxio.org) so that we can starting reviewing your pull request. The name and email associated with your pull request must match the name and email found in your `git config` and in the signed CLA. See [Configuring Your Git Email]({{ '/en/contributor/Contribution-Guide.html#configuring-your-git-email' | relativize_url }}).
 
 ### Reviewing the Pull Request
 
-After the pull request has been submitted, it can be found on the
-[Pull Request page of the Alluxio repository](https://github.com/Alluxio/alluxio/pulls).
-
-After it is submitted, other developers in the community will review your pull request. Others may
+After your pull request is submitted, other developers in the community will review your pull request. Others may
 add comments or questions to your pull request. Tests and checks will also be run against the
 new changes to validate your changes are safe to merge.
 

--- a/docs/en/introduction/Glossary.md
+++ b/docs/en/introduction/Glossary.md
@@ -30,11 +30,19 @@ FUSE Kernel Cache
 FUSE Userspace Cache
 : Recommended for data cache, userspace cache is a cache mechanism that operates at the application or userspace level. It involves storing frequently accessed data closer to the application, typically in memory, to improve performance and reduce the need for expensive disk or network operations. Userspace cache provides a more fine-grain control on the cache (e.g. cache medium, maximum cache size, eviction policy) and the cache will not affect other applications in containerized environments unexpectedly. [Learn more]({{ '/en/fuse-sdk/Local-Cache.html' | relativize_url }})
 
+Helm
+: Helm is an open-source package manager for Kubernetes. It simplifies the deployment and management of applications on Kubernetes clusters by providing a templating engine and a collection of pre-configured application packages called "charts." 
+
+: Helm Charts help you define, install, and upgrade Kubernetes applications. See [Install Alluxio on Kubernetes]({{ '/en/kubernetes/Install-Alluxio-On-Kubernetes.html' | relativize_url }}) on how to use Helm Charts in your Alluxio deployment on Kubernetes.
+
 Job
 : A job is a computation or processing task performed by an application or framework that interacts with Alluxio as a data storage layer.
 
 Job Service
 : Job service helps in coordinating and monitoring the execution of jobs that involve data access or processing using Alluxio as the storage layer.
+
+Kubernetes
+: Kubernetes, also known as K8s, is an open-source system for automating deployment, scaling, and management of containerized applications. It groups containers that make up an application into logical units for easy management and discovery. [Install Alluxio on Kubernetes]({{ '/en/kubernetes/Install-Alluxio-On-Kubernetes.html' | relativize_url }})
 
 Master
 : The Alluxio Master serves all user requests and journals file system metadata changes. The Alluxio Job Master is the process which serves as a lightweight scheduler for file system operations which are then executed on Alluxio Job Workers.
@@ -43,6 +51,9 @@ Master
 
 Metadata Management
 : Alluxio manages metadata associated with data stored in various storage systems. It tracks metadata changes, provides metadata caching, and ensures consistency and coherence across different storage systems. [See more on Metadata Cache & Invalidation]({{ '/en/core-services/Metadata-Caching.html' | relativize_url }})
+
+Operator
+: An operator is a software extension for Kubernetes that makes use of custom resources to manage applications and their components. See [Install Alluxio on Kubernetes]({{ '/en/kubernetes/Install-Alluxio-On-Kubernetes.html' | relativize_url }}) on how to use Operator in your Alluxio deployment on Kubernetes.
 
 Paging Worker Storage
 : Alluxio supports finer-grained page-level caching storage on Alluxio workers, as an alternative option to the existing block-based tiered caching storage. This paging storage supports general workloads including reading and writing, with customizable cache eviction policies. [Learn more]({{ '/en/core-services/Data-Caching.html#paging-worker-storage' | relativize_url}})
@@ -61,6 +72,9 @@ Transparent Data Access
 
 Trino
 : Trino is a distributed SQL query engine designed for fast, interactive SQL queries across large-scale data sets, supporting a wide range of data sources and providing excellent performance and scalability. [Run Trino with Alluxio]({{ '/en/compute/Trino.html' | relativize_url }})
+
+Under File Storage (UFS)
+: Under File Storage, also referred to as under storage, is a type of storage that is represented as space not managed by Alluxio. UFS storage may come from an external file system, including HDFS or S3. [See Data Caching]({{ '/en/core-services/Data-Caching.html' | relativize_url}})
 
 Unified Namespace
 : Alluxio presents a unified namespace that spans multiple storage systems, creating a logical view of the data. It allows applications to interact with data consistently, regardless of where the data is physically stored.

--- a/docs/en/introduction/Introduction.md
+++ b/docs/en/introduction/Introduction.md
@@ -3,6 +3,12 @@ layout: global
 title: Introduction
 ---
 
+Check out these 2 short videos to learn about the existing data problems that Alluxio is designed to solve and where Alluxio sits in the big data ecosystem:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/_zenG90idAA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/py-kfEGRDZA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
 ## About Alluxio
 
 Alluxio is world's first open source [data orchestration technology](https://www.alluxio.io/blog/data-orchestration-the-missing-piece-in-the-data-world/)

--- a/docs/en/kubernetes/Install-Alluxio-On-Kubernetes.md
+++ b/docs/en/kubernetes/Install-Alluxio-On-Kubernetes.md
@@ -169,7 +169,7 @@ $ kubectl delete dataset <dataset-name>
 $ kubectl delete alluxiocluster <alluxio-cluster-name>
 ```
 
-### Bonus - Load the data into Alluxio
+### [Bonus] Load the data into Alluxio
 
 To load your data into Alluxio cluster, so that your application can read the data faster, create a
 resource file `load.yaml`. Here is an example:
@@ -193,7 +193,7 @@ To check the status of the load:
 $ kubectl get load
 ```
 
-### More bonus - an example alluxio cluster configuration for AI/ML use case
+### [Bonus] Example Alluxio cluster configuration for AI/ML use case
 ```yaml
 apiVersion: k8s-operator.alluxio.com/v1alpha1
 kind: AlluxioCluster

--- a/docs/en/kubernetes/Install-Alluxio-On-Kubernetes.md
+++ b/docs/en/kubernetes/Install-Alluxio-On-Kubernetes.md
@@ -12,9 +12,9 @@ We recommend using the operator to deploy Alluxio on Kubernetes. However,
 if some required permissions are missing, consider using helm chart instead.
 
 
-<iframe width="425" height="239" src="https://www.youtube.com/embed/FlvbekK_xG0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/FlvbekK_xG0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-<iframe width="425" height="239" src="https://www.youtube.com/embed/zwhMwiYmO8M" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/zwhMwiYmO8M" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ## Prerequisites
 

--- a/docs/en/operation/Journal.md
+++ b/docs/en/operation/Journal.md
@@ -73,20 +73,6 @@ when using multiple masters without Zookeeper. This property is not used when Zo
 If this is not set, clients will look for masters using the hostnames from `alluxio.master.embedded.journal.addresses`
 and the master rpc port (Default:`19998`).
 
-<!-- ### Advanced configuration
-
-<ul>
-{% for item in site.data.table.master-configuration %}
-    {% capture journal_properties %}{{ 'alluxio.master.embedded.journal.' }}{% endcapture %} 
-    {% assign journal_prop_size = journal_properties | size %}
-    {% assign result = item.propertyName | slice: 0, journal_prop_size %}
-    
-    {% if result == journal_properties %}
-        <li><code>{{ item.propertyName }}</code>: {{ site.data.table.en.master-configuration[item.propertyName] }} Default: <code>{{ item.defaultValue }}</code></li>
-    {% endif %}
-{% endfor %}
-</ul> -->
-
 ### Configuring the Job service
 
 It is usually best not to set any of these - by default the job master will use the same hostnames as the Alluxio master,

--- a/docs/en/operation/Journal.md
+++ b/docs/en/operation/Journal.md
@@ -21,8 +21,8 @@ based on a self-managed consensus protocol;
 whereas UFS journal stores edit logs in an external shared UFS storage,
 and relies on an external Zookeeper for coordination for HA mode.
 Starting from 2.2, the default journal type is `EMBEDDED`.
-This can be changed by setting the property "`alluxio.master.journal.type`" to "`UFS`"
-instead of "`EMBEDDED`".
+This can be changed by setting the property `alluxio.master.journal.type` to `UFS`
+instead of `EMBEDDED`.
 
 To choose between the default Embedded Journal and UFS journal,
 here are some aspects to consider:

--- a/docs/en/operation/Journal.md
+++ b/docs/en/operation/Journal.md
@@ -73,7 +73,7 @@ when using multiple masters without Zookeeper. This property is not used when Zo
 If this is not set, clients will look for masters using the hostnames from `alluxio.master.embedded.journal.addresses`
 and the master rpc port (Default:`19998`).
 
-### Advanced configuration
+<!-- ### Advanced configuration
 
 <ul>
 {% for item in site.data.table.master-configuration %}
@@ -85,7 +85,7 @@ and the master rpc port (Default:`19998`).
         <li><code>{{ item.propertyName }}</code>: {{ site.data.table.en.master-configuration[item.propertyName] }} Default: <code>{{ item.defaultValue }}</code></li>
     {% endif %}
 {% endfor %}
-</ul>
+</ul> -->
 
 ### Configuring the Job service
 

--- a/docs/en/ufs/Azure-Blob-Store.md
+++ b/docs/en/ufs/Azure-Blob-Store.md
@@ -22,8 +22,6 @@ called `<AZURE_DIRECTORY>`. For more information about Azure storage account, pl
 
 ## Basic Setup
 
-### Root Mount
-
 To use Azure blob store as the UFS of Alluxio root mount point,
 you need to configure Alluxio to use under storage systems by modifying
 `conf/alluxio-site.properties`. If it does not exist, create the configuration file from the

--- a/docs/en/ufs/Azure-Data-Lake-Gen2.md
+++ b/docs/en/ufs/Azure-Data-Lake-Gen2.md
@@ -20,8 +20,6 @@ the directory in that storage account is called `<AZURE_DIRECTORY>`, and the nam
 
 ## Setup with Shared Key
 
-### Root Mount
-
 To use Azure Data Lake Storage as the UFS of Alluxio root mount point,
 you need to configure Alluxio to use under storage systems by modifying
 `conf/alluxio-site.properties`. If it does not exist, create the configuration file from the
@@ -44,8 +42,6 @@ fs.azure.account.key.<AZURE_ACCOUNT>.dfs.core.windows.net=<SHARED_KEY>
 ```
 
 ## Setup with OAuth 2.0 Client Credentials
-
-### Root Mount
 
 To use Azure Data Lake Storage as the UFS of Alluxio root mount point,
 you need to configure Alluxio to use under storage systems by modifying
@@ -72,8 +68,6 @@ fs.azure.account.oauth2.client.secret=<CLIENT_SECRET>
 ```
 
 ## Setup with Azure Managed Identities
-
-### Root Mount
 
 To use Azure Data Lake Storage as the UFS of Alluxio root mount point,
 you need to configure Alluxio to use under storage systems by modifying

--- a/docs/en/ufs/Azure-Data-Lake.md
+++ b/docs/en/ufs/Azure-Data-Lake.md
@@ -51,19 +51,6 @@ fs.adl.account.<AZURE_ACCOUNT>.oauth2.credential=<AUTHENTICATION_KEY>
 fs.adl.account.<AZURE_ACCOUNT>.oauth2.refresh.url=https://login.microsoftonline.com/<TENANT_ID>/oauth2/token
 ```
 
-### Nested Mount
-An Azure Data Lake store location can be mounted at a nested directory in the Alluxio namespace to have unified access
-to multiple under storage systems. Alluxio's
-[Command Line Interface]({{ '/en/operation/User-CLI.html' | relativize_url }}) can be used for this purpose.
-
-```shell
-$ ./bin/alluxio fs mount \
-  --option fs.adl.account.<AZURE_ACCOUNT>.oauth2.client.id=<APPLICATION_ID>
-  --option fs.adl.account.<AZURE_ACCOUNT>.oauth2.credential=<AUTHENTICATION_KEY>
-  --option fs.adl.account.<AZURE_ACCOUNT>.oauth2.refresh.url=https://login.microsoftonline.com/<TENANT_ID>/oauth2/token
-  /mnt/adls adl://<AZURE_ACCOUNT>.azuredatalakestore.net/<AZURE_DIRECTORY>/
-```
-
 After these changes, Alluxio should be configured to work with Azure Data Lake storage as its under storage system, and you can run Alluxio locally with it.
 
 ## Running Alluxio Locally with Data Lake Storage

--- a/docs/en/ufs/Azure-Data-Lake.md
+++ b/docs/en/ufs/Azure-Data-Lake.md
@@ -23,8 +23,6 @@ about Azure storage account, please see
 
 ## Basic Setup
 
-### Root Mount
-
 To use Azure Data Lake Storage as the UFS of Alluxio root mount point,
 you need to configure Alluxio to use under storage systems by modifying
 `conf/alluxio-site.properties`. If it does not exist, create the configuration file from the

--- a/docs/en/ufs/COS.md
+++ b/docs/en/ufs/COS.md
@@ -85,22 +85,6 @@ $ ./bin/alluxio-stop.sh local
 
 ## Advanced Setup
 
-### Nested Mount
-
-An COS location can be mounted at a nested directory in the Alluxio namespace to have unified
-access to multiple under storage systems. Alluxio's
-[Mount Command]({{ '/en/operation/User-CLI.html' | relativize_url }}#mount) can be used for this purpose.
-For example, the following command mounts a directory inside an COS bucket into Alluxio directory
-`/cos`:
-
-```shell
-$ ./bin/alluxio fs mount --option fs.cos.access.key=<COS_SECRET_ID> \
-    --option fs.cos.secret.key=<COS_SECRET_KEY> \
-    --option fs.cos.region=<COS_REGION> \
-    --option fs.cos.app.id=<COS_APP_ID> \
-    /cos cos://<COS_ALLUXIO_BUCKET>/<COS_DATA>/
-```
-
 ### [Experimental] COS multipart upload
 
 The default upload method uploads one file completely from start to end in one go. We use multipart-upload method to upload one file by multiple parts, every part will be uploaded in one thread. It won't generate any temporary files while uploading.

--- a/docs/en/ufs/COS.md
+++ b/docs/en/ufs/COS.md
@@ -19,9 +19,9 @@ You also need to provide APPID and REGION. In this guide, the APPID is called `C
 
 ## Basic Setup
 
-### Root Mount Point
-
-Create `conf/alluxio-site.properties` if it does not exist.
+To use Tencent COS as the UFS of Alluxio, you need to configure Alluxio to use under storage systems by modifying
+`conf/alluxio-site.properties`. If it does not exist, create the configuration file from the
+template.
 
 ```shell
 $ cp conf/alluxio-site.properties.template conf/alluxio-site.properties

--- a/docs/en/ufs/COSN.md
+++ b/docs/en/ufs/COSN.md
@@ -8,13 +8,13 @@ This guide describes how to configure Alluxio with [COSN](https://hadoop.apache.
 COSN, also known as Hadoop-COS, is a client that makes the upper computing systems based on HDFS be able to use [Tencent Cloud Object Storage (COS)](https://cloud.tencent.com/product/cos) as its underlying storage system. 
 
 
-## Basic Setup
+## Prerequisites
 
 In preparation for using COS with Alluxio, create a new bucket or use an existing bucket.
 You should also note the directory you want to use in that bucket, either by creating a new directory in the bucket or using an existing one.
 For the purposes of this guide, the COS Bucket name is called `COSN_ALLUXIO_BUCKET`, the directory in that bucket is called `COSN_DATA`, and COS Bucket region is called `COSN_REGION` which specifies the region of your bucket.
 
-### Root Mount Point
+## Basic Setup 
 
 Create `conf/alluxio-site.properties` and `conf/core-site.xml` if they do not exist.
 

--- a/docs/en/ufs/CephObjectStorage.md
+++ b/docs/en/ufs/CephObjectStorage.md
@@ -16,8 +16,6 @@ Alluxio supports two different clients APIs to connect to Ceph Object Storage us
 
 A Ceph bucket can be mounted to Alluxio either at the root of the namespace, or at a nested directory.
 
-### Root Mount Point
-
 Configure Alluxio to use under storage systems by modifying
 `conf/alluxio-site.properties`. If it does not exist, create the configuration file from the
 template.
@@ -26,7 +24,7 @@ template.
 $ cp conf/alluxio-site.properties.template conf/alluxio-site.properties
 ```
 
-#### Option 1: S3 Interface (preferred)
+### Option 1: S3 Interface (preferred)
 
 Modify `conf/alluxio-site.properties` to include:
 
@@ -43,7 +41,7 @@ If using a Ceph release such as hammer (or older) specify `alluxio.underfs.s3.si
 to use v2 S3 signatures. To use GET Bucket (List Objects) Version 1 specify
 `alluxio.underfs.s3.list.objects.v1=true`.
 
-#### Option 2: Swift Interface
+### Option 2: Swift Interface
 Modify `conf/alluxio-site.properties` to include:
 
 ```properties

--- a/docs/en/ufs/GCS.md
+++ b/docs/en/ufs/GCS.md
@@ -38,8 +38,6 @@ than the default one in metadata and read/write operations.
 
 A GCS bucket can be mounted to the Alluxio either at the root of the namespace, or at a nested directory.
 
-### Root Mount Point
-
 Configure Alluxio to use under storage systems by modifying
 `conf/alluxio-site.properties`. If it does not exist, create the configuration file from the
 template.

--- a/docs/en/ufs/HDFS.md
+++ b/docs/en/ufs/HDFS.md
@@ -36,7 +36,7 @@ See [mounting HDFS with specific versions]({{ '/en/ufs/HDFS.html' | relativize_u
 alluxio.underfs.version=<HADOOP VERSION>
 ```
 
-## Example: Running Alluxio Locally with HDFS
+## Running Alluxio Locally with HDFS
 
 Before this step, make sure your HDFS cluster is running and the directory mapped to Alluxio
 exists. Start the Alluxio servers:

--- a/docs/en/ufs/Minio.md
+++ b/docs/en/ufs/Minio.md
@@ -49,7 +49,7 @@ For these parameters, replace `<MINIO_ENDPOINT>` with the hostname and port of y
 e.g., `http://localhost:9000/`.
 If the port value is left unset, it defaults to port 80 for `http` and 443 for `https`.
 
-## Test the MinIO Configuration
+## Running Alluxio Locally with MinIO
 
 Format and start Alluxio with
 

--- a/docs/en/ufs/NFS.md
+++ b/docs/en/ufs/NFS.md
@@ -13,7 +13,7 @@ You'll need to have a configured and running installation of NFS for the rest of
 If you need to get your own NFS installation up and running, we recommend taking a look at the
 [NFS-HOW TO](http://nfs.sourceforge.net/nfs-howto/)
 
-## Requirements
+## Prerequisites
 
 The prerequisite for this part is that you have a version of
 [Java 8](https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=hotspot)

--- a/docs/en/ufs/OBS.md
+++ b/docs/en/ufs/OBS.md
@@ -18,8 +18,6 @@ the bucket, or using an existing one. For the purposes of this guide, the OBS bu
 
 ## Basic Setup
 
-### Root Mount Point
-
 Create `conf/alluxio-site.properties` if it does not exist.
 
 ```shell

--- a/docs/en/ufs/OBS.md
+++ b/docs/en/ufs/OBS.md
@@ -83,21 +83,6 @@ $ ./bin/alluxio-stop.sh local
 
 ## Advanced Setup
 
-### Nested Mount
-
-An OBS location can be mounted at a nested directory in the Alluxio namespace to have unified
-access to multiple under storage systems. Alluxio's
-[Mount Command]({{ '/en/operation/User-CLI.html' | relativize_url }}#mount) can be used for this purpose.
-For example, the following command mounts a directory inside an OBS bucket into Alluxio directory
-`/obs`:
-
-```shell
-$ ./bin/alluxio fs mount --option fs.obs.accessKey=<OBS ACCESS KEY> \
-  --option fs.obs.secretKey=<OBS SECRET KEY> \
-  --option fs.obs.endpoint=<OBS_ENDPOINT> \
-  /obs obs://<OBS_BUCKET>/<OBS_DIRECTORY>/
-```
-
 ### [Experimental] OBS multipart upload
 
 The default upload method uploads one file completely from start to end in one go. We use multipart-upload method to upload one file by multiple parts, every part will be uploaded in one thread. It won't generate any temporary files while uploading.

--- a/docs/en/ufs/OSS.md
+++ b/docs/en/ufs/OSS.md
@@ -76,21 +76,6 @@ $ ./bin/alluxio-stop.sh local
 
 ## Advanced Setup
 
-### Nested Mount
-
-An OSS location can be mounted at a nested directory in the Alluxio namespace to have unified
-access to multiple under storage systems. Alluxio's
-[Mount Command]({{ '/en/operation/User-CLI.html' | relativize_url }}#mount) can be used for this purpose.
-For example, the following command mounts a directory inside an OSS bucket into Alluxio directory
-`/oss`:
-
-```shell
-$ ./bin/alluxio fs mount --option fs.oss.accessKeyId=<OSS_ACCESS_KEY_ID> \
-  --option fs.oss.accessKeySecret=<OSS_ACCESS_KEY_SECRET> \
-  --option fs.oss.endpoint=<OSS_ENDPOINT> \
-  /oss oss://<OSS_BUCKET>/<OSS_DIRECTORY>/
-```
-
 ### [Experimental] OSS multipart upload
 
 The default upload method uploads one file completely from start to end in one go. We use multipart-upload method to upload one file by multiple parts, every part will be uploaded in one thread. It won't generate any temporary files while uploading.

--- a/docs/en/ufs/OSS.md
+++ b/docs/en/ufs/OSS.md
@@ -46,7 +46,7 @@ which are created and managed in [Aliyun AccessKey management console](https://a
 values like `oss-us-west-1.aliyuncs.com` and `oss-cn-shanghai.aliyuncs.com`. Available endpoints are listed in the 
 [OSS Internet Endpoints documentation](https://intl.aliyun.com/help/doc-detail/31837.htm).
 
-## Example: Running Alluxio Locally with OSS
+## Running Alluxio Locally with Aliyun OSS
 
 Start the Alluxio servers:
 

--- a/docs/en/ufs/Ozone.md
+++ b/docs/en/ufs/Ozone.md
@@ -82,7 +82,7 @@ When mounting the under storage at the Alluxio root with a specific Ozone versio
 alluxio.underfs.version=<OZONE_VERSION>
 ```
 
-## Example: Running Alluxio Locally with Ozone
+## Running Alluxio Locally with Ozone
 
 Start the Alluxio servers:
 

--- a/docs/en/ufs/Qiniu-KODO.md
+++ b/docs/en/ufs/Qiniu-KODO.md
@@ -50,27 +50,27 @@ alluxio.underfs.kodo.endpoint=<KODO_ENDPOINT>
 <tr>
     <td markdown="span">East China</td>
     <td markdown="span">z0</td>
-    <td markdown="span">iovip.qbox.me</td>
+    <td markdown="span">`iovip.qbox.me`</td>
 </tr>
 <tr>
     <td markdown="span">North China</td>
     <td markdown="span">z1</td>
-    <td markdown="span">iovip-z1.qbox.me</td>
+    <td markdown="span">`iovip-z1.qbox.me`</td>
 </tr>
 <tr>
     <td markdown="span">South China</td>
     <td markdown="span">z2</td>
-    <td markdown="span">iovip-z2.qbox.me</td>
+    <td markdown="span">`iovip-z2.qbox.me`</td>
 </tr>
 <tr>
     <td markdown="span">North America</td>
     <td markdown="span">na0</td>
-    <td markdown="span">iovip-na0.qbox.me</td>
+    <td markdown="span">`iovip-na0.qbox.me`</td>
 </tr>
 <tr>
     <td markdown="span">Southeast Asia</td>
     <td markdown="span">as0</td>
-    <td markdown="span">iovip-as0.qbox.me</td>
+    <td markdown="span">`iovip-as0.qbox.me`</td>
 </tr>
 </table>
 

--- a/docs/en/ufs/Qiniu-KODO.md
+++ b/docs/en/ufs/Qiniu-KODO.md
@@ -8,7 +8,7 @@ This guide describes how to configure Alluxio with [Qiniu Kodo](https://www.qini
 
 Qiniu Object Storage Service (Kodo) is a cloud-based object storage service provided by Qiniu Cloud, a Chinese cloud service provider. Kodo is a massive, secure and highly reliable cloud storge service that is designed to store, manage, and serve large amounts of unstructured data.
 
-## Initial Setup
+## Prerequisites
 
 A Qiniu Kodo bucket is necessary before using Kodo with Alluxio. In this guide, the Qiniu Kodo bucket
 is called `KODO_BUCKET`, and the directory in the bucket is called `KODO_DIRECTORY`.
@@ -21,10 +21,15 @@ Alluxio unifies access to different storage systems through the
 unified namespace feature.
 The root of Alluxio namespace or its subdirectories are all available for the mount point of Kodo.
 
-### Root Mount
+If you want to use Qiniu Kodo as its under storage system in Alluxio, you need to configure Alluxio to use under storage systems by modifying
+`conf/alluxio-site.properties`. If it does not exist, create the configuration file from the
+template.
 
-If you want to use Qiniu Kodo as its under storage system in Alluxio, `conf/alluxio-site.properties` must be modified.
-In the beginning, an existing Kodo bucket and its directory should be specified for storage by the following code:
+```shell
+$ cp conf/alluxio-site.properties.template conf/alluxio-site.properties
+```
+
+In the beginning, an existing Kodo bucket and its directory should be specified for storage:
 ```properties
 alluxio.dora.client.ufs.root=kodo://<KODO_BUCKET>/<KODO_DIRECTORY>/
 ```

--- a/docs/en/ufs/S3.md
+++ b/docs/en/ufs/S3.md
@@ -18,8 +18,6 @@ the bucket, or using an existing one. For the purposes of this guide, the S3 buc
 
 ## Basic Setup
 
-### Root Mount Point
-
 Create `conf/alluxio-site.properties` if it does not exist.
 
 ```shell

--- a/docs/en/ufs/Swift.md
+++ b/docs/en/ufs/Swift.md
@@ -13,8 +13,6 @@ Swift is a highly available, distributed, eventually consistent object/blob stor
 
 A Swift bucket can be mounted to the Alluxio either at the root of the namespace, or at a nested directory.
 
-### Root Mount Point
-
 Configure Alluxio to use under storage systems by modifying
 `conf/alluxio-site.properties`. If it does not exist, create the configuration file from the
 template.


### PR DESCRIPTION
### What changes are proposed in this pull request?

Deleted mount command links because they redirected to main page
Added more resources to Get Started page
Added more relevant terms to glossary

### Why are the changes needed?

Mount command links are not useful. 
More resources in the Get Started for next steps after running locally
More relevant terms to glossary

### Does this PR introduce any user facing changes?
 
Web UI
