### PR TITLE
Fix DefaultMetaMaster authentication

### DIFF
--- a/common/transport/src/main/proto/grpc/meta_master.proto
+++ b/common/transport/src/main/proto/grpc/meta_master.proto
@@ -202,6 +202,21 @@ service MetaMasterClientService {
    * Returns the status of all known Proxy instances in the cluster.
    */
   rpc ListProxyStatus(ListProxyStatusPRequest) returns (ListProxyStatusPResponse);
+
+  /**
+   * Sets a property for a path.
+   */
+  rpc SetPathConfiguration (SetPathConfigurationPRequest) returns (SetPathConfigurationPResponse);
+
+  /**
+   * Removes properties for a path, if the keys are empty, it means remove all properties.
+   */
+  rpc RemovePathConfiguration (RemovePathConfigurationPRequest) returns (RemovePathConfigurationPResponse);
+
+  /**
+   * Sets a property.
+   */
+  rpc UpdateConfiguration(UpdateConfigurationPRequest) returns (UpdateConfigurationPResponse);
 }
 
 message SetPathConfigurationPOptions {}
@@ -237,21 +252,9 @@ service MetaMasterConfigurationService {
   rpc GetConfiguration (GetConfigurationPOptions) returns (GetConfigurationPResponse);
 
   /**
-   * Sets a property for a path.
-   */
-  rpc SetPathConfiguration (SetPathConfigurationPRequest) returns (SetPathConfigurationPResponse);
-
-  /**
-   * Removes properties for a path, if the keys are empty, it means remove all properties.
-   */
-  rpc RemovePathConfiguration (RemovePathConfigurationPRequest) returns (RemovePathConfigurationPResponse);
-
-  /**
    * Returns the hashes of cluster and path level configurations.
    */
   rpc GetConfigHash (GetConfigHashPOptions) returns (GetConfigHashPResponse);
-
-  rpc UpdateConfiguration(UpdateConfigurationPRequest) returns (UpdateConfigurationPResponse);
 }
 
 message GetMasterIdPOptions {}

--- a/dora/core/client/fs/src/main/java/alluxio/client/meta/MetaMasterClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/meta/MetaMasterClient.java
@@ -11,7 +11,9 @@
 
 package alluxio.client.meta;
 
+import alluxio.AlluxioURI;
 import alluxio.Client;
+import alluxio.conf.PropertyKey;
 import alluxio.grpc.BackupPRequest;
 import alluxio.grpc.MasterInfo;
 import alluxio.grpc.MasterInfoField;
