### PR TITLE
Process the mount point from user input

### DIFF
--- a/dora/integration/fuse/bin/alluxio-fuse
+++ b/dora/integration/fuse/bin/alluxio-fuse
@@ -177,7 +177,7 @@ launch_fuse_process() {
     return 1
   fi
   declare -r ufs_address="$1"
-  get_mount_point $2
+  get_mount_point "$2"
   declare -r mount_point=$FUSE_MOUNT_POINT
   shift 2
 
@@ -310,7 +310,8 @@ unmount_command() {
     echo -e "${USAGE}"
     return 1
   fi
-  declare -r mount_point="$1"
+  get_mount_point "$1"
+  declare -r mount_point=$FUSE_MOUNT_POINT
   shift
 
   local force_kill='false'

--- a/dora/integration/fuse/bin/alluxio-fuse
+++ b/dora/integration/fuse/bin/alluxio-fuse
@@ -128,6 +128,38 @@ print_mount_status() {
 }
 
 #######################################
+# Get Normalized Mount Point
+#   e.g. remove trailing "/" from the end or remove excessive "/" in the middle.
+#   and check existance of parent dir and mount point.
+#
+#   The following inputs should translate to "/home/work/alluxio_fuse" or report error.
+# /home/work/alluxio_fuse///
+# /home//work/alluxio_fuse///
+# /home/work///alluxio_fuse///
+# ////home/work/alluxio_fuse///
+# ///////home/work/alluxio_fuse///
+# /home/////////work/alluxio_fuse///
+# //hoooome/work////alluxio_fuse   (parent dir does not exist)
+# //home/work////alluxio_fuse_not_exist/  (mount point does not exist)
+#######################################
+get_mount_point() {
+  local MP_NAME=$(basename $1)
+  local DIR_NAME=$(dirname $1)
+  local OLDPWD="$(pwd)"
+  cd "$DIR_NAME" || {
+    err "Dir '$DIR_NAME' does not exist"
+    exit 1
+  }
+  DIR_NAME="$(pwd)"
+  [ -d "$DIR_NAME/$MP_NAME" ] || {
+    err "Mount point '$DIR_NAME/$MP_NAME' does not exist"
+    exit 1
+  }
+  cd "$OLDPWD"
+  export FUSE_MOUNT_POINT="$DIR_NAME/$MP_NAME"
+}
+
+#######################################
 # Launch the Alluxio FUSE process.
 # Globals:
 #   ALLUXIO_FUSE_JAVA_OPTS
@@ -145,7 +177,8 @@ launch_fuse_process() {
     return 1
   fi
   declare -r ufs_address="$1"
-  declare -r mount_point="$2"
+  get_mount_point $2
+  declare -r mount_point=$FUSE_MOUNT_POINT
   shift 2
 
   local mount_options=""


### PR DESCRIPTION
### What changes are proposed in this pull request?

e.g. removing trailing "/" at the end or in the middle.
checking existance of parent dir and mount point

### Why are the changes needed?

If the mount point is not processed, it may contains excessive "/" at the end or in the middle.
But the 'mount' command will output mount point without those excessive "/".
So, the script cannot determine if the mount is succeeded or not.

### Does this PR introduce any user facing changes?

N/A
