### PR TITLE
Set min replicate to 0 and unpin file if we fail to replicate a file

### DIFF
--- a/job/server/src/main/java/alluxio/job/plan/replicate/SetReplicaDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/SetReplicaDefinition.java
@@ -173,6 +173,9 @@ public final class SetReplicaDefinition
     try {
       JobUtils.loadBlock(status, context.getFsContext(), config.getBlockId(), null, false);
     } catch (IOException e) {
+      // This will remove the file from the pinlist if it fails to replicate, there can be false
+      // positives because replication can fail transiently and this would unpin it. However,
+      // compared to repeatedly replicating, this is a more acceptable result.
       LOG.warn("Replication of {} failed, reduce min replication to 0 and unpin. Reason: {} ",
           status.getPath(), e.getMessage());
       SetAttributePOptions.Builder optionsBuilder =

--- a/job/server/src/main/java/alluxio/job/plan/replicate/SetReplicaDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/SetReplicaDefinition.java
@@ -173,8 +173,8 @@ public final class SetReplicaDefinition
     try {
       JobUtils.loadBlock(status, context.getFsContext(), config.getBlockId(), null, false);
     } catch (IOException e) {
-      LOG.warn("Replication of {} failed, reduce min replication to 0 and unpin.",
-          status.getPath());
+      LOG.warn("Replication of {} failed, reduce min replication to 0 and unpin. Reason: {} ",
+          status.getPath(), e.getMessage());
       SetAttributePOptions.Builder optionsBuilder =
           SetAttributePOptions.newBuilder();
       try {
@@ -182,6 +182,7 @@ public final class SetReplicaDefinition
             optionsBuilder.setReplicationMin(0).setPinned(false).build());
       } catch (Throwable e2) {
         e.addSuppressed(e2);
+        LOG.warn("Attempt to set min replication to 0 and unpin failed due to ", e2);
       }
       throw e;
     }

--- a/job/server/src/main/java/alluxio/job/plan/replicate/SetReplicaDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/SetReplicaDefinition.java
@@ -173,12 +173,16 @@ public final class SetReplicaDefinition
     try {
       JobUtils.loadBlock(status, context.getFsContext(), config.getBlockId(), null, false);
     } catch (IOException e) {
-      LOG.warn("Replication of {} failed, reduce min replication to 1 and unpin.",
+      LOG.warn("Replication of {} failed, reduce min replication to 0 and unpin.",
           status.getPath());
       SetAttributePOptions.Builder optionsBuilder =
           SetAttributePOptions.newBuilder();
-      context.getFileSystem().setAttribute(new AlluxioURI(config.getPath()),
-          optionsBuilder.setReplicationMin(0).setPinned(false).build());
+      try {
+        context.getFileSystem().setAttribute(new AlluxioURI(config.getPath()),
+            optionsBuilder.setReplicationMin(0).setPinned(false).build());
+      } catch (Throwable e2) {
+        e.addSuppressed(e2);
+      }
       throw e;
     }
     LOG.info("Replicated file " + config.getPath() + " block " + config.getBlockId());


### PR DESCRIPTION
### What changes are proposed in this pull request?

Now we unpin and set min replication to 0 if we failed due to IO related reasons. (such as UFS not available, file does not exist etc).

### Why are the changes needed?
Previously if a replication job fails, it would be rescheduled again and again, causing Denial of Service.


### Does this PR introduce any user facing changes?
Yes, the user would expect certain files unpinned or adjusted if it becomes unavailable. 