@@ -20,7 +22,9 @@ import alluxio.wire.BackupStatus;
 import alluxio.wire.ConfigCheckReport;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -73,6 +77,53 @@ public interface MetaMasterClient extends Client {
    * @return the hostname of the master that did the checkpoint
    */
   String checkpoint() throws IOException;
+
+  /**
+   * Sets a property for a path.
+   *
+   * @param path the path
+   * @param key the property key
+   * @param value the property value
+   */
+  default void setPathConfiguration(AlluxioURI path, PropertyKey key, String value)
+      throws IOException {
+    Map<PropertyKey, String> properties = new HashMap<>();
+    properties.put(key, value);
+    setPathConfiguration(path, properties);
+  }
+
+  /**
+   * Sets properties for a path.
+   *
+   * @param path the path
+   * @param properties the properties
+   */
+  void setPathConfiguration(AlluxioURI path, Map<PropertyKey, String> properties)
+      throws IOException;
+
+  /**
+   * Removes properties for a path.
+   *
+   * @param path the path
+   * @param keys the property keys
+   */
+  void removePathConfiguration(AlluxioURI path, Set<PropertyKey> keys) throws IOException;
+
+  /**
+   * Removes all properties for a path.
+   *
+   * @param path the path
+   */
+  void removePathConfiguration(AlluxioURI path) throws IOException;
+
+  /**
+   * Updates properties.
+   *
+   * @param propertiesMap the properties map to be updated
+   * @return the update properties status map
+   */
+  Map<PropertyKey, Boolean> updateConfiguration(
+      Map<PropertyKey, String> propertiesMap) throws IOException;
 
   /**
    * Lists information of all known proxy instances from the primary master.

--- a/dora/core/client/fs/src/main/java/alluxio/client/meta/MetaMasterConfigClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/meta/MetaMasterConfigClient.java
@@ -11,17 +11,12 @@
 
 package alluxio.client.meta;
 
-import alluxio.AlluxioURI;
 import alluxio.Client;
-import alluxio.conf.PropertyKey;
 import alluxio.grpc.GetConfigurationPOptions;
 import alluxio.wire.ConfigHash;
 import alluxio.wire.Configuration;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Interface for a meta master config client.
@@ -37,51 +32,4 @@ public interface MetaMasterConfigClient extends Client {
    * @return hashes of cluster and path level configurations
    */
   ConfigHash getConfigHash() throws IOException;
-
-  /**
-   * Sets a property for a path.
-   *
-   * @param path the path
-   * @param key the property key
-   * @param value the property value
-   */
-  default void setPathConfiguration(AlluxioURI path, PropertyKey key, String value)
-      throws IOException {
-    Map<PropertyKey, String> properties = new HashMap<>();
-    properties.put(key, value);
-    setPathConfiguration(path, properties);
-  }
-
-  /**
-   * Sets properties for a path.
-   *
-   * @param path the path
-   * @param properties the properties
-   */
-  void setPathConfiguration(AlluxioURI path, Map<PropertyKey, String> properties)
-      throws IOException;
-
-  /**
-   * Removes properties for a path.
-   *
-   * @param path the path
-   * @param keys the property keys
-   */
-  void removePathConfiguration(AlluxioURI path, Set<PropertyKey> keys) throws IOException;
-
-  /**
-   * Removes all properties for a path.
-   *
-   * @param path the path
-   */
-  void removePathConfiguration(AlluxioURI path) throws IOException;
-
-  /**
-   * Updates properties.
-   *
-   * @param propertiesMap the properties map to be updated
-   * @return the update properties status map
-   */
-  Map<PropertyKey, Boolean> updateConfiguration(
-      Map<PropertyKey, String> propertiesMap) throws IOException;
 }

--- a/dora/core/client/fs/src/main/java/alluxio/client/meta/RetryHandlingMetaMasterConfigClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/meta/RetryHandlingMetaMasterConfigClient.java
@@ -12,16 +12,12 @@
 package alluxio.client.meta;
 
 import alluxio.AbstractMasterClient;
-import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.GetConfigHashPOptions;
 import alluxio.grpc.GetConfigurationPOptions;
 import alluxio.grpc.MetaMasterConfigurationServiceGrpc;
-import alluxio.grpc.RemovePathConfigurationPRequest;
 import alluxio.grpc.ServiceType;
-import alluxio.grpc.SetPathConfigurationPRequest;
-import alluxio.grpc.UpdateConfigurationPRequest;
 import alluxio.master.MasterClientContext;
 import alluxio.wire.ConfigHash;
 import alluxio.wire.Configuration;
@@ -30,10 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -90,50 +82,5 @@ public class RetryHandlingMetaMasterConfigClient extends AbstractMasterClient
         mContext.getClusterConf().getMs(PropertyKey.WORKER_MASTER_PERIODICAL_RPC_TIMEOUT),
         TimeUnit.MILLISECONDS).getConfigHash(GetConfigHashPOptions.getDefaultInstance()),
         RPC_LOG, "GetConfigHash", ""));
