### PR TITLE
Bump grpc & netty version

### DIFF
--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -131,7 +131,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>2.0.34.Final</version>
+      <version>2.0.56.Final</version>
     </dependency>
 
     <!-- Internal dependencies -->
@@ -157,6 +157,12 @@
       <artifactId>netty-buffer</artifactId>
       <version>${netty.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${jupiter.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -130,9 +130,9 @@
     <build.path>build</build.path>
     <catalyst.version>1.2.1</catalyst.version>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
-    <grpc.version>1.37.0</grpc.version>
+    <grpc.version>1.54.1</grpc.version>
     <gson.version>2.8.9</gson.version>
-    <netty.version>4.1.52.Final</netty.version>
+    <netty.version>4.1.87.Final</netty.version>
     <rocksdb.version>7.0.3</rocksdb.version>
     <hadoop.version>3.3.1</hadoop.version>
     <jacoco.version>0.8.5</jacoco.version>
@@ -141,6 +141,7 @@
     <jersey.version>2.34</jersey.version>
     <jetty.version>9.4.46.v20220331</jetty.version>
     <junit.version>4.13.1</junit.version>
+    <jupiter.version>5.9.2</jupiter.version>
     <log4j.version>2.17.1</log4j.version>
     <maven.version>3.3.9</maven.version>
     <metrics.version>4.1.11</metrics.version>


### PR DESCRIPTION
cherry-pick 16cbf9c0142c20c29b71fb94bd59f049647aac79

cherry-pick the commit since the following security issue.

<img width="2006" alt="image" src="https://github.com/Alluxio/alluxio/assets/17329931/8dc20d78-3b5c-40b3-9d63-b98087a271eb">



Bump grpc & netty version

1. We want to try netty io_uring feature
2. The new aws client we are going to introduce relies on newer version of netty
3. Current grpc & netty versions do not match. (https://github.com/grpc/grpc-java/blob/master/SECURITY.md)

N/A
			pr-link: Alluxio/alluxio#17413 change-id: cid-8bfb171d1660c6da96977129b62b6b6640625f4c

### What changes are proposed in this pull request?

Please outline the changes and how this PR fixes the issue.

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
