### PR TITLE
Add metrics for num of request to external storage when cache miss

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -194,6 +194,7 @@ public class LocalCacheFileInStream extends FileInStream {
     stopwatch.stop();
     if (bytesRead > 0) {
       MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE.getName()).mark(bytesRead);
+      MetricsSystem.counter(MetricKey.CLIENT_CACHE_HIT_REQUESTS.getName()).inc();
       if (cacheContext != null) {
         cacheContext.incrementCounter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE.getMetricName(), BYTE,
             bytesRead);
@@ -213,6 +214,7 @@ public class LocalCacheFileInStream extends FileInStream {
       // cache misses
       MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getName())
           .mark(bytesToReadInPage);
+      MetricsSystem.counter(MetricKey.CLIENT_CACHE_EXTERNAL_REQUESTS.getName()).inc();
       if (cacheContext != null) {
         cacheContext.incrementCounter(
             MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getMetricName(), BYTE,

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -364,6 +364,10 @@ public class LocalCacheFileInStreamTest {
         Arrays.copyOfRange(testData, offset, offset + partialReadSize), cacheMiss);
     Assert.assertEquals(0, manager.mPagesServed);
     Assert.assertEquals(1, manager.mPagesCached);
+    Assert.assertEquals(1,
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_EXTERNAL_REQUESTS.getName()).getCount());
+    Assert.assertEquals(0,
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_HIT_REQUESTS.getName()).getCount());
 
     // cache hit
     byte[] cacheHit = new byte[partialReadSize];
@@ -372,6 +376,10 @@ public class LocalCacheFileInStreamTest {
     Assert.assertArrayEquals(
         Arrays.copyOfRange(testData, offset, offset + partialReadSize), cacheHit);
     Assert.assertEquals(1, manager.mPagesServed);
+    Assert.assertEquals(1,
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_EXTERNAL_REQUESTS.getName()).getCount());
+    Assert.assertEquals(1,
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_HIT_REQUESTS.getName()).getCount());
   }
 
   @Test
@@ -418,6 +426,10 @@ public class LocalCacheFileInStreamTest {
         MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getName()).getCount());
     Assert.assertEquals(fileSize,
         MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_EXTERNAL.getName()).getCount());
+    Assert.assertEquals(5,
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_EXTERNAL_REQUESTS.getName()).getCount());
+    Assert.assertEquals(0,
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_HIT_REQUESTS.getName()).getCount());
 
     // cache hit
     stream.read();
@@ -427,6 +439,10 @@ public class LocalCacheFileInStreamTest {
         MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getName()).getCount());
     Assert.assertEquals(fileSize,
         MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_EXTERNAL.getName()).getCount());
+    Assert.assertEquals(5,
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_EXTERNAL_REQUESTS.getName()).getCount());
+    Assert.assertEquals(1,
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_HIT_REQUESTS.getName()).getCount());
   }
 
   @Test

--- a/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -2275,6 +2275,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_EXTERNAL_REQUESTS =
+      new Builder("Client.CacheBytesExternalRequests")
+          .setDescription("Total number of requests to read from external storage.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_PAGE_READ_CACHE_TIME_NS =
       new Builder("Client.CachePageReadCacheTimeNanos")
           .setDescription("Time in nanoseconds taken to read a page from the client cache "
@@ -2329,6 +2335,12 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder("Client.CacheHitRate")
           .setDescription("Cache hit rate: (# bytes read from cache) / (# bytes requested).")
           .setMetricType(MetricType.GAUGE)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_HIT_REQUESTS =
+      new Builder("Client.CacheHitRequests")
+          .setDescription("Total number of requests of hitting the cache.")
+          .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey CLIENT_CACHE_SPACE_AVAILABLE =


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add metrics for num of request to external storage when cache miss

### Why are the changes needed?

For cost saving

### Does this PR introduce any user facing changes?
no
