### PR TITLE
Fix compilation for unit tests build

### DIFF
--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -46,7 +46,7 @@ jobs:
           mkdir -p ~/.m2
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=\!assembly/client,\!assembly/server,\!dora/shaded/client,\!dora/tests,\!webui \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=\!assembly/client,\!assembly/server,\!dora/tests,\!dora/microbench,\!webui \
           ALLUXIO_DOCKER_MVN_TESTS=${{ matrix.modules }} \
           dev/github/run_docker.sh
         timeout-minutes: 60


### PR DESCRIPTION
this build is failing the compilation step, claiming it can't find dora/tests jar when building dora/microbench. strange that it wasn't happening when validating https://github.com/Alluxio/alluxio/pull/17811