-  }
-
-  @Override
-  public void setPathConfiguration(AlluxioURI path, Map<PropertyKey, String> properties)
-      throws IOException {
-    Map<String, String> props = new HashMap<>();
-    properties.forEach((key, value) -> props.put(key.getName(), value));
-    retryRPC(() -> mClient.setPathConfiguration(SetPathConfigurationPRequest.newBuilder()
-        .setPath(path.getPath()).putAllProperties(props).build()),
-        RPC_LOG, "setPathConfiguration", "path=%s,properties=%s", path, properties);
-  }
-
-  @Override
-  public void removePathConfiguration(AlluxioURI path, Set<PropertyKey> keys) throws IOException {
-    Set<String> keySet = new HashSet<>();
-    for (PropertyKey key : keys) {
-      keySet.add(key.getName());
-    }
-    retryRPC(() -> mClient.removePathConfiguration(RemovePathConfigurationPRequest.newBuilder()
-        .setPath(path.getPath()).addAllKeys(keySet).build()),
-        RPC_LOG, "removePathConfiguration", "path=%s,keys=%s", path, keys);
-  }
-
-  @Override
-  public void removePathConfiguration(AlluxioURI path) throws IOException {
-    retryRPC(() -> mClient.removePathConfiguration(RemovePathConfigurationPRequest.newBuilder()
-        .setPath(path.getPath()).build()), RPC_LOG, "removePathConfiguration", "path=%s", path);
-  }
-
-  @Override
-  public Map<PropertyKey, Boolean> updateConfiguration(
-      Map<PropertyKey, String> propertiesMap) throws IOException {
-    Map<PropertyKey, Boolean> resultMap = new HashMap<>();
-    Map<String, String> inputMap = new HashMap<>();
-    propertiesMap.forEach((k, v) -> inputMap.put(k.getName(), v));
-    retryRPC(
-        () -> mClient.updateConfiguration(
-            UpdateConfigurationPRequest.newBuilder()
-                .putAllProperties(inputMap)
-                .build()),
-        RPC_LOG, "updateConfiguration", "propertiesMap=%s", propertiesMap)
-        .getStatusMap().forEach((k, v) -> {
-          resultMap.put(PropertyKey.getOrBuildCustom(k), v);
-        });
-    return resultMap;
   }
 }

--- a/dora/core/server/master/src/main/java/alluxio/master/meta/MetaMasterConfigurationServiceHandler.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/meta/MetaMasterConfigurationServiceHandler.java
@@ -12,28 +12,16 @@
 package alluxio.master.meta;
 
 import alluxio.RpcUtils;
-import alluxio.conf.PropertyKey;
 import alluxio.grpc.GetConfigHashPOptions;
 import alluxio.grpc.GetConfigHashPResponse;
 import alluxio.grpc.GetConfigurationPOptions;
 import alluxio.grpc.GetConfigurationPResponse;
 import alluxio.grpc.MetaMasterConfigurationServiceGrpc;
