### PR TITLE
Improve filter exclusion setting for shade plugin

### DIFF
--- a/dora/shaded/client/pom.xml
+++ b/dora/shaded/client/pom.xml
@@ -181,6 +181,10 @@
                   <excludes>
                     <exclude>LICENSE</exclude>
                     <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/LICENSE.*</exclude>
+                    <exclude>META-INF/license/*</exclude>
+                    <exclude>META-INF/NOTICE</exclude>
+                    <exclude>META-INF/NOTICE.*</exclude>
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>

--- a/dora/underfs/abfs/pom.xml
+++ b/dora/underfs/abfs/pom.xml
@@ -71,20 +71,10 @@
             <configuration>
               <filters>
                 <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>LICENSE</exclude>
-                    <exclude>META-INF/LICENSE</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
-                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
-                  </excludes>
-                </filter>
-                <filter>
                   <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
                   <excludes>
+                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
+                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
                     <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>
                   </excludes>
                 </filter>

--- a/dora/underfs/adl/pom.xml
+++ b/dora/underfs/adl/pom.xml
@@ -76,20 +76,10 @@
             <configuration>
               <filters>
                 <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>LICENSE</exclude>
-                    <exclude>META-INF/LICENSE</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
-                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
-                  </excludes>
-                </filter>
-                <filter>
                   <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
                   <excludes>
+                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
+                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
                     <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>
                   </excludes>
                 </filter>

--- a/dora/underfs/cephfs-hadoop/pom.xml
+++ b/dora/underfs/cephfs-hadoop/pom.xml
@@ -60,18 +60,10 @@
             <configuration>
               <filters>
                 <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>LICENSE</exclude>
-                    <exclude>META-INF/LICENSE</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-                <filter>
                   <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
                   <excludes>
+                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
+                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
                     <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>
                   </excludes>
                 </filter>

--- a/dora/underfs/cosn/pom.xml
+++ b/dora/underfs/cosn/pom.xml
@@ -76,20 +76,10 @@
             <configuration>
               <filters>
                 <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>LICENSE</exclude>
-                    <exclude>META-INF/LICENSE</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
-                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
-                  </excludes>
-                </filter>
-                <filter>
                   <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
                   <excludes>
+                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
+                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
                     <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>
                   </excludes>
                 </filter>

--- a/dora/underfs/ozone/pom.xml
+++ b/dora/underfs/ozone/pom.xml
@@ -106,22 +106,6 @@
               </artifactSet>
               <filters>
                 <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>LICENSE</exclude>
-                    <exclude>META-INF/LICENSE</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>commons-httpclient:commons-httpclient</artifact>
-                  <excludes>
-                    <exclude>META-INF/LICENSE.txt</exclude>
-                  </excludes>
-                </filter>
-                <filter>
                   <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
                   <excludes>
                     <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>

--- a/dora/underfs/pom.xml
+++ b/dora/underfs/pom.xml
@@ -106,6 +106,10 @@
                     <excludes>
                       <exclude>LICENSE</exclude>
                       <exclude>META-INF/LICENSE</exclude>
+                      <exclude>META-INF/LICENSE.*</exclude>
+                      <exclude>META-INF/license/*</exclude>
+                      <exclude>META-INF/NOTICE</exclude>
+                      <exclude>META-INF/NOTICE.*</exclude>
                       <exclude>META-INF/*.SF</exclude>
                       <exclude>META-INF/*.DSA</exclude>
                       <exclude>META-INF/*.RSA</exclude>

--- a/dora/underfs/wasb/pom.xml
+++ b/dora/underfs/wasb/pom.xml
@@ -77,20 +77,10 @@
             <configuration>
               <filters>
                 <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>LICENSE</exclude>
-                    <exclude>META-INF/LICENSE</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
-                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
-                  </excludes>
-                </filter>
-                <filter>
                   <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
                   <excludes>
+                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
+                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
                     <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>
                   </excludes>
                 </filter>


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Improve filter setting in `dora/shaded/client/pom.xml` to eliminate some warnings in the shading process.
2. Remove duplicated code of filter setting in UFS. The shading filter in each UFS will inherit the shading plugin settings from `dora/underfs/pom.xml`, enabling us to reduce duplication by moving the common settings to `dora/underfs/pom.xml`.

### Why are the changes needed?

Code hygiene and readability

### Does this PR introduce any user facing changes?

No
