### PR TITLE
Add process subcommands for multiple nodes

### DIFF
--- a/cli/src/alluxio.org/cli/env/env.go
+++ b/cli/src/alluxio.org/cli/env/env.go
@@ -224,7 +224,7 @@ func checkAndSetJava(envVar *viper.Viper) error {
 	// check if java is available via `PATH` using `which`
 	whichJavaPath, err := exec.Command("which", "java").Output()
 	if err == nil {
-		envVar.Set(ConfJava.EnvVar, strings.Trim(string(whichJavaPath), "\n"))
+		envVar.Set(ConfJava.EnvVar, strings.TrimSpace(string(whichJavaPath)))
 		return nil
 	}
 	// cannot find java

--- a/cli/src/alluxio.org/cli/env/env.go
+++ b/cli/src/alluxio.org/cli/env/env.go
@@ -224,7 +224,7 @@ func checkAndSetJava(envVar *viper.Viper) error {
 	// check if java is available via `PATH` using `which`
 	whichJavaPath, err := exec.Command("which", "java").Output()
 	if err == nil {
-		envVar.Set(ConfJava.EnvVar, string(whichJavaPath))
+		envVar.Set(ConfJava.EnvVar, strings.Trim(string(whichJavaPath), "\n"))
 		return nil
 	}
 	// cannot find java

--- a/cli/src/alluxio.org/cli/env/env.go
+++ b/cli/src/alluxio.org/cli/env/env.go
@@ -71,7 +71,7 @@ func InitAlluxioEnv(rootPath string, isDeployed bool) error {
 
 	// set default values
 	for k, v := range map[string]string{
-		confAlluxioHome.EnvVar:        rootPath,
+		ConfAlluxioHome.EnvVar:        rootPath,
 		ConfAlluxioConfDir.EnvVar:     filepath.Join(rootPath, "conf"),
 		ConfAlluxioLogsDir.EnvVar:     filepath.Join(rootPath, "logs"),
 		confAlluxioUserLogsDir.EnvVar: filepath.Join(rootPath, "logs", "user"),
@@ -119,7 +119,7 @@ func InitAlluxioEnv(rootPath string, isDeployed bool) error {
 		envVar.GetString(ConfAlluxioConfDir.EnvVar) + "/",
 		envVar.GetString(confAlluxioClasspath.EnvVar),
 		envVar.GetString(envAlluxioAssemblyClientJar),
-		filepath.Join(envVar.GetString(confAlluxioHome.EnvVar), "lib", fmt.Sprintf("alluxio-integration-tools-validation-%v.jar", ver)),
+		filepath.Join(envVar.GetString(ConfAlluxioHome.EnvVar), "lib", fmt.Sprintf("alluxio-integration-tools-validation-%v.jar", ver)),
 	}, ":"))
 	envVar.Set(EnvAlluxioServerClasspath, strings.Join([]string{
 		envVar.GetString(ConfAlluxioConfDir.EnvVar) + "/",
@@ -151,7 +151,7 @@ func InitAlluxioEnv(rootPath string, isDeployed bool) error {
 	}
 
 	for _, c := range []*AlluxioConfigEnvVar{
-		confAlluxioHome,
+		ConfAlluxioHome,
 		ConfAlluxioConfDir,
 		ConfAlluxioLogsDir,
 		confAlluxioUserLogsDir,

--- a/cli/src/alluxio.org/cli/env/env_vars.go
+++ b/cli/src/alluxio.org/cli/env/env_vars.go
@@ -54,7 +54,7 @@ var (
 		configKey: "alluxio.conf.dir",
 		EnvVar:    "ALLUXIO_CONF_DIR",
 	}
-	confAlluxioHome = &AlluxioConfigEnvVar{
+	ConfAlluxioHome = &AlluxioConfigEnvVar{
 		configKey: "alluxio.home",
 		EnvVar:    "ALLUXIO_HOME",
 	}

--- a/cli/src/alluxio.org/cli/env/process_start.go
+++ b/cli/src/alluxio.org/cli/env/process_start.go
@@ -16,13 +16,15 @@ import (
 )
 
 type StartProcessCommand struct {
+	Name            string
 	AsyncStart      bool
 	SkipKillOnStart bool
 }
 
 func (c *StartProcessCommand) ToCommand() *cobra.Command {
+	c.Name = "start"
 	cmd := &cobra.Command{
-		Use:   "start",
+		Use:   c.Name,
 		Short: "Starts a process",
 	}
 	cmd.PersistentFlags().BoolVarP(&c.SkipKillOnStart, "skip-kill-prev", "N", false, "Avoid killing previous running processes when starting")

--- a/cli/src/alluxio.org/cli/env/process_stop.go
+++ b/cli/src/alluxio.org/cli/env/process_stop.go
@@ -14,12 +14,14 @@ package env
 import "github.com/spf13/cobra"
 
 type StopProcessCommand struct {
+	Name     string
 	SoftKill bool
 }
 
 func (c *StopProcessCommand) ToCommand() *cobra.Command {
+	c.Name = "stop"
 	cmd := &cobra.Command{
-		Use:   "stop",
+		Use:   c.Name,
 		Short: "Stops a process",
 	}
 	cmd.PersistentFlags().BoolVarP(&c.SoftKill, "soft", "s", false, "Soft kill only, don't forcibly kill the process")

--- a/cli/src/alluxio.org/cli/main.go
+++ b/cli/src/alluxio.org/cli/main.go
@@ -29,10 +29,12 @@ import (
 
 func main() {
 	for _, p := range []env.Process{
+		processes.All,
 		processes.JobMaster,
 		processes.JobMasters,
 		processes.JobWorker,
 		processes.JobWorkers,
+		processes.Local,
 		processes.Master,
 		processes.Masters,
 		processes.Proxy,

--- a/cli/src/alluxio.org/cli/main.go
+++ b/cli/src/alluxio.org/cli/main.go
@@ -32,7 +32,9 @@ func main() {
 		processes.JobMaster,
 		processes.JobWorker,
 		processes.Master,
+		processes.Masters,
 		processes.Proxy,
+		processes.Proxies,
 		processes.Worker,
 		processes.Workers,
 	} {

--- a/cli/src/alluxio.org/cli/main.go
+++ b/cli/src/alluxio.org/cli/main.go
@@ -30,7 +30,9 @@ import (
 func main() {
 	for _, p := range []env.Process{
 		processes.JobMaster,
+		processes.JobMasters,
 		processes.JobWorker,
+		processes.JobWorkers,
 		processes.Master,
 		processes.Masters,
 		processes.Proxy,

--- a/cli/src/alluxio.org/cli/main.go
+++ b/cli/src/alluxio.org/cli/main.go
@@ -34,6 +34,7 @@ func main() {
 		processes.Master,
 		processes.Proxy,
 		processes.Worker,
+		processes.Workers,
 	} {
 		env.RegisterProcess(p)
 	}

--- a/cli/src/alluxio.org/cli/processes/all.go
+++ b/cli/src/alluxio.org/cli/processes/all.go
@@ -56,20 +56,20 @@ func (p *AllProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *AllProcess) Start(cmd *env.StartProcessCommand) error {
-	for i := 0; i < len(All.Processes); i++ {
-		subProcess := All.Processes[i]
+	for i := 0; i < len(p.Processes); i++ {
+		subProcess := p.Processes[i]
 		if err := subProcess.Start(cmd); err != nil {
-			return stacktrace.Propagate(err, "Error on subprocess start %v", All.Processes[i])
+			return stacktrace.Propagate(err, "Error starting subprocesses for %v", p.Processes[i])
 		}
 	}
 	return nil
 }
 
 func (p *AllProcess) Stop(cmd *env.StopProcessCommand) error {
-	for i := len(All.Processes) - 1; i >= 0; i-- {
-		subProcess := All.Processes[i]
+	for i := len(p.Processes) - 1; i >= 0; i-- {
+		subProcess := p.Processes[i]
 		if err := subProcess.Stop(cmd); err != nil {
-			return stacktrace.Propagate(err, "Error: %s on subprocess stop %s", err, All.Processes[i])
+			return stacktrace.Propagate(err, "Error stopping subprocesses for", p.Processes[i])
 		}
 	}
 	return nil

--- a/cli/src/alluxio.org/cli/processes/all.go
+++ b/cli/src/alluxio.org/cli/processes/all.go
@@ -1,0 +1,90 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package processes
+
+import (
+	"os/exec"
+	"path"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"alluxio.org/cli/env"
+)
+
+var All = &AllProcess{
+	BaseProcess: &env.BaseProcess{
+		Name: "all",
+	},
+}
+
+type AllProcess struct {
+	*env.BaseProcess
+}
+
+func (p *AllProcess) SetEnvVars(envVar *viper.Viper) {
+	return
+}
+
+func (p *AllProcess) Base() *env.BaseProcess {
+	return p.BaseProcess
+}
+
+func (p *AllProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Use = p.Name
+	return cmd
+}
+
+func (p *AllProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Use = p.Name
+	return cmd
+}
+
+func (p *AllProcess) Start(cmd *env.StartProcessCommand) error {
+	// generate commands
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	components := []string{"masters", "job_masters", "workers", "job_workers", "proxies"}
+	var commands []string
+	for _, component := range components {
+		arguments := "process start" + " " + component
+		if cmd.AsyncStart {
+			arguments = arguments + " -a"
+		}
+		if cmd.SkipKillOnStart {
+			arguments = arguments + " -N"
+		}
+		commands = append(commands, cliPath+" "+arguments)
+	}
+
+	for _, command := range commands {
+		exec.Command(command)
+	}
+
+	return nil
+}
+
+func (p *AllProcess) Stop(cmd *env.StopProcessCommand) error {
+	// generate commands
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	components := []string{"masters", "job_masters", "workers", "job_workers", "proxies"}
+	var commands []string
+	for _, component := range components {
+		arguments := "process stop" + " " + component
+		commands = append(commands, cliPath+" "+arguments)
+	}
+
+	for _, command := range commands {
+		exec.Command(command)
+	}
+
+	return nil
+}

--- a/cli/src/alluxio.org/cli/processes/all.go
+++ b/cli/src/alluxio.org/cli/processes/all.go
@@ -59,7 +59,7 @@ func (p *AllProcess) Start(cmd *env.StartProcessCommand) error {
 	for i := 0; i < len(p.Processes); i++ {
 		subProcess := p.Processes[i]
 		if err := subProcess.Start(cmd); err != nil {
-			return stacktrace.Propagate(err, "Error starting subprocesses for %v", p.Processes[i])
+			return stacktrace.Propagate(err, "Error starting subprocesses for %s", p.Processes[i])
 		}
 	}
 	return nil
@@ -69,7 +69,7 @@ func (p *AllProcess) Stop(cmd *env.StopProcessCommand) error {
 	for i := len(p.Processes) - 1; i >= 0; i-- {
 		subProcess := p.Processes[i]
 		if err := subProcess.Stop(cmd); err != nil {
-			return stacktrace.Propagate(err, "Error stopping subprocesses for", p.Processes[i])
+			return stacktrace.Propagate(err, "Error stopping subprocesses for %s", p.Processes[i])
 		}
 	}
 	return nil

--- a/cli/src/alluxio.org/cli/processes/common.go
+++ b/cli/src/alluxio.org/cli/processes/common.go
@@ -20,6 +20,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/palantir/stacktrace"
@@ -35,23 +36,28 @@ var privateKeySigner ssh.Signer
 var masterList []string
 var workerList []string
 
-// for each master, create a client and run
+type Result struct {
+	err error
+	msg string
+}
+
+// for each node, create a client and run
 // TODO: now start master one by one, need to do them in parallel
 func runCommand(command string, onMasters bool, onWorkers bool) error {
 	// get list of masters and workers
 	var nodes []string
 	if onMasters {
 		if len(masterList) == 0 {
-			if err := getNodes(true); err != nil {
-				log.Logger.Fatalf("Cannot get masters, error: %s", err)
+			if err := getNodes("masters"); err != nil {
+				return stacktrace.Propagate(err, "Cannot get masters")
 			}
 		}
 		nodes = append(nodes, masterList...)
 	}
 	if onWorkers {
 		if len(workerList) == 0 {
-			if err := getNodes(false); err != nil {
-				log.Logger.Fatalf("Cannot get workers, error: %s", err)
+			if err := getNodes("workers"); err != nil {
+				return stacktrace.Propagate(err, "Cannot get workers")
 			}
 		}
 		nodes = append(nodes, workerList...)
@@ -75,27 +81,105 @@ func runCommand(command string, onMasters bool, onWorkers bool) error {
 		}
 	}
 
+	clientConfig := &ssh.ClientConfig{
+		User: currentUsername,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(privateKeySigner),
+		},
+		Timeout:         5 * time.Second,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	// find default ssh port
+	port, err := net.LookupPort("tcp", "ssh")
+	if err != nil {
+		return stacktrace.Propagate(err, "Get default ssh port failed.")
+	}
+
 	// dial nodes, run sessions and close
-	var errors []error
+	var waitGroup sync.WaitGroup
+	results := make(chan Result)
 	for _, node := range nodes {
-		conn, err := dialConnection(node, privateKeySigner)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		if err := runSession(node, conn, command); err != nil {
-			errors = append(errors, err)
-		}
-		if err := conn.Close(); err != nil {
-			log.Logger.Infof("Connection to %s closed. Error: %s", node, err)
-		} else {
-			log.Logger.Infof("Connection to %s closed.", node)
+		waitGroup.Add(1)
+		node := node
+		go func() {
+			defer waitGroup.Done()
+
+			// dial remote node via the ssh port
+			dialAddr := fmt.Sprintf("%s:%d", node, port)
+			conn, err := ssh.Dial("tcp", dialAddr, clientConfig)
+			if err != nil {
+				result := Result{
+					err: err,
+					msg: fmt.Sprintf("Dial failed to %v.", node),
+				}
+				results <- result
+			}
+			defer func(conn *ssh.Client) {
+				if err := conn.Close(); err != nil {
+					log.Logger.Infof("Connection to %s closed. Error: %s", node, err)
+				} else {
+					log.Logger.Infof("Connection to %s closed.", node)
+				}
+			}(conn)
+
+			// create a session for each worker
+			session, err := conn.NewSession()
+			if err != nil {
+				result := Result{
+					err: err,
+					msg: fmt.Sprintf("Cannot create session at %v.", node),
+				}
+				results <- result
+			}
+			defer func(session *ssh.Session) {
+				err := session.Close()
+				if err != nil && err != io.EOF {
+					log.Logger.Infof("Session at %s closed. Error: %s", node, err)
+				} else {
+					log.Logger.Infof("Session at %s closed.", node)
+				}
+			}(session)
+
+			session.Stdout = os.Stdout
+			session.Stderr = os.Stderr
+
+			// run session
+			if err = session.Run(command); err != nil {
+				result := Result{
+					err: err,
+					msg: fmt.Sprintf("Run command %v failed at %v", command, node),
+				}
+				results <- result
+			}
+
+			result := Result{
+				err: nil,
+				msg: "",
+			}
+			results <- result
+		}()
+	}
+
+	go func() {
+		waitGroup.Wait()
+		close(results)
+	}()
+
+	hasError := 0
+	for result := range results {
+		if result.err != nil {
+			hasError++
+			err := stacktrace.Propagate(result.err, result.msg)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
-	if len(errors) != 0 {
-		log.Logger.Warningf("Run command %s failed, number of failures: %v", command, len(errors))
-		return stacktrace.Propagate(errors[0], "First error: ")
+	if hasError != 0 {
+		log.Logger.Warningf("Run command %s failed, number of failures: %v", command, hasError)
+		return nil
 	}
 	log.Logger.Infof("Run command %s successful on nodes: %s", command, nodes)
 	return nil
@@ -122,19 +206,23 @@ func addStopFlags(argument string, cmd *env.StopProcessCommand) string {
 	return strings.Join(command, " ")
 }
 
-func getNodes(isMasters bool) error {
-	var FilePath string
-	if isMasters {
-		FilePath = filepath.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "masters")
+func getNodes(nodeType string) error {
+	var p string
+	if nodeType == "masters" {
+		p = filepath.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "masters")
+	} else if nodeType == "workers" {
+		p = filepath.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "workers")
 	} else {
-		FilePath = filepath.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "workers")
+		return stacktrace.Propagate(fmt.Errorf("invalid nodeType"),
+			"NodeType must be one of [masters, workers].")
 	}
-	File, err := ioutil.ReadFile(FilePath)
+
+	f, err := ioutil.ReadFile(p)
 	if err != nil {
-		return stacktrace.Propagate(err, "Error reading hostnames at %v", FilePath)
+		return stacktrace.Propagate(err, "Error reading hostnames at %v", p)
 	}
 	var nodesList []string
-	for _, line := range strings.Split(string(File), "\n") {
+	for _, line := range strings.Split(string(f), "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "#") {
 			continue
 		}
@@ -142,10 +230,13 @@ func getNodes(isMasters bool) error {
 			nodesList = append(nodesList, line)
 		}
 	}
-	if isMasters {
+	if nodeType == "masters" {
 		masterList = nodesList
-	} else {
+	} else if nodeType == "workers" {
 		workerList = nodesList
+	} else {
+		return stacktrace.Propagate(fmt.Errorf("invalid nodeType"),
+			"NodeType must be one of [masters, workers].")
 	}
 	return nil
 }
@@ -166,55 +257,5 @@ func getPrivateKey() error {
 		return stacktrace.Propagate(err, "Cannot parse public key at %v", privateKeyFile)
 	}
 	privateKeySigner = parsedPrivateKey
-	return nil
-}
-
-func dialConnection(remoteAddress string, signer ssh.Signer) (*ssh.Client, error) {
-	clientConfig := &ssh.ClientConfig{
-		User: currentUsername,
-		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(signer),
-		},
-		Timeout:         5 * time.Second,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-	}
-
-	// find default ssh port
-	port, err := net.LookupPort("tcp", "ssh")
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "Get default ssh port failed.")
-	}
-
-	// dial remote node via the ssh port
-	dialAddr := fmt.Sprintf("%s:%d", remoteAddress, port)
-	conn, err := ssh.Dial("tcp", dialAddr, clientConfig)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "Dial failed to %v, error: %v", remoteAddress, err)
-	}
-	return conn, err
-}
-
-func runSession(remoteAddress string, conn *ssh.Client, command string) error {
-	// create a session for each worker
-	session, err := conn.NewSession()
-	if err != nil {
-		return stacktrace.Propagate(err, "Cannot create session at %v", remoteAddress)
-	}
-
-	session.Stdout = os.Stdout
-	session.Stderr = os.Stderr
-
-	// run session
-	if err = session.Run(command); err != nil {
-		return stacktrace.Propagate(err, "Run command %v failed at %v", command, remoteAddress)
-	}
-
-	// close session
-	if err = session.Close(); err != nil && err != io.EOF {
-		log.Logger.Infof("Session at %s closed. Error: %s", remoteAddress, err)
-		return err
-	} else {
-		log.Logger.Infof("Session at %s closed.", remoteAddress)
-	}
 	return nil
 }

--- a/cli/src/alluxio.org/cli/processes/common.go
+++ b/cli/src/alluxio.org/cli/processes/common.go
@@ -1,0 +1,170 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package processes
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"alluxio.org/cli/env"
+	"alluxio.org/log"
+	"golang.org/x/crypto/ssh"
+)
+
+func getMasters() ([]string, error) {
+	mastersDir := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "masters")
+	mastersFile, err := os.Open(mastersDir)
+	if err != nil {
+		log.Logger.Errorf("Error reading worker hostnames at %s", mastersDir)
+		return nil, err
+	}
+
+	mastersReader := bufio.NewReader(mastersFile)
+	var mastersList []string
+	lastLine := false
+	for !lastLine {
+		// read lines of the workers file
+		line, err := mastersReader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				lastLine = true
+			} else {
+				log.Logger.Errorf("Error parsing worker file at this line: %s", line)
+				return nil, err
+			}
+		}
+		// remove notes
+		if strings.Index(line, "#") != -1 {
+			line = line[:strings.Index(line, "#")]
+		}
+		line = strings.TrimSpace(line)
+		if line != "" {
+			mastersList = append(mastersList, line)
+		}
+	}
+	return mastersList, nil
+}
+
+func getWorkers() ([]string, error) {
+	workersDir := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "workers")
+	workersFile, err := os.Open(workersDir)
+	if err != nil {
+		log.Logger.Errorf("Error reading worker hostnames at %s", workersDir)
+		return nil, err
+	}
+
+	workersReader := bufio.NewReader(workersFile)
+	var workersList []string
+	lastLine := false
+	for !lastLine {
+		// read lines of the workers file
+		line, err := workersReader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				lastLine = true
+			} else {
+				log.Logger.Errorf("Error parsing worker file at this line: %s", line)
+				return nil, err
+			}
+		}
+		// remove notes
+		if strings.Index(line, "#") != -1 {
+			line = line[:strings.Index(line, "#")]
+		}
+		line = strings.TrimSpace(line)
+		if line != "" {
+			workersList = append(workersList, line)
+		}
+	}
+	return workersList, nil
+}
+
+func getPrivateKey() (ssh.Signer, error) {
+	homePath, err := os.UserHomeDir()
+	if err != nil {
+		log.Logger.Errorf("User home directory not found at %s", homePath)
+		return nil, err
+	}
+	privateKey, err := os.ReadFile(path.Join(homePath, ".ssh", "id_rsa"))
+	if err != nil {
+		log.Logger.Errorf("Private key file not found at %s", path.Join(homePath, ".ssh", "id_rsa"))
+		return nil, err
+	}
+	parsedPrivateKey, err := ssh.ParsePrivateKey(privateKey)
+	if err != nil {
+		log.Logger.Errorf("Cannot parse public key at %s", path.Join(homePath, ".ssh", "id_rsa"))
+		return nil, err
+	}
+	return parsedPrivateKey, nil
+}
+
+func runCommands(workers []string, key ssh.Signer, command string) []error {
+	var errors []error
+	for _, worker := range workers {
+		clientConfig := &ssh.ClientConfig{
+			// TODO: how to get user name? Like ${USER} in alluxio-common.sh
+			User: "root",
+			Auth: []ssh.AuthMethod{
+				ssh.PublicKeys(key),
+			},
+			Timeout:         5 * time.Second,
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+		// TODO: Some machines might have changed default SSH port. Get ssh port or remind users when get started.
+		dialAddr := fmt.Sprintf("%s:%d", worker, 22)
+		conn, err := ssh.Dial("tcp", dialAddr, clientConfig)
+		defer func(conn *ssh.Client) {
+			err := conn.Close()
+			if err != nil {
+				log.Logger.Infof("Connection to %s closed. Error: %s", dialAddr, err)
+			} else {
+				log.Logger.Infof("Connection to %s closed.", dialAddr)
+			}
+		}(conn)
+
+		if err != nil {
+			log.Logger.Errorf("Dial failed to %s, error: %s", dialAddr, err)
+			errors = append(errors, err)
+		}
+
+		// create a session for each worker
+		session, err := conn.NewSession()
+		if err != nil {
+			log.Logger.Errorf("Cannot create session at %s", dialAddr)
+			errors = append(errors, err)
+		}
+		defer func(session *ssh.Session) {
+			err := session.Close()
+			if err != nil && err != io.EOF {
+				log.Logger.Infof("Session at %s closed. Error: %s", dialAddr, err)
+			} else {
+				log.Logger.Infof("Session at %s closed.", dialAddr)
+			}
+		}(session)
+
+		session.Stdout = os.Stdout
+		session.Stderr = os.Stderr
+
+		// run session
+		err = session.Run(command)
+		if err != nil {
+			log.Logger.Errorf("Run command %s failed at %s", command, dialAddr)
+			errors = append(errors, err)
+		}
+	}
+	return errors
+}

--- a/cli/src/alluxio.org/cli/processes/common.go
+++ b/cli/src/alluxio.org/cli/processes/common.go
@@ -27,42 +27,29 @@ import (
 	"alluxio.org/log"
 )
 
-func getMasters() ([]string, error) {
-	mastersFilePath := filepath.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "masters")
-	mastersFile, err := ioutil.ReadFile(mastersFilePath)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "Error reading master hostnames at %v", mastersFilePath)
-	}
+var cliPath = filepath.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 
-	var mastersList []string
-	for _, line := range strings.Split(string(mastersFile), "\n") {
+func getNodes(isMasters bool) ([]string, error) {
+	var FilePath string
+	if isMasters {
+		FilePath = filepath.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "masters")
+	} else {
+		FilePath = filepath.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "workers")
+	}
+	File, err := ioutil.ReadFile(FilePath)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "Error reading hostnames at %v", FilePath)
+	}
+	var nodesList []string
+	for _, line := range strings.Split(string(File), "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "#") {
 			continue
 		}
 		if strings.TrimSpace(line) != "" {
-			mastersList = append(mastersList, line)
+			nodesList = append(nodesList, line)
 		}
 	}
-	return mastersList, nil
-}
-
-func getWorkers() ([]string, error) {
-	workersFilePath := filepath.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "workers")
-	workersFile, err := ioutil.ReadFile(workersFilePath)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "Error reading worker hostnames at %v", workersFilePath)
-	}
-
-	var workersList []string
-	for _, line := range strings.Split(string(workersFile), "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "#") {
-			continue
-		}
-		if strings.TrimSpace(line) != "" {
-			workersList = append(workersList, line)
-		}
-	}
-	return workersList, nil
+	return nodesList, nil
 }
 
 func getPrivateKey() (ssh.Signer, error) {

--- a/cli/src/alluxio.org/cli/processes/job_masters.go
+++ b/cli/src/alluxio.org/cli/processes/job_masters.go
@@ -12,6 +12,8 @@
 package processes
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -47,11 +49,11 @@ func (p *JobMastersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *JobMastersProcess) Start(cmd *env.StartProcessCommand) error {
-	arguments := "process start job_master"
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobMasterProcess{}.Name}, "")
 	return runCommand(addStartFlags(arguments, cmd), "master")
 }
 
 func (p *JobMastersProcess) Stop(cmd *env.StopProcessCommand) error {
-	arguments := "process stop job_master"
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobMasterProcess{}.Name}, "")
 	return runCommand(addStopFlags(arguments, cmd), "master")
 }

--- a/cli/src/alluxio.org/cli/processes/job_masters.go
+++ b/cli/src/alluxio.org/cli/processes/job_masters.go
@@ -63,7 +63,7 @@ func (p *JobMastersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process start job_master"
 	if cmd.AsyncStart {
 		arguments = arguments + " -a"
@@ -114,8 +114,11 @@ func (p *JobMastersProcess) Stop(cmd *env.StopProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process stop job_master"
+	if cmd.SoftKill {
+		arguments = arguments + " -s"
+	}
 	command := cliPath + " " + arguments
 
 	// for each master, create a client and run

--- a/cli/src/alluxio.org/cli/processes/job_masters.go
+++ b/cli/src/alluxio.org/cli/processes/job_masters.go
@@ -48,10 +48,10 @@ func (p *JobMastersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *JobMastersProcess) Start(cmd *env.StartProcessCommand) error {
 	arguments := "process start job_master"
-	return runCommand(addStartFlags(arguments, cmd), true, false)
+	return runCommand(addStartFlags(arguments, cmd), "master")
 }
 
 func (p *JobMastersProcess) Stop(cmd *env.StopProcessCommand) error {
 	arguments := "process stop job_master"
-	return runCommand(addStopFlags(arguments, cmd), true, false)
+	return runCommand(addStopFlags(arguments, cmd), "master")
 }

--- a/cli/src/alluxio.org/cli/processes/job_masters.go
+++ b/cli/src/alluxio.org/cli/processes/job_masters.go
@@ -12,8 +12,6 @@
 package processes
 
 import (
-	"path"
-
 	"alluxio.org/cli/env"
 	"alluxio.org/log"
 	"github.com/spf13/cobra"
@@ -50,7 +48,7 @@ func (p *JobMastersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *JobMastersProcess) Start(cmd *env.StartProcessCommand) error {
 	// get list of all masters, stored at mastersList
-	masters, err := getMasters()
+	masters, err := getNodes(true)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get masters, error: %s", err)
 	}
@@ -62,7 +60,6 @@ func (p *JobMastersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process start job_master"
 	if cmd.AsyncStart {
 		arguments = arguments + " -a"
@@ -99,7 +96,7 @@ func (p *JobMastersProcess) Start(cmd *env.StartProcessCommand) error {
 
 func (p *JobMastersProcess) Stop(cmd *env.StopProcessCommand) error {
 	// get list of all masters, stored at mastersList
-	masters, err := getMasters()
+	masters, err := getNodes(true)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get masters, error: %s", err)
 	}
@@ -111,7 +108,6 @@ func (p *JobMastersProcess) Stop(cmd *env.StopProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process stop job_master"
 	if cmd.SoftKill {
 		arguments = arguments + " -s"

--- a/cli/src/alluxio.org/cli/processes/job_masters.go
+++ b/cli/src/alluxio.org/cli/processes/job_masters.go
@@ -14,11 +14,10 @@ package processes
 import (
 	"path"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
 	"alluxio.org/cli/env"
 	"alluxio.org/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var JobMasters = &JobMastersProcess{
@@ -82,12 +81,10 @@ func (p *JobMastersProcess) Start(cmd *env.StartProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(master, conn, command)
-		if err != nil {
+		if err = runCommand(master, conn, command); err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(master, conn)
-		if err != nil {
+		if err = closeConnection(master, conn); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -130,20 +127,17 @@ func (p *JobMastersProcess) Stop(cmd *env.StopProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(master, conn, command)
-		if err != nil {
+		if err = runCommand(master, conn, command); err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(master, conn)
-		if err != nil {
+		if err = closeConnection(master, conn); err != nil {
 			errors = append(errors, err)
 		}
 	}
 
-	if len(errors) == 0 {
-		log.Logger.Infof("Run command %s successful on masters: %s", command, masters)
-	} else {
-		log.Logger.Fatalf("Run command %s failed, number of failures: %v", command, len(errors))
+	if len(errors) != 0 {
+		log.Logger.Fatalf("Run command %v failed. Failed commands: %v", command, len(errors))
 	}
+	log.Logger.Infof("Run command %s successful on masters: %s", command, masters)
 	return nil
 }

--- a/cli/src/alluxio.org/cli/processes/job_masters.go
+++ b/cli/src/alluxio.org/cli/processes/job_masters.go
@@ -82,11 +82,11 @@ func (p *JobMastersProcess) Start(cmd *env.StartProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(conn, command)
+		err = runCommand(master, conn, command)
 		if err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(conn)
+		err = closeConnection(master, conn)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -130,11 +130,11 @@ func (p *JobMastersProcess) Stop(cmd *env.StopProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(conn, command)
+		err = runCommand(master, conn, command)
 		if err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(conn)
+		err = closeConnection(master, conn)
 		if err != nil {
 			errors = append(errors, err)
 		}

--- a/cli/src/alluxio.org/cli/processes/job_masters.go
+++ b/cli/src/alluxio.org/cli/processes/job_masters.go
@@ -12,10 +12,10 @@
 package processes
 
 import (
-	"alluxio.org/cli/env"
-	"alluxio.org/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"alluxio.org/cli/env"
 )
 
 var JobMasters = &JobMastersProcess{
@@ -47,93 +47,11 @@ func (p *JobMastersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *JobMastersProcess) Start(cmd *env.StartProcessCommand) error {
-	// get list of all masters, stored at mastersList
-	masters, err := getNodes(true)
-	if err != nil {
-		log.Logger.Fatalf("Cannot get masters, error: %s", err)
-	}
-
-	// get public key for passwordless ssh
-	key, err := getPrivateKey()
-	if err != nil {
-		log.Logger.Fatalf("Cannot get private key, error: %s", err)
-	}
-
-	// generate command
 	arguments := "process start job_master"
-	if cmd.AsyncStart {
-		arguments = arguments + " -a"
-	}
-	if cmd.SkipKillOnStart {
-		arguments = arguments + " -N"
-	}
-	command := cliPath + " " + arguments
-
-	// for each master, create a client and run
-	// TODO: now start master one by one, need to do them in parallel
-	var errors []error
-	for _, master := range masters {
-		conn, err := dialConnection(master, key)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		if err = runCommand(master, conn, command); err != nil {
-			errors = append(errors, err)
-		}
-		if err = closeConnection(master, conn); err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	if len(errors) == 0 {
-		log.Logger.Infof("Run command %s successful on masters: %s", command, masters)
-	} else {
-		log.Logger.Fatalf("Run command %s failed, number of failures: %v", command, len(errors))
-	}
-	return nil
+	return runCommand(addStartFlags(arguments, cmd), true, false)
 }
 
 func (p *JobMastersProcess) Stop(cmd *env.StopProcessCommand) error {
-	// get list of all masters, stored at mastersList
-	masters, err := getNodes(true)
-	if err != nil {
-		log.Logger.Fatalf("Cannot get masters, error: %s", err)
-	}
-
-	// get public key for passwordless ssh
-	key, err := getPrivateKey()
-	if err != nil {
-		log.Logger.Fatalf("Cannot get private key, error: %s", err)
-	}
-
-	// generate command
 	arguments := "process stop job_master"
-	if cmd.SoftKill {
-		arguments = arguments + " -s"
-	}
-	command := cliPath + " " + arguments
-
-	// for each master, create a client and run
-	// TODO: now stop master one by one, need to do them in parallel
-	var errors []error
-	for _, master := range masters {
-		conn, err := dialConnection(master, key)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		if err = runCommand(master, conn, command); err != nil {
-			errors = append(errors, err)
-		}
-		if err = closeConnection(master, conn); err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	if len(errors) != 0 {
-		log.Logger.Fatalf("Run command %v failed. Failed commands: %v", command, len(errors))
-	}
-	log.Logger.Infof("Run command %s successful on masters: %s", command, masters)
-	return nil
+	return runCommand(addStopFlags(arguments, cmd), true, false)
 }

--- a/cli/src/alluxio.org/cli/processes/job_masters.go
+++ b/cli/src/alluxio.org/cli/processes/job_masters.go
@@ -49,11 +49,11 @@ func (p *JobMastersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *JobMastersProcess) Start(cmd *env.StartProcessCommand) error {
-	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobMasterProcess{}.Name}, "")
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobMasterProcess{}.Name}, " ")
 	return runCommand(addStartFlags(arguments, cmd), "master")
 }
 
 func (p *JobMastersProcess) Stop(cmd *env.StopProcessCommand) error {
-	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobMasterProcess{}.Name}, "")
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobMasterProcess{}.Name}, " ")
 	return runCommand(addStopFlags(arguments, cmd), "master")
 }

--- a/cli/src/alluxio.org/cli/processes/job_workers.go
+++ b/cli/src/alluxio.org/cli/processes/job_workers.go
@@ -21,35 +21,35 @@ import (
 	"alluxio.org/log"
 )
 
-var Workers = &WorkersProcess{
+var JobWorkers = &JobWorkersProcess{
 	BaseProcess: &env.BaseProcess{
-		Name: "workers",
+		Name: "job_workers",
 	},
 }
 
-type WorkersProcess struct {
+type JobWorkersProcess struct {
 	*env.BaseProcess
 }
 
-func (p *WorkersProcess) SetEnvVars(envVar *viper.Viper) {
+func (p *JobWorkersProcess) SetEnvVars(envVar *viper.Viper) {
 	return
 }
 
-func (p *WorkersProcess) Base() *env.BaseProcess {
+func (p *JobWorkersProcess) Base() *env.BaseProcess {
 	return p.BaseProcess
 }
 
-func (p *WorkersProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
+func (p *JobWorkersProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
 	cmd.Use = p.Name
 	return cmd
 }
 
-func (p *WorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
+func (p *JobWorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 	cmd.Use = p.Name
 	return cmd
 }
 
-func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
+func (p *JobWorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	// get list of all workers, stored at workersList
 	workers, err := getWorkers()
 	if err != nil {
@@ -64,7 +64,7 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 
 	// generate command
 	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
-	arguments := "process start worker"
+	arguments := "process start job_worker"
 	if cmd.AsyncStart {
 		arguments = arguments + " -a"
 	}
@@ -100,7 +100,7 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	return nil
 }
 
-func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
+func (p *JobWorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	// get list of all workers, stored at workersList
 	workers, err := getWorkers()
 	if err != nil {
@@ -115,7 +115,7 @@ func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 
 	// generate command
 	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
-	arguments := "process stop worker"
+	arguments := "process stop job_worker"
 	command := cliPath + " " + arguments
 
 	// for each worker, create a client and run

--- a/cli/src/alluxio.org/cli/processes/job_workers.go
+++ b/cli/src/alluxio.org/cli/processes/job_workers.go
@@ -49,11 +49,11 @@ func (p *JobWorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *JobWorkersProcess) Start(cmd *env.StartProcessCommand) error {
-	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobWorkerProcess{}.Name}, "")
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobWorkerProcess{}.Name}, " ")
 	return runCommand(addStartFlags(arguments, cmd), "worker")
 }
 
 func (p *JobWorkersProcess) Stop(cmd *env.StopProcessCommand) error {
-	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobWorkerProcess{}.Name}, "")
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobWorkerProcess{}.Name}, " ")
 	return runCommand(addStopFlags(arguments, cmd), "worker")
 }

--- a/cli/src/alluxio.org/cli/processes/job_workers.go
+++ b/cli/src/alluxio.org/cli/processes/job_workers.go
@@ -12,6 +12,8 @@
 package processes
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -47,11 +49,11 @@ func (p *JobWorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *JobWorkersProcess) Start(cmd *env.StartProcessCommand) error {
-	arguments := "process start job_worker"
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobWorkerProcess{}.Name}, "")
 	return runCommand(addStartFlags(arguments, cmd), "worker")
 }
 
 func (p *JobWorkersProcess) Stop(cmd *env.StopProcessCommand) error {
-	arguments := "process stop job_worker"
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, JobWorkerProcess{}.Name}, "")
 	return runCommand(addStopFlags(arguments, cmd), "worker")
 }

--- a/cli/src/alluxio.org/cli/processes/job_workers.go
+++ b/cli/src/alluxio.org/cli/processes/job_workers.go
@@ -63,7 +63,7 @@ func (p *JobWorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process start job_worker"
 	if cmd.AsyncStart {
 		arguments = arguments + " -a"
@@ -114,8 +114,11 @@ func (p *JobWorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process stop job_worker"
+	if cmd.SoftKill {
+		arguments = arguments + " -s"
+	}
 	command := cliPath + " " + arguments
 
 	// for each worker, create a client and run

--- a/cli/src/alluxio.org/cli/processes/job_workers.go
+++ b/cli/src/alluxio.org/cli/processes/job_workers.go
@@ -82,11 +82,11 @@ func (p *JobWorkersProcess) Start(cmd *env.StartProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(conn, command)
+		err = runCommand(worker, conn, command)
 		if err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(conn)
+		err = closeConnection(worker, conn)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -130,11 +130,11 @@ func (p *JobWorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(conn, command)
+		err = runCommand(worker, conn, command)
 		if err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(conn)
+		err = closeConnection(worker, conn)
 		if err != nil {
 			errors = append(errors, err)
 		}

--- a/cli/src/alluxio.org/cli/processes/job_workers.go
+++ b/cli/src/alluxio.org/cli/processes/job_workers.go
@@ -48,10 +48,10 @@ func (p *JobWorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *JobWorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	arguments := "process start job_worker"
-	return runCommand(addStartFlags(arguments, cmd), false, true)
+	return runCommand(addStartFlags(arguments, cmd), "worker")
 }
 
 func (p *JobWorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	arguments := "process stop job_worker"
-	return runCommand(addStopFlags(arguments, cmd), false, true)
+	return runCommand(addStopFlags(arguments, cmd), "worker")
 }

--- a/cli/src/alluxio.org/cli/processes/job_workers.go
+++ b/cli/src/alluxio.org/cli/processes/job_workers.go
@@ -82,12 +82,10 @@ func (p *JobWorkersProcess) Start(cmd *env.StartProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(worker, conn, command)
-		if err != nil {
+		if err = runCommand(worker, conn, command); err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(worker, conn)
-		if err != nil {
+		if err = closeConnection(worker, conn); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -130,20 +128,17 @@ func (p *JobWorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(worker, conn, command)
-		if err != nil {
+		if err = runCommand(worker, conn, command); err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(worker, conn)
-		if err != nil {
+		if err = closeConnection(worker, conn); err != nil {
 			errors = append(errors, err)
 		}
 	}
 
-	if len(errors) == 0 {
-		log.Logger.Infof("Run command %s successful on workers: %s", command, workers)
-	} else {
-		log.Logger.Fatalf("Run command %s failed, number of failures: %v", command, len(errors))
+	if len(errors) != 0 {
+		log.Logger.Fatalf("Run command %v failed. Failed commands: %v", command, len(errors))
 	}
+	log.Logger.Infof("Run command %s successful on workers: %s", command, workers)
 	return nil
 }

--- a/cli/src/alluxio.org/cli/processes/job_workers.go
+++ b/cli/src/alluxio.org/cli/processes/job_workers.go
@@ -12,8 +12,6 @@
 package processes
 
 import (
-	"path"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -51,7 +49,7 @@ func (p *JobWorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *JobWorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	// get list of all workers, stored at workersList
-	workers, err := getWorkers()
+	workers, err := getNodes(false)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get workers, error: %s", err)
 	}
@@ -63,7 +61,6 @@ func (p *JobWorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process start job_worker"
 	if cmd.AsyncStart {
 		arguments = arguments + " -a"
@@ -100,7 +97,7 @@ func (p *JobWorkersProcess) Start(cmd *env.StartProcessCommand) error {
 
 func (p *JobWorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	// get list of all workers, stored at workersList
-	workers, err := getWorkers()
+	workers, err := getNodes(false)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get workers, error: %s", err)
 	}
@@ -112,7 +109,6 @@ func (p *JobWorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process stop job_worker"
 	if cmd.SoftKill {
 		arguments = arguments + " -s"

--- a/cli/src/alluxio.org/cli/processes/job_workers.go
+++ b/cli/src/alluxio.org/cli/processes/job_workers.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spf13/viper"
 
 	"alluxio.org/cli/env"
-	"alluxio.org/log"
 )
 
 var JobWorkers = &JobWorkersProcess{
@@ -48,93 +47,11 @@ func (p *JobWorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *JobWorkersProcess) Start(cmd *env.StartProcessCommand) error {
-	// get list of all workers, stored at workersList
-	workers, err := getNodes(false)
-	if err != nil {
-		log.Logger.Fatalf("Cannot get workers, error: %s", err)
-	}
-
-	// get public key for passwordless ssh
-	key, err := getPrivateKey()
-	if err != nil {
-		log.Logger.Fatalf("Cannot get private key, error: %s", err)
-	}
-
-	// generate command
 	arguments := "process start job_worker"
-	if cmd.AsyncStart {
-		arguments = arguments + " -a"
-	}
-	if cmd.SkipKillOnStart {
-		arguments = arguments + " -N"
-	}
-	command := cliPath + " " + arguments
-
-	// for each worker, create a client and run
-	// TODO: now start worker one by one, need to do them in parallel
-	var errors []error
-	for _, worker := range workers {
-		conn, err := dialConnection(worker, key)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		if err = runCommand(worker, conn, command); err != nil {
-			errors = append(errors, err)
-		}
-		if err = closeConnection(worker, conn); err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	if len(errors) == 0 {
-		log.Logger.Infof("Run command %s successful on workers: %s", command, workers)
-	} else {
-		log.Logger.Fatalf("Run command %s failed, number of failures: %v", command, len(errors))
-	}
-	return nil
+	return runCommand(addStartFlags(arguments, cmd), false, true)
 }
 
 func (p *JobWorkersProcess) Stop(cmd *env.StopProcessCommand) error {
-	// get list of all workers, stored at workersList
-	workers, err := getNodes(false)
-	if err != nil {
-		log.Logger.Fatalf("Cannot get workers, error: %s", err)
-	}
-
-	// get public key for passwordless ssh
-	key, err := getPrivateKey()
-	if err != nil {
-		log.Logger.Fatalf("Cannot get private key, error: %s", err)
-	}
-
-	// generate command
 	arguments := "process stop job_worker"
-	if cmd.SoftKill {
-		arguments = arguments + " -s"
-	}
-	command := cliPath + " " + arguments
-
-	// for each worker, create a client and run
-	// TODO: now stop worker one by one, need to do them in parallel
-	var errors []error
-	for _, worker := range workers {
-		conn, err := dialConnection(worker, key)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		if err = runCommand(worker, conn, command); err != nil {
-			errors = append(errors, err)
-		}
-		if err = closeConnection(worker, conn); err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	if len(errors) != 0 {
-		log.Logger.Fatalf("Run command %v failed. Failed commands: %v", command, len(errors))
-	}
-	log.Logger.Infof("Run command %s successful on workers: %s", command, workers)
-	return nil
+	return runCommand(addStopFlags(arguments, cmd), false, true)
 }

--- a/cli/src/alluxio.org/cli/processes/local.go
+++ b/cli/src/alluxio.org/cli/processes/local.go
@@ -56,20 +56,20 @@ func (p *LocalProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *LocalProcess) Start(cmd *env.StartProcessCommand) error {
-	for i := 0; i < len(Local.Processes); i++ {
-		subProcess := Local.Processes[i]
+	for i := 0; i < len(p.Processes); i++ {
+		subProcess := p.Processes[i]
 		if err := subProcess.Start(cmd); err != nil {
-			return stacktrace.Propagate(err, "Error: %s on subprocess start %s", err, Local.Processes[i])
+			return stacktrace.Propagate(err, "Error starting subprocesses for %s", p.Processes[i])
 		}
 	}
 	return nil
 }
 
 func (p *LocalProcess) Stop(cmd *env.StopProcessCommand) error {
-	for i := len(Local.Processes) - 1; i >= 0; i-- {
-		subProcess := Local.Processes[i]
+	for i := len(p.Processes) - 1; i >= 0; i-- {
+		subProcess := p.Processes[i]
 		if err := subProcess.Stop(cmd); err != nil {
-			return stacktrace.Propagate(err, "Error: %s on subprocess stop %s", err, Local.Processes[i])
+			return stacktrace.Propagate(err, "Error stopping subprocesses for %s", p.Processes[i])
 		}
 	}
 	return nil

--- a/cli/src/alluxio.org/cli/processes/local.go
+++ b/cli/src/alluxio.org/cli/processes/local.go
@@ -1,0 +1,90 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package processes
+
+import (
+	"os/exec"
+	"path"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"alluxio.org/cli/env"
+)
+
+var Local = &LocalProcess{
+	BaseProcess: &env.BaseProcess{
+		Name: "local",
+	},
+}
+
+type LocalProcess struct {
+	*env.BaseProcess
+}
+
+func (p *LocalProcess) SetEnvVars(envVar *viper.Viper) {
+	return
+}
+
+func (p *LocalProcess) Base() *env.BaseProcess {
+	return p.BaseProcess
+}
+
+func (p *LocalProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Use = p.Name
+	return cmd
+}
+
+func (p *LocalProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Use = p.Name
+	return cmd
+}
+
+func (p *LocalProcess) Start(cmd *env.StartProcessCommand) error {
+	// generate commands
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	components := []string{"master", "job_master", "worker", "job_worker", "proxy"}
+	var commands []string
+	for _, component := range components {
+		arguments := "process start" + " " + component
+		if cmd.AsyncStart {
+			arguments = arguments + " -a"
+		}
+		if cmd.SkipKillOnStart {
+			arguments = arguments + " -N"
+		}
+		commands = append(commands, cliPath+" "+arguments)
+	}
+
+	for _, command := range commands {
+		exec.Command(command)
+	}
+
+	return nil
+}
+
+func (p *LocalProcess) Stop(cmd *env.StopProcessCommand) error {
+	// generate commands
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	components := []string{"master", "job_master", "worker", "job_worker", "proxy"}
+	var commands []string
+	for _, component := range components {
+		arguments := "process stop" + " " + component
+		commands = append(commands, cliPath+" "+arguments)
+	}
+
+	for _, command := range commands {
+		exec.Command(command)
+	}
+
+	return nil
+}

--- a/cli/src/alluxio.org/cli/processes/masters.go
+++ b/cli/src/alluxio.org/cli/processes/masters.go
@@ -23,7 +23,7 @@ import (
 
 var Masters = &MastersProcess{
 	BaseProcess: &env.BaseProcess{
-		Name: "proxies",
+		Name: "masters",
 	},
 }
 

--- a/cli/src/alluxio.org/cli/processes/masters.go
+++ b/cli/src/alluxio.org/cli/processes/masters.go
@@ -82,12 +82,10 @@ func (p *MastersProcess) Start(cmd *env.StartProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(master, conn, command)
-		if err != nil {
+		if err = runCommand(master, conn, command); err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(master, conn)
-		if err != nil {
+		if err = closeConnection(master, conn); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -130,20 +128,17 @@ func (p *MastersProcess) Stop(cmd *env.StopProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(master, conn, command)
-		if err != nil {
+		if err = runCommand(master, conn, command); err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(master, conn)
-		if err != nil {
+		if err = closeConnection(master, conn); err != nil {
 			errors = append(errors, err)
 		}
 	}
 
-	if len(errors) == 0 {
-		log.Logger.Infof("Run command %s successful on masters: %s", command, masters)
-	} else {
-		log.Logger.Fatalf("Run command %s failed, number of failures: %v", command, len(errors))
+	if len(errors) != 0 {
+		log.Logger.Fatalf("Run command %v failed. Failed commands: %v", command, len(errors))
 	}
+	log.Logger.Infof("Run command %s successful on masters: %s", command, masters)
 	return nil
 }

--- a/cli/src/alluxio.org/cli/processes/masters.go
+++ b/cli/src/alluxio.org/cli/processes/masters.go
@@ -82,11 +82,11 @@ func (p *MastersProcess) Start(cmd *env.StartProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(conn, command)
+		err = runCommand(master, conn, command)
 		if err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(conn)
+		err = closeConnection(master, conn)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -130,11 +130,11 @@ func (p *MastersProcess) Stop(cmd *env.StopProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(conn, command)
+		err = runCommand(master, conn, command)
 		if err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(conn)
+		err = closeConnection(master, conn)
 		if err != nil {
 			errors = append(errors, err)
 		}

--- a/cli/src/alluxio.org/cli/processes/masters.go
+++ b/cli/src/alluxio.org/cli/processes/masters.go
@@ -1,0 +1,55 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package processes
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"alluxio.org/cli/env"
+)
+
+var Masters = &MastersProcess{
+	BaseProcess: &env.BaseProcess{
+		Name: "proxies",
+	},
+}
+
+type MastersProcess struct {
+	*env.BaseProcess
+}
+
+func (p *MastersProcess) SetEnvVars(envVar *viper.Viper) {
+	return
+}
+
+func (p *MastersProcess) Base() *env.BaseProcess {
+	return p.BaseProcess
+}
+
+func (p *MastersProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Use = p.Name
+	return cmd
+}
+
+func (p *MastersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Use = p.Name
+	return cmd
+}
+
+func (p *MastersProcess) Start(cmd *env.StartProcessCommand) error {
+	return nil
+}
+
+func (p *MastersProcess) Stop(cmd *env.StopProcessCommand) error {
+	return nil
+}

--- a/cli/src/alluxio.org/cli/processes/masters.go
+++ b/cli/src/alluxio.org/cli/processes/masters.go
@@ -48,10 +48,10 @@ func (p *MastersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *MastersProcess) Start(cmd *env.StartProcessCommand) error {
 	arguments := "process start master"
-	return runCommand(addStartFlags(arguments, cmd), true, false)
+	return runCommand(addStartFlags(arguments, cmd), "master")
 }
 
 func (p *MastersProcess) Stop(cmd *env.StopProcessCommand) error {
 	arguments := "process stop master"
-	return runCommand(addStopFlags(arguments, cmd), true, false)
+	return runCommand(addStopFlags(arguments, cmd), "master")
 }

--- a/cli/src/alluxio.org/cli/processes/masters.go
+++ b/cli/src/alluxio.org/cli/processes/masters.go
@@ -49,11 +49,11 @@ func (p *MastersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *MastersProcess) Start(cmd *env.StartProcessCommand) error {
-	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, MasterProcess{}.Name}, "")
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, MasterProcess{}.Name}, " ")
 	return runCommand(addStartFlags(arguments, cmd), "master")
 }
 
 func (p *MastersProcess) Stop(cmd *env.StopProcessCommand) error {
-	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, MasterProcess{}.Name}, "")
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, MasterProcess{}.Name}, " ")
 	return runCommand(addStopFlags(arguments, cmd), "master")
 }

--- a/cli/src/alluxio.org/cli/processes/masters.go
+++ b/cli/src/alluxio.org/cli/processes/masters.go
@@ -12,8 +12,6 @@
 package processes
 
 import (
-	"path"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -51,7 +49,7 @@ func (p *MastersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *MastersProcess) Start(cmd *env.StartProcessCommand) error {
 	// get list of all masters, stored at mastersList
-	masters, err := getMasters()
+	masters, err := getNodes(true)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get masters, error: %s", err)
 	}
@@ -63,7 +61,6 @@ func (p *MastersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process start master"
 	if cmd.AsyncStart {
 		arguments = arguments + " -a"
@@ -100,7 +97,7 @@ func (p *MastersProcess) Start(cmd *env.StartProcessCommand) error {
 
 func (p *MastersProcess) Stop(cmd *env.StopProcessCommand) error {
 	// get list of all masters, stored at mastersList
-	masters, err := getMasters()
+	masters, err := getNodes(true)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get masters, error: %s", err)
 	}
@@ -112,7 +109,6 @@ func (p *MastersProcess) Stop(cmd *env.StopProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process stop master"
 	if cmd.SoftKill {
 		arguments = arguments + " -s"

--- a/cli/src/alluxio.org/cli/processes/masters.go
+++ b/cli/src/alluxio.org/cli/processes/masters.go
@@ -63,7 +63,7 @@ func (p *MastersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process start master"
 	if cmd.AsyncStart {
 		arguments = arguments + " -a"
@@ -114,8 +114,11 @@ func (p *MastersProcess) Stop(cmd *env.StopProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process stop master"
+	if cmd.SoftKill {
+		arguments = arguments + " -s"
+	}
 	command := cliPath + " " + arguments
 
 	// for each master, create a client and run

--- a/cli/src/alluxio.org/cli/processes/masters.go
+++ b/cli/src/alluxio.org/cli/processes/masters.go
@@ -12,11 +12,7 @@
 package processes
 
 import (
-	"bufio"
-	"io"
-	"os"
 	"path"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -78,7 +74,7 @@ func (p *MastersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 	command := cliPath + " " + arguments
 
-	errors := runCommandOnMachines(masters, key, command)
+	errors := runCommands(masters, key, command)
 
 	if len(errors) == 0 {
 		log.Logger.Infof("Run command %s successful on masters: %s", command, masters)
@@ -107,7 +103,7 @@ func (p *MastersProcess) Stop(cmd *env.StopProcessCommand) error {
 	arguments := "process stop master"
 	command := cliPath + " " + arguments
 
-	errors := runCommandOnMachines(masters, key, command)
+	errors := runCommands(masters, key, command)
 
 	if len(errors) == 0 {
 		log.Logger.Infof("Run command %s successful on masters: %s", command, masters)
@@ -115,38 +111,4 @@ func (p *MastersProcess) Stop(cmd *env.StopProcessCommand) error {
 		log.Logger.Fatalf("Run command %s failed: %s", command, err)
 	}
 	return nil
-}
-
-func getMasters() ([]string, error) {
-	mastersDir := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "masters")
-	mastersFile, err := os.Open(mastersDir)
-	if err != nil {
-		log.Logger.Errorf("Error reading worker hostnames at %s", mastersDir)
-		return nil, err
-	}
-
-	mastersReader := bufio.NewReader(mastersFile)
-	var mastersList []string
-	lastLine := false
-	for !lastLine {
-		// read lines of the workers file
-		line, err := mastersReader.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				lastLine = true
-			} else {
-				log.Logger.Errorf("Error parsing worker file at this line: %s", line)
-				return nil, err
-			}
-		}
-		// remove notes
-		if strings.Index(line, "#") != -1 {
-			line = line[:strings.Index(line, "#")]
-		}
-		line = strings.TrimSpace(line)
-		if line != "" {
-			mastersList = append(mastersList, line)
-		}
-	}
-	return mastersList, nil
 }

--- a/cli/src/alluxio.org/cli/processes/masters.go
+++ b/cli/src/alluxio.org/cli/processes/masters.go
@@ -12,6 +12,8 @@
 package processes
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -47,11 +49,11 @@ func (p *MastersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *MastersProcess) Start(cmd *env.StartProcessCommand) error {
-	arguments := "process start master"
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, MasterProcess{}.Name}, "")
 	return runCommand(addStartFlags(arguments, cmd), "master")
 }
 
 func (p *MastersProcess) Stop(cmd *env.StopProcessCommand) error {
-	arguments := "process stop master"
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, MasterProcess{}.Name}, "")
 	return runCommand(addStopFlags(arguments, cmd), "master")
 }

--- a/cli/src/alluxio.org/cli/processes/proxies.go
+++ b/cli/src/alluxio.org/cli/processes/proxies.go
@@ -12,8 +12,6 @@
 package processes
 
 import (
-	"path"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -51,11 +49,11 @@ func (p *ProxiesProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *ProxiesProcess) Start(cmd *env.StartProcessCommand) error {
 	// get list of all masters and workers, stored at allList
-	masters, err := getMasters()
+	masters, err := getNodes(true)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get masters, error: %s", err)
 	}
-	workers, err := getWorkers()
+	workers, err := getNodes(false)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get workers, error: %s", err)
 	}
@@ -68,7 +66,6 @@ func (p *ProxiesProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process start proxy"
 	if cmd.AsyncStart {
 		arguments = arguments + " -a"
@@ -105,11 +102,11 @@ func (p *ProxiesProcess) Start(cmd *env.StartProcessCommand) error {
 
 func (p *ProxiesProcess) Stop(cmd *env.StopProcessCommand) error {
 	// get list of all masters and workers, stored at allList
-	masters, err := getMasters()
+	masters, err := getNodes(true)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get masters, error: %s", err)
 	}
-	workers, err := getWorkers()
+	workers, err := getNodes(false)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get workers, error: %s", err)
 	}
@@ -122,7 +119,6 @@ func (p *ProxiesProcess) Stop(cmd *env.StopProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process stop proxy"
 	if cmd.SoftKill {
 		arguments = arguments + " -s"

--- a/cli/src/alluxio.org/cli/processes/proxies.go
+++ b/cli/src/alluxio.org/cli/processes/proxies.go
@@ -87,11 +87,11 @@ func (p *ProxiesProcess) Start(cmd *env.StartProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(conn, command)
+		err = runCommand(node, conn, command)
 		if err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(conn)
+		err = closeConnection(node, conn)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -140,11 +140,11 @@ func (p *ProxiesProcess) Stop(cmd *env.StopProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(conn, command)
+		err = runCommand(node, conn, command)
 		if err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(conn)
+		err = closeConnection(node, conn)
 		if err != nil {
 			errors = append(errors, err)
 		}

--- a/cli/src/alluxio.org/cli/processes/proxies.go
+++ b/cli/src/alluxio.org/cli/processes/proxies.go
@@ -49,11 +49,11 @@ func (p *ProxiesProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *ProxiesProcess) Start(cmd *env.StartProcessCommand) error {
-	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, ProxyProcess{}.Name}, "")
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, ProxyProcess{}.Name}, " ")
 	return runCommand(addStartFlags(arguments, cmd), "all")
 }
 
 func (p *ProxiesProcess) Stop(cmd *env.StopProcessCommand) error {
-	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, ProxyProcess{}.Name}, "")
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, ProxyProcess{}.Name}, " ")
 	return runCommand(addStopFlags(arguments, cmd), "all")
 }

--- a/cli/src/alluxio.org/cli/processes/proxies.go
+++ b/cli/src/alluxio.org/cli/processes/proxies.go
@@ -12,6 +12,8 @@
 package processes
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -47,11 +49,11 @@ func (p *ProxiesProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *ProxiesProcess) Start(cmd *env.StartProcessCommand) error {
-	arguments := "process start proxy"
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, ProxyProcess{}.Name}, "")
 	return runCommand(addStartFlags(arguments, cmd), "all")
 }
 
 func (p *ProxiesProcess) Stop(cmd *env.StopProcessCommand) error {
-	arguments := "process stop proxy"
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, ProxyProcess{}.Name}, "")
 	return runCommand(addStopFlags(arguments, cmd), "all")
 }

--- a/cli/src/alluxio.org/cli/processes/proxies.go
+++ b/cli/src/alluxio.org/cli/processes/proxies.go
@@ -79,7 +79,7 @@ func (p *ProxiesProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 	command := cliPath + " " + arguments
 
-	errors := runCommandOnMachines(allList, key, command)
+	errors := runCommands(allList, key, command)
 
 	if len(errors) == 0 {
 		log.Logger.Infof("Run command %s successful on machines: %s", command, workers)
@@ -113,7 +113,7 @@ func (p *ProxiesProcess) Stop(cmd *env.StopProcessCommand) error {
 	arguments := "process stop proxy"
 	command := cliPath + " " + arguments
 
-	errors := runCommandOnMachines(allList, key, command)
+	errors := runCommands(allList, key, command)
 
 	if len(errors) == 0 {
 		log.Logger.Infof("Run command %s successful on machines: %s", command, workers)

--- a/cli/src/alluxio.org/cli/processes/proxies.go
+++ b/cli/src/alluxio.org/cli/processes/proxies.go
@@ -68,7 +68,7 @@ func (p *ProxiesProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process start proxy"
 	if cmd.AsyncStart {
 		arguments = arguments + " -a"
@@ -124,8 +124,11 @@ func (p *ProxiesProcess) Stop(cmd *env.StopProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process stop proxy"
+	if cmd.SoftKill {
+		arguments = arguments + " -s"
+	}
 	command := cliPath + " " + arguments
 
 	// for each node, create a client

--- a/cli/src/alluxio.org/cli/processes/proxies.go
+++ b/cli/src/alluxio.org/cli/processes/proxies.go
@@ -48,10 +48,10 @@ func (p *ProxiesProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *ProxiesProcess) Start(cmd *env.StartProcessCommand) error {
 	arguments := "process start proxy"
-	return runCommand(addStartFlags(arguments, cmd), true, true)
+	return runCommand(addStartFlags(arguments, cmd), "all")
 }
 
 func (p *ProxiesProcess) Stop(cmd *env.StopProcessCommand) error {
 	arguments := "process stop proxy"
-	return runCommand(addStopFlags(arguments, cmd), true, true)
+	return runCommand(addStopFlags(arguments, cmd), "all")
 }

--- a/cli/src/alluxio.org/cli/processes/proxies.go
+++ b/cli/src/alluxio.org/cli/processes/proxies.go
@@ -1,0 +1,55 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package processes
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"alluxio.org/cli/env"
+)
+
+var Proxies = &ProxiesProcess{
+	BaseProcess: &env.BaseProcess{
+		Name: "proxies",
+	},
+}
+
+type ProxiesProcess struct {
+	*env.BaseProcess
+}
+
+func (p *ProxiesProcess) SetEnvVars(envVar *viper.Viper) {
+	return
+}
+
+func (p *ProxiesProcess) Base() *env.BaseProcess {
+	return p.BaseProcess
+}
+
+func (p *ProxiesProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Use = p.Name
+	return cmd
+}
+
+func (p *ProxiesProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Use = p.Name
+	return cmd
+}
+
+func (p *ProxiesProcess) Start(cmd *env.StartProcessCommand) error {
+	return nil
+}
+
+func (p *ProxiesProcess) Stop(cmd *env.StopProcessCommand) error {
+	return nil
+}

--- a/cli/src/alluxio.org/cli/processes/proxies.go
+++ b/cli/src/alluxio.org/cli/processes/proxies.go
@@ -87,12 +87,10 @@ func (p *ProxiesProcess) Start(cmd *env.StartProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(node, conn, command)
-		if err != nil {
+		if err = runCommand(node, conn, command); err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(node, conn)
-		if err != nil {
+		if err = closeConnection(node, conn); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -140,20 +138,17 @@ func (p *ProxiesProcess) Stop(cmd *env.StopProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(node, conn, command)
-		if err != nil {
+		if err = runCommand(node, conn, command); err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(node, conn)
-		if err != nil {
+		if err = closeConnection(node, conn); err != nil {
 			errors = append(errors, err)
 		}
 	}
 
-	if len(errors) == 0 {
-		log.Logger.Infof("Run command %s successful on nodes: %s", command, allNodes)
-	} else {
-		log.Logger.Fatalf("Run command %s failed, number of failures: %v", command, len(errors))
+	if len(errors) != 0 {
+		log.Logger.Fatalf("Run command %v failed. Failed commands: %v", command, len(errors))
 	}
+	log.Logger.Infof("Run command %s successful on nodes: %s", command, allNodes)
 	return nil
 }

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -82,12 +82,10 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(worker, conn, command)
-		if err != nil {
+		if err = runCommand(worker, conn, command); err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(worker, conn)
-		if err != nil {
+		if err = closeConnection(worker, conn); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -130,20 +128,17 @@ func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(worker, conn, command)
-		if err != nil {
+		if err = runCommand(worker, conn, command); err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(worker, conn)
-		if err != nil {
+		if err = closeConnection(worker, conn); err != nil {
 			errors = append(errors, err)
 		}
 	}
 
-	if len(errors) == 0 {
-		log.Logger.Infof("Run command %s successful on workers: %s", command, workers)
-	} else {
-		log.Logger.Fatalf("Run command %s failed, number of failures: %v", command, len(errors))
+	if len(errors) != 0 {
+		log.Logger.Fatalf("Run command %v failed. Failed commands: %v", command, len(errors))
 	}
+	log.Logger.Infof("Run command %s successful on workers: %s", command, workers)
 	return nil
 }

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -81,7 +81,7 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 	command := cliPath + " " + arguments
 
-	errors := runCommandOnWorkers(workers, key, command)
+	errors := runCommandOnMachines(workers, key, command)
 
 	if len(errors) == 0 {
 		log.Logger.Infof("Run command %s successful on workers: %s", command, workers)
@@ -110,7 +110,7 @@ func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	arguments := "process stop worker"
 	command := cliPath + " " + arguments
 
-	errors := runCommandOnWorkers(workers, key, command)
+	errors := runCommandOnMachines(workers, key, command)
 
 	if len(errors) == 0 {
 		log.Logger.Infof("Run command %s on workers: %s", command, workers)
@@ -173,7 +173,7 @@ func getPrivateKey() (ssh.Signer, error) {
 	return parsedPrivateKey, nil
 }
 
-func runCommandOnWorkers(workers []string, key ssh.Signer, command string) []error {
+func runCommandOnMachines(workers []string, key ssh.Signer, command string) []error {
 	var errors []error
 	for _, worker := range workers {
 		clientConfig := &ssh.ClientConfig{

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -12,6 +12,8 @@
 package processes
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -47,11 +49,11 @@ func (p *WorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
-	arguments := "process start worker"
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, WorkerProcess{}.Name}, "")
 	return runCommand(addStartFlags(arguments, cmd), "worker")
 }
 
 func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
-	arguments := "process stop worker"
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, WorkerProcess{}.Name}, "")
 	return runCommand(addStopFlags(arguments, cmd), "worker")
 }

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -12,20 +12,12 @@
 package processes
 
 import (
-	"bufio"
-	"fmt"
-	"io"
-	"os"
 	"path"
-	"strings"
-	"time"
-
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"golang.org/x/crypto/ssh"
 
 	"alluxio.org/cli/env"
 	"alluxio.org/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var Workers = &WorkersProcess{
@@ -81,7 +73,7 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 	command := cliPath + " " + arguments
 
-	errors := runCommandOnMachines(workers, key, command)
+	errors := runCommands(workers, key, command)
 
 	if len(errors) == 0 {
 		log.Logger.Infof("Run command %s successful on workers: %s", command, workers)
@@ -110,7 +102,7 @@ func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	arguments := "process stop worker"
 	command := cliPath + " " + arguments
 
-	errors := runCommandOnMachines(workers, key, command)
+	errors := runCommands(workers, key, command)
 
 	if len(errors) == 0 {
 		log.Logger.Infof("Run command %s on workers: %s", command, workers)
@@ -118,114 +110,4 @@ func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 		log.Logger.Fatalf("Run command %s failed: %s", command, err)
 	}
 	return nil
-}
-
-func getWorkers() ([]string, error) {
-	workersDir := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "workers")
-	workersFile, err := os.Open(workersDir)
-	if err != nil {
-		log.Logger.Errorf("Error reading worker hostnames at %s", workersDir)
-		return nil, err
-	}
-
-	workersReader := bufio.NewReader(workersFile)
-	var workersList []string
-	lastLine := false
-	for !lastLine {
-		// read lines of the workers file
-		line, err := workersReader.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				lastLine = true
-			} else {
-				log.Logger.Errorf("Error parsing worker file at this line: %s", line)
-				return nil, err
-			}
-		}
-		// remove notes
-		if strings.Index(line, "#") != -1 {
-			line = line[:strings.Index(line, "#")]
-		}
-		line = strings.TrimSpace(line)
-		if line != "" {
-			workersList = append(workersList, line)
-		}
-	}
-	return workersList, nil
-}
-
-func getPrivateKey() (ssh.Signer, error) {
-	homePath, err := os.UserHomeDir()
-	if err != nil {
-		log.Logger.Errorf("User home directory not found at %s", homePath)
-		return nil, err
-	}
-	privateKey, err := os.ReadFile(path.Join(homePath, ".ssh", "id_rsa"))
-	if err != nil {
-		log.Logger.Errorf("Private key file not found at %s", path.Join(homePath, ".ssh", "id_rsa"))
-		return nil, err
-	}
-	parsedPrivateKey, err := ssh.ParsePrivateKey(privateKey)
-	if err != nil {
-		log.Logger.Errorf("Cannot parse public key at %s", path.Join(homePath, ".ssh", "id_rsa"))
-		return nil, err
-	}
-	return parsedPrivateKey, nil
-}
-
-func runCommandOnMachines(workers []string, key ssh.Signer, command string) []error {
-	var errors []error
-	for _, worker := range workers {
-		clientConfig := &ssh.ClientConfig{
-			// TODO: how to get user name? Like ${USER} in alluxio-common.sh
-			User: "root",
-			Auth: []ssh.AuthMethod{
-				ssh.PublicKeys(key),
-			},
-			Timeout:         5 * time.Second,
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		}
-		// TODO: Some machines might have changed default SSH port. Get ssh port or remind users when get started.
-		dialAddr := fmt.Sprintf("%s:%d", worker, 22)
-		conn, err := ssh.Dial("tcp", dialAddr, clientConfig)
-		defer func(conn *ssh.Client) {
-			err := conn.Close()
-			if err != nil {
-				log.Logger.Infof("Connection to %s closed. Error: %s", dialAddr, err)
-			} else {
-				log.Logger.Infof("Connection to %s closed.", dialAddr)
-			}
-		}(conn)
-
-		if err != nil {
-			log.Logger.Errorf("Dial failed to %s, error: %s", dialAddr, err)
-			errors = append(errors, err)
-		}
-
-		// create a session for each worker
-		session, err := conn.NewSession()
-		if err != nil {
-			log.Logger.Errorf("Cannot create session at %s", dialAddr)
-			errors = append(errors, err)
-		}
-		defer func(session *ssh.Session) {
-			err := session.Close()
-			if err != nil && err != io.EOF {
-				log.Logger.Infof("Session at %s closed. Error: %s", dialAddr, err)
-			} else {
-				log.Logger.Infof("Session at %s closed.", dialAddr)
-			}
-		}(session)
-
-		session.Stdout = os.Stdout
-		session.Stderr = os.Stderr
-
-		// run session
-		err = session.Run(command)
-		if err != nil {
-			log.Logger.Errorf("Run command %s failed at %s", command, dialAddr)
-			errors = append(errors, err)
-		}
-	}
-	return errors
 }

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -112,16 +112,21 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	// 3. for each worker, create a client
+	// TODO: now start worker one by one, need to do them in parallel
 	for _, worker := range workersList {
 		clientConfig := &ssh.ClientConfig{
+			// TODO: how to get user name? Like ${USER} in alluxio-common.sh
 			User: "root",
+			// TODO: if configure nothing, can use none as the authentication method, suggest use public key
 			Auth: []ssh.AuthMethod{
 				ssh.PublicKeys(parsedPrivateKey),
 			},
 			Timeout:         5 * time.Second,
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		}
+		// TODO: get ssh port if needed (some machines might have changed default port)
 		dialAddr := fmt.Sprintf("%s:%d", worker, 22)
+		// TODO: error to resolve: handshake error, authentication failed
 		sshClient, err := ssh.Dial("tcp", dialAddr, clientConfig)
 		if err != nil {
 			log.Logger.Fatalf("Dial failed to %s, error: %s", dialAddr, err)
@@ -144,7 +149,7 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 		session.Stderr = os.Stderr
 
 		// 5. run session
-		command := "${ALLUXIO_HOME}/bin/cli.sh process start workers"
+		command := "${ALLUXIO_HOME}/bin/cli.sh process start worker"
 		err = session.Run(command)
 		if err != nil {
 			log.Logger.Fatalf("Run command %s failed at %s", command, dialAddr)

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -1,0 +1,16 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package processes
+
+// find all workers
+// for each worker, create SSH session and run './bin/cli.sh process start worker'
+// output pid and logs

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -11,6 +11,50 @@
 
 package processes
 
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"alluxio.org/cli/env"
+)
+
 // find all workers
 // for each worker, create SSH session and run './bin/cli.sh process start worker'
 // output pid and logs
+
+var Workers = &WorkersProcess{}
+
+// parameters
+const ()
+
+var ()
+
+type WorkersProcess struct {
+	*env.BaseProcess
+}
+
+func (p *WorkersProcess) SetEnvVars(viper *viper.Viper) {
+	return
+}
+
+func (p *WorkersProcess) Base() *env.BaseProcess {
+	return p.BaseProcess
+}
+
+func (p *WorkersProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Use = p.Name
+	return cmd
+}
+
+func (p *WorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Use = p.Name
+	return cmd
+}
+
+func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
+	return nil
+}
+
+func (p *WorkersProcess) Stop(command *env.StopProcessCommand) error {
+	return nil
+}

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -63,7 +63,7 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process start worker"
 	if cmd.AsyncStart {
 		arguments = arguments + " -a"
@@ -114,8 +114,11 @@ func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "cli.sh")
+	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process stop worker"
+	if cmd.SoftKill {
+		arguments = arguments + " -s"
+	}
 	command := cliPath + " " + arguments
 
 	// for each worker, create a client and run

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -49,11 +49,11 @@ func (p *WorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
-	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, WorkerProcess{}.Name}, "")
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, WorkerProcess{}.Name}, " ")
 	return runCommand(addStartFlags(arguments, cmd), "worker")
 }
 
 func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
-	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, WorkerProcess{}.Name}, "")
+	arguments := strings.Join([]string{env.Service{}.Name, cmd.Name, WorkerProcess{}.Name}, " ")
 	return runCommand(addStopFlags(arguments, cmd), "worker")
 }

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -149,11 +149,15 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 		session.Stderr = os.Stderr
 
 		// 5. run session
-		command := "${ALLUXIO_HOME}/bin/cli.sh process start worker"
+		command := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio-start.sh") + " worker"
+		failed := false
 		err = session.Run(command)
 		if err != nil {
-			log.Logger.Fatalf("Run command %s failed at %s", command, dialAddr)
-			return err
+			log.Logger.Errorf("Run command %s failed at %s", command, dialAddr)
+			failed = true
+		}
+		if failed {
+			log.Logger.Fatalf("Run command %s failed. See previous error messages.", command)
 		}
 		return nil
 	}

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -12,8 +12,6 @@
 package processes
 
 import (
-	"path"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -51,7 +49,7 @@ func (p *WorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	// get list of all workers, stored at workersList
-	workers, err := getWorkers()
+	workers, err := getNodes(false)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get workers, error: %s", err)
 	}
@@ -63,7 +61,6 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process start worker"
 	if cmd.AsyncStart {
 		arguments = arguments + " -a"
@@ -100,7 +97,7 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 
 func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	// get list of all workers, stored at workersList
-	workers, err := getWorkers()
+	workers, err := getNodes(false)
 	if err != nil {
 		log.Logger.Fatalf("Cannot get workers, error: %s", err)
 	}
@@ -112,7 +109,6 @@ func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	}
 
 	// generate command
-	cliPath := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), "bin", "alluxio")
 	arguments := "process stop worker"
 	if cmd.SoftKill {
 		arguments = arguments + " -s"

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -48,10 +48,10 @@ func (p *WorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	arguments := "process start worker"
-	return runCommand(addStartFlags(arguments, cmd), false, true)
+	return runCommand(addStartFlags(arguments, cmd), "worker")
 }
 
 func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	arguments := "process stop worker"
-	return runCommand(addStopFlags(arguments, cmd), false, true)
+	return runCommand(addStopFlags(arguments, cmd), "worker")
 }

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -28,18 +28,11 @@ import (
 	"alluxio.org/log"
 )
 
-// find all workers
-// for each worker, create SSH session and run './bin/cli.sh process start worker'
-// output pid and logs
-
 var Workers = &WorkersProcess{
 	BaseProcess: &env.BaseProcess{
 		Name: "workers",
 	},
 }
-
-// parameters
-const ()
 
 type WorkersProcess struct {
 	*env.BaseProcess
@@ -95,7 +88,6 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 	} else {
 		log.Logger.Fatalf("Run command %s failed: %s", command, err)
 	}
-
 	return nil
 }
 
@@ -125,7 +117,6 @@ func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 	} else {
 		log.Logger.Fatalf("Run command %s failed: %s", command, err)
 	}
-
 	return nil
 }
 

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -82,11 +82,11 @@ func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(conn, command)
+		err = runCommand(worker, conn, command)
 		if err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(conn)
+		err = closeConnection(worker, conn)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -130,11 +130,11 @@ func (p *WorkersProcess) Stop(cmd *env.StopProcessCommand) error {
 			errors = append(errors, err)
 			continue
 		}
-		err = runCommand(conn, command)
+		err = runCommand(worker, conn, command)
 		if err != nil {
 			errors = append(errors, err)
 		}
-		err = closeConnection(conn)
+		err = closeConnection(worker, conn)
 		if err != nil {
 			errors = append(errors, err)
 		}

--- a/cli/src/alluxio.org/cli/processes/workers.go
+++ b/cli/src/alluxio.org/cli/processes/workers.go
@@ -12,28 +12,40 @@
 package processes
 
 import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/crypto/ssh"
 
 	"alluxio.org/cli/env"
+	"alluxio.org/log"
 )
 
 // find all workers
 // for each worker, create SSH session and run './bin/cli.sh process start worker'
 // output pid and logs
 
-var Workers = &WorkersProcess{}
+var Workers = &WorkersProcess{
+	BaseProcess: &env.BaseProcess{
+		Name: "workers",
+	},
+}
 
 // parameters
 const ()
-
-var ()
 
 type WorkersProcess struct {
 	*env.BaseProcess
 }
 
-func (p *WorkersProcess) SetEnvVars(viper *viper.Viper) {
+func (p *WorkersProcess) SetEnvVars(envVar *viper.Viper) {
 	return
 }
 
@@ -52,6 +64,95 @@ func (p *WorkersProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *WorkersProcess) Start(cmd *env.StartProcessCommand) error {
+	// 1. get list of all workers, stored at workersList
+	workersDir := path.Join(env.Env.EnvVar.GetString(env.ConfAlluxioConfDir.EnvVar), "workers")
+	workers, err := os.Open(workersDir)
+	if err != nil {
+		log.Logger.Fatalf("Error reading worker hostnames at %s", workersDir)
+		return err
+	}
+
+	workersReader := bufio.NewReader(workers)
+	var workersList []string
+	for {
+		// read lines of the workers file
+		line, err := workersReader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				log.Logger.Fatalf("Error parsing worker file at this line: %s", line)
+			}
+		}
+		// remove notes
+		if strings.Index(line, "#") != -1 {
+			line = line[:strings.Index(line, "#")]
+		}
+		line = strings.TrimSpace(line)
+		if line != "" {
+			workersList = append(workersList, line)
+		}
+	}
+
+	// 2. get public key for passwordless ssh
+	homePath, err := os.UserHomeDir()
+	if err != nil {
+		log.Logger.Fatalf("User home directory not found at %s", homePath)
+		return err
+	}
+	privateKey, err := os.ReadFile(path.Join(homePath, ".ssh", "id_rsa"))
+	if err != nil {
+		log.Logger.Fatalf("Private key file not found at %s", path.Join(homePath, ".ssh", "id_rsa"))
+		return err
+	}
+	parsedPrivateKey, err := ssh.ParsePrivateKey(privateKey)
+	if err != nil {
+		log.Logger.Fatalf("Cannot parse public key at %s", path.Join(homePath, ".ssh", "id_rsa"))
+		return err
+	}
+
+	// 3. for each worker, create a client
+	for _, worker := range workersList {
+		clientConfig := &ssh.ClientConfig{
+			User: "root",
+			Auth: []ssh.AuthMethod{
+				ssh.PublicKeys(parsedPrivateKey),
+			},
+			Timeout:         5 * time.Second,
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+		dialAddr := fmt.Sprintf("%s:%d", worker, 22)
+		sshClient, err := ssh.Dial("tcp", dialAddr, clientConfig)
+		if err != nil {
+			log.Logger.Fatalf("Dial failed to %s, error: %s", dialAddr, err)
+			return err
+		}
+
+		// 4. create a session for each worker
+		session, err := sshClient.NewSession()
+		if err != nil {
+			log.Logger.Fatalf("Cannot create session at %s", dialAddr)
+			return err
+		}
+		defer func(session *ssh.Session) {
+			err := session.Close()
+			if err != nil {
+				log.Logger.Fatalf("Session closed with error: %s", err)
+			}
+		}(session)
+		session.Stdout = os.Stdout
+		session.Stderr = os.Stderr
+
+		// 5. run session
+		command := "${ALLUXIO_HOME}/bin/cli.sh process start workers"
+		err = session.Run(command)
+		if err != nil {
+			log.Logger.Fatalf("Run command %s failed at %s", command, dialAddr)
+			return err
+		}
+		return nil
+	}
+
 	return nil
 }
 

--- a/cli/src/alluxio.org/go.mod
+++ b/cli/src/alluxio.org/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
+	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 )
 
 require (

--- a/cli/src/alluxio.org/go.sum
+++ b/cli/src/alluxio.org/go.sum
@@ -205,6 +205,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -328,6 +330,7 @@ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Add `process` commands with multiple nodes to golang CLI as part of https://github.com/Alluxio/alluxio/issues/17522

`bin/alluxio-start.sh masters` -> `bin/cli.sh process start masters`
`bin/alluxio-start.sh job_masters` -> `bin/cli.sh process start job_masters`
`bin/alluxio-start.sh workers` -> `bin/cli.sh process start workers`
`bin/alluxio-start.sh job_workers` -> `bin/cli.sh process start job_workers`
`bin/alluxio-start.sh proxies` -> `bin/cli.sh process start proxies`
`bin/alluxio-start.sh all` -> `bin/cli.sh process start all`
`bin/alluxio-start.sh local` -> `bin/cli.sh process start local`

`bin/alluxio-stop.sh masters` -> `bin/cli.sh process stop masters`
`bin/alluxio-stop.sh job_masters` -> `bin/cli.sh process stop job_masters`
`bin/alluxio-stop.sh workers` -> `bin/cli.sh process stop workers`
`bin/alluxio-stop.sh job_workers` -> `bin/cli.sh process stop job_workers`
`bin/alluxio-stop.sh proxies` -> `bin/cli.sh process stop proxies`
`bin/alluxio-stop.sh all` -> `bin/cli.sh process stop all`
`bin/alluxio-stop.sh local` -> `bin/cli.sh process stop local`

For command `process start/stop` on multiple nodes, using crypto's `ssh` package to create an SSH session, connect to masters, workers or all nodes, then send according subcommand on single nodes to these nodes.