-import alluxio.grpc.RemovePathConfigurationPRequest;
-import alluxio.grpc.RemovePathConfigurationPResponse;
-import alluxio.grpc.SetPathConfigurationPRequest;
-import alluxio.grpc.SetPathConfigurationPResponse;
-import alluxio.grpc.UpdateConfigurationPRequest;
-import alluxio.grpc.UpdateConfigurationPResponse;
 import alluxio.wire.ConfigHash;
 
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 
 /**
  * This class is a gRPC handler for meta master RPCs.
@@ -96,48 +84,5 @@ public final class MetaMasterConfigurationServiceHandler
     RpcUtils.call(LOG, () ->
         mMetaMaster.getConfigHash().toProto(), "getConfigHash", "request=%s", responseObserver,
         request);
-  }
-
-  @Override
-  public void setPathConfiguration(SetPathConfigurationPRequest request,
-      StreamObserver<SetPathConfigurationPResponse> responseObserver) {
-    String path = request.getPath();
-    Map<String, String> properties = request.getPropertiesMap();
-
-    RpcUtils.call(LOG, () -> {
-      Map<PropertyKey, String> props = new HashMap<>();
-      properties.forEach((key, value) -> props.put(PropertyKey.fromString(key), value));
-      mMetaMaster.setPathConfiguration(path, props);
-      return SetPathConfigurationPResponse.getDefaultInstance();
-    }, "setPathConfiguration", "request=%s", responseObserver, request);
-  }
-
-  @Override
-  public void removePathConfiguration(RemovePathConfigurationPRequest request,
-      StreamObserver<RemovePathConfigurationPResponse> responseObserver) {
-    String path = request.getPath();
-    List<String> keys = request.getKeysList();
-
-    RpcUtils.call(LOG, () -> {
-      if (keys.isEmpty()) {
-        mMetaMaster.removePathConfiguration(path);
-      } else {
-        mMetaMaster.removePathConfiguration(path, new HashSet<>(keys));
-      }
-      return RemovePathConfigurationPResponse.getDefaultInstance();
-    }, "removePathConfiguration", "request=%s", responseObserver, request);
-  }
-
-  @Override
-  public void updateConfiguration(
-      UpdateConfigurationPRequest request,
-      StreamObserver<UpdateConfigurationPResponse> responseObserver) {
-    RpcUtils.call(LOG, () -> {
-      Map<String, Boolean> result =
-          mMetaMaster.updateConfiguration(request.getPropertiesMap());
-      return UpdateConfigurationPResponse.newBuilder()
-          .putAllStatus(result)
-          .build();
-    }, "updateConfiguration", "request=%s", responseObserver, request);
   }
 }

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/command/UpdateConfCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/command/UpdateConfCommand.java
@@ -66,7 +66,7 @@ public final class UpdateConfCommand extends AbstractFsAdminCommand {
     }
 
     Map<PropertyKey, Boolean> result =
-        mMetaConfigClient.updateConfiguration(properties);
+        mMetaClient.updateConfiguration(properties);
     System.out.println("Updated " + result.size() + " configs");
     for (Entry<PropertyKey, Boolean> entry : result.entrySet()) {
       if (!entry.getValue()) {

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/pathconf/AddCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/pathconf/AddCommand.java
@@ -86,7 +86,7 @@ public final class AddCommand extends AbstractFsAdminCommand {
         propertyMap.put(key, property.getValue());
       }
     }
-    mMetaConfigClient.setPathConfiguration(path, propertyMap);
+    mMetaClient.setPathConfiguration(path, propertyMap);
     return 0;
   }
 

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/pathconf/RemoveCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/pathconf/RemoveCommand.java
@@ -98,12 +98,12 @@ public final class RemoveCommand extends AbstractFsAdminCommand {
 
     if (keysToRemove.isEmpty()) {
       for (AlluxioURI p : pathsToRemove) {
-        mMetaConfigClient.removePathConfiguration(p);
+        mMetaClient.removePathConfiguration(p);
       }
       return 0;
     }
     for (AlluxioURI p : pathsToRemove) {
-      mMetaConfigClient.removePathConfiguration(p, keysToRemove);
+      mMetaClient.removePathConfiguration(p, keysToRemove);
     }
     return 0;
   }

--- a/dora/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ListCommandIntegrationTest.java
+++ b/dora/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ListCommandIntegrationTest.java
@@ -17,8 +17,8 @@ import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.client.cli.fs.AbstractShellIntegrationTest;
 import alluxio.client.file.FileSystemContext;
-import alluxio.client.meta.MetaMasterConfigClient;
-import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
+import alluxio.client.meta.MetaMasterClient;
+import alluxio.client.meta.RetryHandlingMetaMasterClient;
 import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
@@ -48,7 +48,7 @@ public class ListCommandIntegrationTest extends AbstractShellIntegrationTest {
    */
   private InstancedConfiguration setPathConfigurations() throws Exception {
     FileSystemContext metaCtx = FileSystemContext.create(Configuration.global());
-    MetaMasterConfigClient client = new RetryHandlingMetaMasterConfigClient(
+    MetaMasterClient client = new RetryHandlingMetaMasterClient(
         MasterClientContext.newBuilder(metaCtx.getClientContext()).build());
     client.setPathConfiguration(new AlluxioURI(DIR1), PROPERTY_KEY1, PROPERTY_VALUE1);
     client.setPathConfiguration(new AlluxioURI(DIR2), PROPERTY_KEY2, PROPERTY_VALUE2);

--- a/dora/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ShowCommandIntegrationTest.java
+++ b/dora/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ShowCommandIntegrationTest.java
@@ -17,8 +17,8 @@ import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.client.cli.fs.AbstractShellIntegrationTest;
 import alluxio.client.file.FileSystemContext;
-import alluxio.client.meta.MetaMasterConfigClient;
-import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
+import alluxio.client.meta.MetaMasterClient;
+import alluxio.client.meta.RetryHandlingMetaMasterClient;
 import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
@@ -52,7 +52,7 @@ public class ShowCommandIntegrationTest extends AbstractShellIntegrationTest {
    */
   private InstancedConfiguration setPathConfigurations() throws Exception {
     FileSystemContext metaCtx = FileSystemContext.create(Configuration.global());
-    MetaMasterConfigClient client = new RetryHandlingMetaMasterConfigClient(
+    MetaMasterClient client = new RetryHandlingMetaMasterClient(
         MasterClientContext.newBuilder(metaCtx.getClientContext()).build());
     client.setPathConfiguration(new AlluxioURI(DIR1), PROPERTY_KEY11, PROPERTY_VALUE11);
     client.setPathConfiguration(new AlluxioURI(DIR1), PROPERTY_KEY12, PROPERTY_VALUE12);

--- a/dora/tests/src/test/java/alluxio/client/fs/FileSystemContextReinitIntegrationTest.java
+++ b/dora/tests/src/test/java/alluxio/client/fs/FileSystemContextReinitIntegrationTest.java
@@ -19,8 +19,8 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemContextReinitializer;
-import alluxio.client.meta.MetaMasterConfigClient;
-import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
+import alluxio.client.meta.MetaMasterClient;
+import alluxio.client.meta.RetryHandlingMetaMasterClient;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.CreateFilePOptions;
@@ -174,7 +174,7 @@ public final class FileSystemContextReinitIntegrationTest extends BaseIntegratio
   }
 
   private void updatePathConf() throws Exception {
-    MetaMasterConfigClient client = new RetryHandlingMetaMasterConfigClient(
+    MetaMasterClient client = new RetryHandlingMetaMasterClient(
         MasterClientContext.newBuilder(mContext.getClientContext()).build());
     client.setPathConfiguration(PATH_TO_UPDATE, KEY_TO_UPDATE, UPDATED_VALUE.name());
   }

--- a/dora/tests/src/test/java/alluxio/client/fs/PathConfigurationIntegrationTest.java
+++ b/dora/tests/src/test/java/alluxio/client/fs/PathConfigurationIntegrationTest.java
@@ -19,8 +19,8 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemUtils;
-import alluxio.client.meta.MetaMasterConfigClient;
-import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
+import alluxio.client.meta.MetaMasterClient;
+import alluxio.client.meta.RetryHandlingMetaMasterClient;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.CreateFilePOptions;
@@ -52,11 +52,11 @@ public class PathConfigurationIntegrationTest {
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, USER_QUOTA_UNIT_BYTES)
           .build();
-  private MetaMasterConfigClient mMetaConfig;
+  private MetaMasterClient mMetaConfig;
   private FileSystem mFileSystem;
   private CreateFilePOptions mWriteThrough;
 
-  private void setPathConfigurations(MetaMasterConfigClient client) throws Exception {
+  private void setPathConfigurations(MetaMasterClient client) throws Exception {
     client.setPathConfiguration(new AlluxioURI(REMOTE_DIR), PropertyKey.USER_FILE_READ_TYPE_DEFAULT,
         ReadType.CACHE.toString());
     client.setPathConfiguration(new AlluxioURI(REMOTE_UNCACHED_FILE),
@@ -70,7 +70,7 @@ public class PathConfigurationIntegrationTest {
   @Before
   public void before() throws Exception {
     FileSystemContext metaCtx = FileSystemContext.create(Configuration.global());
-    mMetaConfig = new RetryHandlingMetaMasterConfigClient(
+    mMetaConfig = new RetryHandlingMetaMasterClient(
         MasterClientContext.newBuilder(metaCtx.getClientContext()).build());
     setPathConfigurations(mMetaConfig);
     FileSystemContext fsCtx = FileSystemContext.create(Configuration.global());


### PR DESCRIPTION
### What changes are proposed in this pull request?

Move some func from MetaMasterConfigurationService to MetaMasterClientService.

### Why are the changes needed?

Because META_MASTER_CONFIG_SERVICE has disableAuthentication in DefaultMetaMaster.getServices(), some sensitive requests to MetaMasterConfigurationService do not need authentication, include updateConfiguration request.

### Does this PR introduce any user facing changes?

Nope
