### PR TITLE
Set FromUFSFallBack flag in URIStatus to reduce client fall back time

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -152,7 +152,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
       UFS_FALLBACK_COUNTER.inc();
       LOG.debug("Dora client get status error ({} times). Fall back to UFS.",
           UFS_FALLBACK_COUNTER.getCount(), ex);
-      return mDelegatedFileSystem.getStatus(ufsFullPath, options).setIsFromUFS();
+      return mDelegatedFileSystem.getStatus(ufsFullPath, options).setFromUFSFallBack();
     }
   }
 
@@ -176,8 +176,8 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
     OpenFilePOptions mergedOptions = FileSystemOptionsUtils.openFileDefaults(conf)
         .toBuilder().mergeFrom(options).build();
     try {
-      if (status.getIsFromUFS()) {
-        throw new RuntimeException("Status is retrieved from UFS by falling back");
+      if (status.isFromUFSFallBack()) {
+        throw new RuntimeException("Status is retrieved from UFS by falling back.");
       }
       Protocol.OpenUfsBlockOptions openUfsBlockOptions =
           Protocol.OpenUfsBlockOptions.newBuilder().setUfsPath(status.getUfsPath())

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -131,7 +131,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
   public URIStatus getStatus(AlluxioURI path, GetStatusPOptions options)
       throws IOException, AlluxioException {
     AlluxioURI ufsFullPath = convertAlluxioPathToUFSPath(path);
-
+    LOG.debug("DoraCacheFileSystem getStatus for " + ufsFullPath);
     if (!mMetadataCacheEnabled) {
       return mDelegatedFileSystem.getStatus(ufsFullPath, options);
     }
@@ -152,7 +152,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
       UFS_FALLBACK_COUNTER.inc();
       LOG.debug("Dora client get status error ({} times). Fall back to UFS.",
           UFS_FALLBACK_COUNTER.getCount(), ex);
-      return mDelegatedFileSystem.getStatus(ufsFullPath, options);
+      return mDelegatedFileSystem.getStatus(ufsFullPath, options).setIsFromUFS();
     }
   }
 
@@ -176,6 +176,9 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
     OpenFilePOptions mergedOptions = FileSystemOptionsUtils.openFileDefaults(conf)
         .toBuilder().mergeFrom(options).build();
     try {
+      if (status.getIsFromUFS()) {
+        throw new RuntimeException("Status is retrieved from UFS by falling back");
+      }
       Protocol.OpenUfsBlockOptions openUfsBlockOptions =
           Protocol.OpenUfsBlockOptions.newBuilder().setUfsPath(status.getUfsPath())
               .setOffsetInFile(0).setBlockSize(status.getLength())

--- a/dora/core/common/src/main/java/alluxio/client/file/URIStatus.java
+++ b/dora/core/common/src/main/java/alluxio/client/file/URIStatus.java
@@ -43,6 +43,8 @@ public class URIStatus {
   /** Context associated with this URI, possibly set by other external engines (e.g., presto). */
   private final CacheContext mCacheContext;
 
+  private boolean mIsFromUFS;
+
   /**
    * Constructs an instance of this class from a {@link FileInfo}.
    *
@@ -61,6 +63,32 @@ public class URIStatus {
   public URIStatus(FileInfo info, @Nullable CacheContext context) {
     mInfo = Preconditions.checkNotNull(info, "info");
     mCacheContext = context;
+    mIsFromUFS = false;
+  }
+
+  /**
+   * @return if the FileInfo is from UFS instead of worker
+   *
+   * If true, it means this status is retrieved by falling back to UFS.
+   */
+  public boolean getIsFromUFS() {
+    return mIsFromUFS;
+  }
+
+  /**
+   * Sets flag that the FileInfo is retrieved from UFS instead of worker.
+   *
+   * Usually, client calls getStatus() and the FileInfo is retrieved from worker.
+   * But if there is something wrong with the worker or the connection between client
+   * and worker is lost, client will fall back to UFS. If that happens, this function
+   * is called to set the flag. So, the subsequent openFile(status, path) will also fall back
+   * to UFS immediately.
+   *
+   * @return this object itself
+   */
+  public URIStatus setIsFromUFS() {
+    mIsFromUFS = true;
+    return this;
   }
 
   /**

--- a/dora/core/common/src/main/java/alluxio/client/file/URIStatus.java
+++ b/dora/core/common/src/main/java/alluxio/client/file/URIStatus.java
@@ -43,7 +43,7 @@ public class URIStatus {
   /** Context associated with this URI, possibly set by other external engines (e.g., presto). */
   private final CacheContext mCacheContext;
 
-  private boolean mIsFromUFS;
+  private boolean mFromUFSFallBack;
 
   /**
    * Constructs an instance of this class from a {@link FileInfo}.
@@ -63,7 +63,7 @@ public class URIStatus {
   public URIStatus(FileInfo info, @Nullable CacheContext context) {
     mInfo = Preconditions.checkNotNull(info, "info");
     mCacheContext = context;
-    mIsFromUFS = false;
+    mFromUFSFallBack = false;
   }
 
   /**
@@ -71,8 +71,8 @@ public class URIStatus {
    *
    * If true, it means this status is retrieved by falling back to UFS.
    */
-  public boolean getIsFromUFS() {
-    return mIsFromUFS;
+  public boolean isFromUFSFallBack() {
+    return mFromUFSFallBack;
   }
 
   /**
@@ -86,8 +86,8 @@ public class URIStatus {
    *
    * @return this object itself
    */
-  public URIStatus setIsFromUFS() {
-    mIsFromUFS = true;
+  public URIStatus setFromUFSFallBack() {
+    mFromUFSFallBack = true;
     return this;
   }
 


### PR DESCRIPTION
With this flag, client read will fall back to UFS when previous getStatus() falls back to UFS.

### What changes are proposed in this pull request?

If a URIStatus is retrieved from UFS in stead of worker by falling back to UFS, set the flag.
So, subsequent openFile(status, path) can fall back UFS immediately. So client read will
continue without error in shorter time interval.

### Why are the changes needed?

To reduce the client fall back time.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
