### PR TITLE
Sort sections in pom files

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -1,4 +1,4 @@
-name: Checkstyle, Findbugs, Doc Check, etc.
+name: Checkstyle, Findbugs, Doc Check, SortPom, etc.
 
 on: [pull_request]
 
@@ -29,7 +29,7 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
 
-      - name: Execute license check, checkstyle, findbugs
+      - name: Execute license check, checkstyle, findbugs, sortpom
         run: |
           mkdir -p ~/.m2
           ALLUXIO_DOCKER_NO_TTY=true \

--- a/assembly/client/pom.xml
+++ b/assembly/client/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-assembly</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-assembly</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
   <artifactId>alluxio-assembly-client</artifactId>
@@ -66,16 +67,16 @@
         <executions>
           <execution>
             <id>uber-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
               </transformers>
               <artifactSet>
                 <excludes>
@@ -85,7 +86,7 @@
               </artifactSet>
               <filters>
                 <filter>
-                  <artifact>*:* </artifact>
+                  <artifact>*:*</artifact>
                   <excludes>
                     <exclude>LICENSE</exclude>
                     <exclude>META-INF/*.SF</exclude>

--- a/assembly/client/pom.xml
+++ b/assembly/client/pom.xml
@@ -31,7 +31,6 @@
   </properties>
 
   <dependencies>
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -22,15 +23,15 @@
   <name>Alluxio Assembly</name>
   <description>Assembly JARs of Alluxio system</description>
 
-  <modules>
-    <module>client</module>
-    <module>server</module>
-  </modules>
-
   <properties>
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.basedir}/build</build.path>
     <failIfNoTests>false</failIfNoTests>
   </properties>
+
+  <modules>
+    <module>client</module>
+    <module>server</module>
+  </modules>
 </project>

--- a/assembly/server/pom.xml
+++ b/assembly/server/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-assembly</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-assembly</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
   <artifactId>alluxio-assembly-server</artifactId>
@@ -66,16 +67,16 @@
         <executions>
           <execution>
             <id>uber-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
               </transformers>
               <artifactSet>
                 <excludes>
@@ -85,7 +86,7 @@
               </artifactSet>
               <filters>
                 <filter>
-                  <artifact>*:* </artifact>
+                  <artifact>*:*</artifact>
                   <excludes>
                     <exclude>LICENSE</exclude>
                     <exclude>META-INF/*.SF</exclude>

--- a/assembly/server/pom.xml
+++ b/assembly/server/pom.xml
@@ -31,7 +31,6 @@
   </properties>
 
   <dependencies>
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-server-master</artifactId>

--- a/build/sortpom/alluxio_pom.xml
+++ b/build/sortpom/alluxio_pom.xml
@@ -1,0 +1,660 @@
+<!--
+
+  The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+  (the "License"). You may not use this work except in compliance with the License, which is
+  available at www.apache.org/licenses/LICENSE-2.0
+
+  This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  either express or implied, as more fully set forth in the License.
+
+  See the NOTICE file distributed with this work for information regarding copyright ownership.
+
+-->
+
+<!--
+  This is a template file used by the sortpom maven plugin as a reference to validate and sort sections in pom files.
+-->
+<project
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion />
+    <parent>
+        <groupId />
+        <artifactId />
+        <version />
+        <relativePath />
+    </parent>
+    <groupId />
+    <artifactId />
+    <version />
+    <packaging />
+    <name />
+    <description />
+    <url />
+    <inceptionYear />
+    <licenses>
+
+        <license>
+            <name />
+            <url />
+            <distribution />
+            <comments />
+        </license>
+    </licenses>
+
+    <prerequisites>
+        <maven />
+    </prerequisites>
+
+    <scm>
+        <connection />
+        <developerConnection />
+        <tag />
+        <url />
+    </scm>
+    <issueManagement>
+        <system />
+        <url />
+    </issueManagement>
+    <ciManagement>
+        <system />
+        <url />
+        <notifiers>
+            <notifier>
+                <type />
+                <address />
+                <sendOnError />
+                <sendOnFailure />
+                <sendOnSuccess />
+                <sendOnWarning />
+                <configuration />
+            </notifier>
+        </notifiers>
+    </ciManagement>
+    <organization>
+        <name />
+        <url />
+    </organization>
+    <developers>
+        <developer>
+            <id />
+            <name />
+            <email />
+            <url />
+            <organization />
+            <organizationUrl />
+            <roles>
+                <role />
+            </roles>
+            <timezone />
+            <properties />
+        </developer>
+    </developers>
+    <contributors>
+        <contributor>
+            <name />
+            <email />
+            <url />
+            <organization />
+            <organizationUrl />
+            <roles>
+                <role />
+            </roles>
+            <timezone />
+            <properties />
+        </contributor>
+    </contributors>
+    <mailingLists>
+        <mailingList>
+            <name />
+            <subscribe />
+            <unsubscribe />
+            <post />
+            <archive />
+            <otherArchives>
+                <otherArchive />
+            </otherArchives>
+        </mailingList>
+    </mailingLists>
+    <distributionManagement>
+        <repository>
+            <uniqueVersion />
+            <id />
+            <name />
+            <url />
+            <layout />
+        </repository>
+        <snapshotRepository>
+            <uniqueVersion />
+            <id />
+            <name />
+            <url />
+            <layout />
+        </snapshotRepository>
+        <site>
+            <id />
+            <name />
+            <url />
+        </site>
+        <relocation>
+            <groupId />
+            <artifactId />
+            <version />
+            <message />
+        </relocation>
+        <downloadUrl />
+        <status />
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <releases>
+                <enabled />
+                <updatePolicy />
+                <checksumPolicy />
+            </releases>
+            <snapshots>
+                <enabled />
+                <updatePolicy />
+                <checksumPolicy />
+            </snapshots>
+            <id />
+            <name />
+            <url />
+            <layout />
+        </repository>
+    </repositories>
+
+    <properties />
+
+    <modules>
+        <module />
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId />
+                <artifactId />
+                <version />
+                <classifier />
+                <type />
+                <scope />
+                <systemPath />
+                <optional />
+                <exclusions>
+                    <exclusion>
+                        <groupId />
+                        <artifactId />
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId />
+            <artifactId />
+            <version />
+            <classifier />
+            <type />
+            <scope />
+            <systemPath />
+            <optional />
+            <exclusions>
+                <exclusion>
+                    <groupId />
+                    <artifactId />
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <releases>
+                <enabled />
+                <updatePolicy />
+                <checksumPolicy />
+            </releases>
+            <snapshots>
+                <enabled />
+                <updatePolicy />
+                <checksumPolicy />
+            </snapshots>
+            <id />
+            <name />
+            <url />
+            <layout />
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <defaultGoal />
+        <directory />
+        <finalName />
+        <filters>
+            <filter />
+        </filters>
+        <resources>
+            <resource>
+                <targetPath />
+                <filtering />
+                <directory />
+                <includes>
+                    <include />
+                </includes>
+                <excludes>
+                    <exclude />
+                </excludes>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <targetPath />
+                <filtering />
+                <directory />
+                <includes>
+                    <include />
+                </includes>
+                <excludes>
+                    <exclude />
+                </excludes>
+            </testResource>
+        </testResources>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId />
+                    <artifactId />
+                    <version />
+                    <extensions />
+                    <goals />
+                    <inherited />
+                    <configuration />
+                    <dependencies>
+                        <dependency>
+                            <groupId />
+                            <artifactId />
+                            <version />
+                            <classifier />
+                            <type />
+                            <scope />
+                            <systemPath />
+                            <optional />
+                            <exclusions>
+                                <exclusion>
+                                    <groupId />
+                                    <artifactId />
+                                </exclusion>
+                            </exclusions>
+                        </dependency>
+                    </dependencies>
+                    <executions>
+                        <execution>
+                            <id />
+                            <goals>
+                                <goal />
+                            </goals>
+                            <phase />
+                            <inherited />
+                            <configuration />
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId />
+                <artifactId />
+                <version />
+                <extensions />
+                <goals />
+                <inherited />
+                <configuration />
+                <dependencies>
+                    <dependency>
+                        <groupId />
+                        <artifactId />
+                        <version />
+                        <classifier />
+                        <type />
+                        <scope />
+                        <systemPath />
+                        <optional />
+                        <exclusions>
+                            <exclusion>
+                                <groupId />
+                                <artifactId />
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id />
+                        <goals>
+                            <goal />
+                        </goals>
+                        <phase />
+                        <inherited />
+                        <configuration />
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <sourceDirectory />
+        <scriptSourceDirectory />
+        <testSourceDirectory />
+        <outputDirectory />
+        <testOutputDirectory />
+        <extensions>
+            <extension>
+                <groupId />
+                <artifactId />
+                <version />
+            </extension>
+        </extensions>
+    </build>
+
+    <reporting>
+        <outputDirectory />
+        <excludeDefaults />
+        <plugins>
+            <plugin>
+                <groupId />
+                <artifactId />
+                <version />
+                <inherited />
+                <configuration />
+                <reportSets>
+                    <reportSet>
+                        <id />
+                        <reports>
+                            <report />
+                        </reports>
+                        <inherited />
+                        <configuration />
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
+
+    <reports />
+
+    <profiles>
+        <profile>
+            <id />
+            <activation>
+                <activeByDefault />
+                <jdk />
+                <os>
+                    <name />
+                    <family />
+                    <arch />
+                    <version />
+                </os>
+                <property>
+                    <name />
+                    <value />
+                </property>
+                <file>
+                    <exists />
+                    <missing />
+                </file>
+            </activation>
+            <modules>
+                <module />
+            </modules>
+            <distributionManagement>
+                <repository>
+                    <uniqueVersion />
+                    <id />
+                    <name />
+                    <url />
+                    <layout />
+                </repository>
+                <snapshotRepository>
+                    <uniqueVersion />
+                    <id />
+                    <name />
+                    <url />
+                    <layout />
+                </snapshotRepository>
+                <site>
+                    <id />
+                    <name />
+                    <url />
+                </site>
+                <relocation>
+                    <groupId />
+                    <artifactId />
+                    <version />
+                    <message />
+                </relocation>
+                <downloadUrl />
+                <status />
+            </distributionManagement>
+            <properties />
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId />
+                        <artifactId />
+                        <version />
+                        <classifier />
+                        <type />
+                        <scope />
+                        <systemPath />
+                        <optional />
+                        <exclusions>
+                            <exclusion>
+                                <groupId />
+                                <artifactId />
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            <dependencies>
+                <dependency>
+                    <groupId />
+                    <artifactId />
+                    <version />
+                    <classifier />
+                    <type />
+                    <scope />
+                    <systemPath />
+                    <optional />
+                    <exclusions>
+                        <exclusion>
+                            <groupId />
+                            <artifactId />
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+            <repositories>
+                <repository>
+                    <releases>
+                        <enabled />
+                        <updatePolicy />
+                        <checksumPolicy />
+                    </releases>
+                    <snapshots>
+                        <enabled />
+                        <updatePolicy />
+                        <checksumPolicy />
+                    </snapshots>
+                    <id />
+                    <name />
+                    <url />
+                    <layout />
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <releases>
+                        <enabled />
+                        <updatePolicy />
+                        <checksumPolicy />
+                    </releases>
+                    <snapshots>
+                        <enabled />
+                        <updatePolicy />
+                        <checksumPolicy />
+                    </snapshots>
+                    <id />
+                    <name />
+                    <url />
+                    <layout />
+                </pluginRepository>
+            </pluginRepositories>
+            <build>
+                <defaultGoal />
+                <directory />
+                <finalName />
+                <filters>
+                    <filter />
+                </filters>
+                <resources>
+                    <resource>
+                        <targetPath />
+                        <filtering />
+                        <directory />
+                        <includes>
+                            <include />
+                        </includes>
+                        <excludes>
+                            <exclude />
+                        </excludes>
+                    </resource>
+                </resources>
+                <testResources>
+                    <testResource>
+                        <targetPath />
+                        <filtering />
+                        <directory />
+                        <includes>
+                            <include />
+                        </includes>
+                        <excludes>
+                            <exclude />
+                        </excludes>
+                    </testResource>
+                </testResources>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId />
+                            <artifactId />
+                            <version />
+                            <extensions />
+                            <goals />
+                            <inherited />
+                            <configuration />
+                            <dependencies>
+                                <dependency>
+                                    <groupId />
+                                    <artifactId />
+                                    <version />
+                                    <classifier />
+                                    <type />
+                                    <scope />
+                                    <systemPath />
+                                    <optional />
+                                    <exclusions>
+                                        <exclusion>
+                                            <groupId />
+                                            <artifactId />
+                                        </exclusion>
+                                    </exclusions>
+                                </dependency>
+                            </dependencies>
+                            <executions>
+                                <execution>
+                                    <id />
+                                    <goals>
+                                        <goal />
+                                    </goals>
+                                    <phase />
+                                    <inherited />
+                                    <configuration />
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId />
+                        <artifactId />
+                        <version />
+                        <extensions />
+                        <goals />
+                        <inherited />
+                        <configuration />
+                        <dependencies>
+                            <dependency>
+                                <groupId />
+                                <artifactId />
+                                <version />
+                                <classifier />
+                                <type />
+                                <scope />
+                                <systemPath />
+                                <optional />
+                                <exclusions>
+                                    <exclusion>
+                                        <groupId />
+                                        <artifactId />
+                                    </exclusion>
+                                </exclusions>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id />
+                                <goals>
+                                    <goal />
+                                </goals>
+                                <phase />
+                                <inherited />
+                                <configuration />
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <outputDirectory />
+                <excludeDefaults />
+                <plugins>
+                    <plugin>
+                        <groupId />
+                        <artifactId />
+                        <version />
+                        <inherited />
+                        <configuration />
+                        <reportSets>
+                            <reportSet>
+                                <id />
+                                <reports>
+                                    <report />
+                                </reports>
+                                <inherited />
+                                <configuration />
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                </plugins>
+            </reporting>
+            <reports />
+        </profile>
+    </profiles>
+</project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -22,13 +23,13 @@
   <name>Alluxio Common</name>
   <description>Parent POM for Alluxio common</description>
 
-  <modules>
-    <module>transport</module>
-  </modules>
-
   <properties>
     <!-- These need to be defined here as well as in the parent pom so that mvn can run
          properly from sub-project directories -->
     <build.path>${project.parent.basedir}/build</build.path>
   </properties>
+
+  <modules>
+    <module>transport</module>
+  </modules>
 </project>

--- a/common/transport/pom.xml
+++ b/common/transport/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -56,62 +57,7 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>generate</id>
-      <properties>
-        <skip.protoc>false</skip.protoc>
-      </properties>
-      <build>
-        <plugins>
-          <!-- Cleans the generated java files, prior to regenerating them from the proto/grpc definitions.  -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-clean-plugin</artifactId>
-            <configuration>
-              <filesets>
-                <fileset>
-                  <directory>src/main/java/alluxio/proto</directory>
-                  <followSymlinks>false</followSymlinks>
-                  <includes>
-                    <include>**/*.java</include>
-                  </includes>
-                </fileset>
-                <fileset>
-                  <directory>src/main/java/alluxio/grpc</directory>
-                  <followSymlinks>false</followSymlinks>
-                  <includes>
-                    <include>**/*.java</include>
-                  </includes>
-                </fileset>
-              </filesets>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>java11</id>
-      <activation>
-        <jdk>11</jdk>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
-
   <build>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2</version>
-      </extension>
-    </extensions>
     <plugins>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
@@ -176,5 +122,60 @@
         </configuration>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.6.2</version>
+      </extension>
+    </extensions>
   </build>
+
+  <profiles>
+    <profile>
+      <id>generate</id>
+      <properties>
+        <skip.protoc>false</skip.protoc>
+      </properties>
+      <build>
+        <plugins>
+          <!-- Cleans the generated java files, prior to regenerating them from the proto/grpc definitions.  -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>src/main/java/alluxio/proto</directory>
+                  <followSymlinks>false</followSymlinks>
+                  <includes>
+                    <include>**/*.java</include>
+                  </includes>
+                </fileset>
+                <fileset>
+                  <directory>src/main/java/alluxio/grpc</directory>
+                  <followSymlinks>false</followSymlinks>
+                  <includes>
+                    <include>**/*.java</include>
+                  </includes>
+                </fileset>
+              </filesets>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>java11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/common/transport/pom.xml
+++ b/common/transport/pom.xml
@@ -34,7 +34,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/dora/core/client/fs/pom.xml
+++ b/dora/core/client/fs/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -75,10 +76,6 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.rocksdb</groupId>
-      <artifactId>rocksdbjni</artifactId>
-    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>
@@ -90,6 +87,10 @@
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-transport</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.rocksdb</groupId>
+      <artifactId>rocksdbjni</artifactId>
     </dependency>
 
     <!-- Internal test dependencies -->

--- a/dora/core/client/fs/pom.xml
+++ b/dora/core/client/fs/pom.xml
@@ -31,7 +31,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.github.stateless4j</groupId>
       <artifactId>stateless4j</artifactId>
@@ -76,8 +75,6 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -93,7 +90,6 @@
       <artifactId>rocksdbjni</artifactId>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/core/client/hdfs/pom.xml
+++ b/dora/core/client/hdfs/pom.xml
@@ -31,13 +31,10 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>
@@ -58,7 +55,6 @@
       <artifactId>hadoop-client</artifactId>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/core/client/hdfs/pom.xml
+++ b/dora/core/client/hdfs/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -35,10 +36,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>
@@ -56,6 +53,10 @@
       <artifactId>alluxio-core-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+    </dependency>
 
     <!-- Internal test dependencies -->
     <dependency>
@@ -66,6 +67,23 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Export test classes in a test-jar so that other projects can use them for testing -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>
@@ -86,21 +104,4 @@
       </build>
     </profile>
   </profiles>
-
-  <build>
-    <plugins>
-      <!-- Export test classes in a test-jar so that other projects can use them for testing -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/dora/core/client/hdfs3/pom.xml
+++ b/dora/core/client/hdfs3/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0

--- a/dora/core/client/hdfs3/pom.xml
+++ b/dora/core/client/hdfs3/pom.xml
@@ -31,7 +31,6 @@
   </properties>
 
   <dependencies>
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-hdfs</artifactId>

--- a/dora/core/client/pom.xml
+++ b/dora/core/client/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-core</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-core</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
   <artifactId>alluxio-core-client</artifactId>
@@ -22,16 +23,16 @@
   <name>Alluxio Core - Client</name>
   <description>Alluxio Core Clients</description>
 
-  <modules>
-    <module>fs</module>
-    <module>hdfs</module>
-    <module>hdfs3</module>
-  </modules>
-
   <properties>
     <!-- These need to be defined here as well as in the parent pom so that mvn can run
          properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.basedir}/build</build.path>
   </properties>
+
+  <modules>
+    <module>fs</module>
+    <module>hdfs</module>
+    <module>hdfs3</module>
+  </modules>
 
 </project>

--- a/dora/core/common/pom.xml
+++ b/dora/core/common/pom.xml
@@ -31,7 +31,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
@@ -113,8 +112,6 @@
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-transport</artifactId>
@@ -153,7 +150,6 @@
       <artifactId>rocksdbjni</artifactId>
     </dependency>
 
-    <!-- External test dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>

--- a/dora/core/common/pom.xml
+++ b/dora/core/common/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -40,24 +41,12 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.github.ben-manes.caffeine</groupId>
-      <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -70,6 +59,14 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
@@ -107,17 +104,29 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
     </dependency>
+    <!-- Determine version with the table here: https://github.com/grpc/grpc-java/blob/master/SECURITY.md-->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>
+
+    <!-- Internal dependencies -->
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-transport</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
@@ -126,6 +135,10 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
@@ -139,18 +152,6 @@
       <groupId>org.rocksdb</groupId>
       <artifactId>rocksdbjni</artifactId>
     </dependency>
-    <!-- Determine version with the table here: https://github.com/grpc/grpc-java/blob/master/SECURITY.md-->
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-    </dependency>
-
-    <!-- Internal dependencies -->
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-transport</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <!-- External test dependencies -->
     <dependency>
@@ -159,15 +160,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
       <version>${netty.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -180,8 +181,8 @@
   <build>
     <resources>
       <resource>
-        <directory>src/main/resources</directory>
         <filtering>true</filtering>
+        <directory>src/main/resources</directory>
       </resource>
     </resources>
     <plugins>
@@ -200,29 +201,29 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>initialize</phase>
-            <goals>
-              <goal>create-metadata</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <outputDirectory>${project.build.directory}/generated/build-metadata</outputDirectory>
           <outputName>build.properties</outputName>
           <revisionPropertyName>git.revision</revisionPropertyName>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>create-metadata</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
         <executions>
           <execution>
-            <phase>initialize</phase>
             <goals>
               <goal>read-project-properties</goal>
             </goals>
+            <phase>initialize</phase>
             <configuration>
               <files>
                 <file>${project.build.directory}/generated/build-metadata/build.properties</file>
@@ -242,8 +243,7 @@
             </goals>
             <configuration>
               <sourceDirectory>src/main/java-templates</sourceDirectory>
-              <outputDirectory>${project.build.directory}/generated-sources/java-templates
-              </outputDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources/java-templates</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/dora/core/pom.xml
+++ b/dora/core/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -22,15 +23,15 @@
   <name>Alluxio Core</name>
   <description>Parent POM for Alluxio core</description>
 
-  <modules>
-    <module>client</module>
-    <module>common</module>
-    <module>server</module>
-  </modules>
-
   <properties>
     <!-- These need to be defined here as well as in the parent pom so that mvn can run
          properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
   </properties>
+
+  <modules>
+    <module>client</module>
+    <module>common</module>
+    <module>server</module>
+  </modules>
 </project>

--- a/dora/core/server/common/pom.xml
+++ b/dora/core/server/common/pom.xml
@@ -30,7 +30,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo</artifactId>
@@ -98,8 +97,6 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -157,7 +154,6 @@
       <scope>runtime</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -165,8 +161,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-
-    <!-- Test dependencies -->
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>

--- a/dora/core/server/common/pom.xml
+++ b/dora/core/server/common/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-core-server</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-core-server</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
   <artifactId>alluxio-core-server-common</artifactId>
@@ -35,19 +36,6 @@
       <artifactId>kryo</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.ratis</groupId>
-      <artifactId>ratis-server</artifactId>
-    </dependency>
-    <dependency>
-      <artifactId>ratis-grpc</artifactId>
-      <groupId>org.apache.ratis</groupId>
-    </dependency>
-    <!-- TODO(lu) remove catalyst dependency which used for serialization and move to Grpc impl -->
-    <dependency>
-      <groupId>io.atomix.catalyst</groupId>
-      <artifactId>catalyst-transport</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
@@ -56,18 +44,31 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <!--aws sdk requires jaxb binding at runtime-->
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <scope>runtime</scope>
+      <groupId>com.hubspot.jackson</groupId>
+      <artifactId>jackson-datatype-protobuf</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
+    </dependency>
+    <!-- TODO(lu) remove catalyst dependency which used for serialization and move to Grpc impl -->
+    <dependency>
+      <groupId>io.atomix.catalyst</groupId>
+      <artifactId>catalyst-transport</artifactId>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
@@ -83,19 +84,31 @@
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_servlet</artifactId>
+      <artifactId>simpleclient_dropwizard</artifactId>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_dropwizard</artifactId>
+      <artifactId>simpleclient_servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
+
+    <!-- Internal dependencies -->
     <dependency>
-      <groupId>jakarta.ws.rs</groupId>
-      <artifactId>jakarta.ws.rs-api</artifactId>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-transport</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -110,6 +123,18 @@
       <artifactId>curator-recipes</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerby-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-grpc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-server</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
     </dependency>
@@ -122,26 +147,23 @@
       <artifactId>jetty-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.hubspot.jackson</groupId>
-      <artifactId>jackson-datatype-protobuf</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>annotations</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.lz4</groupId>
       <artifactId>lz4-java</artifactId>
     </dependency>
+    <!--aws sdk requires jaxb binding at runtime-->
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-xml</artifactId>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <scope>runtime</scope>
     </dependency>
+
+    <!-- Internal test dependencies -->
     <dependency>
-      <groupId>org.apache.kerby</groupId>
-      <artifactId>kerby-util</artifactId>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
 
     <!-- Test dependencies -->
@@ -153,27 +175,6 @@
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Internal dependencies -->
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-transport</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <!-- Internal test dependencies -->
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-common</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dora/core/server/master/pom.xml
+++ b/dora/core/server/master/pom.xml
@@ -30,7 +30,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -56,8 +55,6 @@
       <artifactId>alluxio-core-client-fs</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -125,14 +122,11 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- External test dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/core/server/master/pom.xml
+++ b/dora/core/server/master/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-core-server</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-core-server</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
   <artifactId>alluxio-core-server-master</artifactId>
@@ -43,12 +44,52 @@
       <artifactId>swagger-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-fs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Internal dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-server-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-transport</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-job-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-stress-shell</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -75,60 +116,13 @@
       <artifactId>rocksdbjni</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-json-jackson</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>it.unimi.dsi</groupId>
-      <artifactId>fastutil-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-transport</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-client-fs</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-server-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-job-client</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.gaul</groupId>
-      <artifactId>s3proxy</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-stress-shell</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- External test dependencies -->
@@ -159,8 +153,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>org.gaul</groupId>
+      <artifactId>s3proxy</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
@@ -181,9 +182,9 @@
 
       <!-- REST API documentation -->
       <plugin>
-        <inherited>false</inherited>
         <groupId>com.github.kongchen</groupId>
         <artifactId>swagger-maven-plugin</artifactId>
+        <inherited>false</inherited>
         <configuration>
           <apiSources>
             <apiSource>
@@ -194,9 +195,7 @@
               <info>
                 <version>v1</version>
                 <title>Alluxio Master REST API Documentation</title>
-                <description>
-                  The Alluxio Master is the central metadata service of the Alluxio System.
-                </description>
+                <description>The Alluxio Master is the central metadata service of the Alluxio System.</description>
               </info>
               <locations>alluxio.master.meta.AlluxioMasterRestServiceHandler</locations>
               <templatePath>${project.parent.parent.parent.parent.basedir}/templates/strapdown.html.hbs</templatePath>

--- a/dora/core/server/pom.xml
+++ b/dora/core/server/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-core</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-core</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
   <artifactId>alluxio-core-server</artifactId>
@@ -22,17 +23,17 @@
   <name>Alluxio Core - Server</name>
   <description>Alluxio core services</description>
 
+  <properties>
+    <!-- These need to be defined here as well as in the parent pom so that mvn can run
+         properly from sub-project directories -->
+    <build.path>${project.parent.parent.parent.basedir}/build</build.path>
+  </properties>
+
   <modules>
     <module>common</module>
     <module>master</module>
     <module>proxy</module>
     <module>worker</module>
   </modules>
-
-  <properties>
-    <!-- These need to be defined here as well as in the parent pom so that mvn can run
-         properly from sub-project directories -->
-    <build.path>${project.parent.parent.parent.basedir}/build</build.path>
-  </properties>
 
 </project>

--- a/dora/core/server/proxy/pom.xml
+++ b/dora/core/server/proxy/pom.xml
@@ -30,7 +30,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
@@ -52,8 +51,6 @@
       <artifactId>alluxio-core-client-fs</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/core/server/proxy/pom.xml
+++ b/dora/core/server/proxy/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-core-server</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-core-server</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
   <artifactId>alluxio-core-server-proxy</artifactId>
@@ -47,12 +48,33 @@
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-fs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Internal dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-server-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerby-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -74,31 +96,10 @@
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.kerby</groupId>
-      <artifactId>kerby-util</artifactId>
-    </dependency>
     <!-- Required at runtime to decode json objects for rest API -->
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-    </dependency>
-
-    <!-- Internal dependencies -->
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-client-fs</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-server-common</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 
@@ -106,9 +107,9 @@
     <plugins>
       <!-- REST API documentation -->
       <plugin>
-        <inherited>false</inherited>
         <groupId>com.github.kongchen</groupId>
         <artifactId>swagger-maven-plugin</artifactId>
+        <inherited>false</inherited>
         <configuration>
           <apiSources>
             <apiSource>
@@ -120,13 +121,11 @@
                 <version>v1</version>
                 <title>Alluxio Proxy REST API Documentation</title>
                 <!-- description must be left aligned after new line or markdown will misinterpret it -->
-                <description>
-                  The Alluxio Proxy acts as a REST gateway for clients to communicate with the Alluxio system. There are three different endpoints:
+                <description>The Alluxio Proxy acts as a REST gateway for clients to communicate with the Alluxio system. There are three different endpoints:
 
 1. The Proxy endpoint gives general info about the proxy service.
 1. The Paths endpoint provides a RESTful gateway to the Alluxio file system for metadata operations.
-1. The Streams endpoint provides a RESTful gateway to the Alluxio file system for data operations.
-                </description>
+1. The Streams endpoint provides a RESTful gateway to the Alluxio file system for data operations.</description>
               </info>
               <locations>
                 <location>alluxio.proxy.AlluxioProxyRestServiceHandler</location>

--- a/dora/core/server/worker/pom.xml
+++ b/dora/core/server/worker/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-core-server</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-core-server</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
   <artifactId>alluxio-core-server-worker</artifactId>
@@ -50,6 +51,33 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
+
+    <!-- Internal dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-fs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-server-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-transport</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-integration-fuse</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
@@ -80,46 +108,18 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Internal dependencies -->
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-client-fs</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-transport</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-server-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-integration-fuse</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <!-- External test dependencies -->
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-hdfs</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- Used by reflection -->
@@ -129,10 +129,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- External test dependencies -->
     <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-hdfs</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -141,9 +142,9 @@
     <plugins>
       <!-- REST API documentation -->
       <plugin>
-        <inherited>false</inherited>
         <groupId>com.github.kongchen</groupId>
         <artifactId>swagger-maven-plugin</artifactId>
+        <inherited>false</inherited>
         <configuration>
           <apiSources>
             <apiSource>
@@ -154,9 +155,7 @@
               <info>
                 <version>v1</version>
                 <title>Alluxio Worker REST API Documentation</title>
-                <description>
-                  The Alluxio Workers are processes which provide clients access to the data exposed by the Alluxio System.
-                </description>
+                <description>The Alluxio Workers are processes which provide clients access to the data exposed by the Alluxio System.</description>
               </info>
               <locations>alluxio.worker.AlluxioWorkerRestServiceHandler</locations>
               <templatePath>${project.parent.parent.parent.parent.basedir}/templates/strapdown.html.hbs</templatePath>

--- a/dora/core/server/worker/pom.xml
+++ b/dora/core/server/worker/pom.xml
@@ -30,7 +30,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -51,8 +50,6 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>
@@ -108,7 +105,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -129,8 +125,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-
-    <!-- External test dependencies -->
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>

--- a/dora/examples/pom.xml
+++ b/dora/examples/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -48,6 +49,11 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-shaded-client</artifactId>
+      <version>2.9.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
@@ -65,11 +71,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-shaded-client</artifactId>
-      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/dora/examples/pom.xml
+++ b/dora/examples/pom.xml
@@ -31,7 +31,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>

--- a/dora/integration/fuse/pom.xml
+++ b/dora/integration/fuse/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -41,13 +42,6 @@
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <version>${project.version}</version>
-      <artifactId>alluxio-core-server-common</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>
@@ -56,6 +50,13 @@
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Internal dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-server-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -109,20 +110,20 @@
         <executions>
           <execution>
             <id>uber-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
               </transformers>
               <filters>
                 <filter>
-                  <artifact>*:* </artifact>
+                  <artifact>*:*</artifact>
                   <excludes>
                     <exclude>LICENSE</exclude>
                     <exclude>META-INF/*.SF</exclude>

--- a/dora/integration/fuse/pom.xml
+++ b/dora/integration/fuse/pom.xml
@@ -29,7 +29,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.github.serceman</groupId>
       <artifactId>jnr-fuse</artifactId>
@@ -52,8 +51,6 @@
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-server-common</artifactId>
@@ -81,7 +78,6 @@
       <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/integration/jnifuse/fs/pom.xml
+++ b/dora/integration/jnifuse/fs/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-integration-jnifuse</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-integration-jnifuse</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
 
@@ -29,27 +30,27 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-integration-jnifuse-native</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>com.github.serceman</groupId>
       <artifactId>jnr-fuse</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-integration-jnifuse-native</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/dora/integration/jnifuse/native/pom.xml
+++ b/dora/integration/jnifuse/native/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-integration-jnifuse</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-integration-jnifuse</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
 
@@ -42,25 +43,25 @@
             <executions>
               <execution>
                 <id>native_fuse_compile</id>
-                <phase>process-resources</phase>
                 <goals>
                   <goal>run</goal>
                 </goals>
+                <phase>process-resources</phase>
                 <configuration>
                   <!--TODO:(maobaolong) make it can build for multi target-->
                   <target>
-                    <mkdir dir="${project.build.directory}/native" />
-                    <exec executable="make" failonerror="true" dir="${project.build.directory}/native">
-                      <arg line="-f ${project.basedir}/src/main/native/libjnifuse/Makefile" />
+                    <mkdir dir="${project.build.directory}/native"/>
+                    <exec dir="${project.build.directory}/native" executable="make" failonerror="true">
+                      <arg line="-f ${project.basedir}/src/main/native/libjnifuse/Makefile"/>
                     </exec>
                     <copy todir="${project.build.directory}/classes">
                       <fileset dir="${project.build.directory}/native/">
-                        <include name="libjnifuse*" />
+                        <include name="libjnifuse*"/>
                       </fileset>
                     </copy>
                     <copy todir="${project.basedir}/src/main/resources">
                       <fileset dir="${project.build.directory}/native/">
-                        <include name="libjnifuse*" />
+                        <include name="libjnifuse*"/>
                       </fileset>
                     </copy>
                   </target>

--- a/dora/integration/jnifuse/pom.xml
+++ b/dora/integration/jnifuse/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -17,18 +18,18 @@
     <artifactId>alluxio-integration</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
-  <packaging>pom</packaging>
   <artifactId>alluxio-integration-jnifuse</artifactId>
+  <packaging>pom</packaging>
   <name>Alluxio Integration - JNIFUSE</name>
   <description>JNI-based FUSE Integration</description>
-
-  <modules>
-    <module>fs</module>
-    <module>native</module>
-  </modules>
   <properties>
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.basedir}/build</build.path>
   </properties>
+
+  <modules>
+    <module>fs</module>
+    <module>native</module>
+  </modules>
 </project>

--- a/dora/integration/pom.xml
+++ b/dora/integration/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -21,15 +22,15 @@
   <packaging>pom</packaging>
   <name>Alluxio Integration</name>
   <description>Parent POM for different integrations with Alluxio</description>
-  <modules>
-    <module>fuse</module>
-    <module>jnifuse</module>
-    <module>tools</module>
-  </modules>
 
   <properties>
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
   </properties>
+  <modules>
+    <module>fuse</module>
+    <module>jnifuse</module>
+    <module>tools</module>
+  </modules>
 </project>

--- a/dora/integration/tools/hms/pom.xml
+++ b/dora/integration/tools/hms/pom.xml
@@ -14,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-integration-tools</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-integration-tools</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
 
@@ -23,7 +23,6 @@
   <packaging>jar</packaging>
   <name>Alluxio Integration - Tools - HMS</name>
   <description>Alluxio integration tools for hive metastore</description>
-
 
   <properties>
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
@@ -85,8 +84,8 @@
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
         <exclusion>
-           <groupId>jdk.tools</groupId>
-           <artifactId>jdk.tools</artifactId>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -100,14 +99,14 @@
         <executions>
           <execution>
             <id>shade</id>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <filters>
                 <filter>
@@ -126,16 +125,16 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/integration/tools/hms/pom.xml
+++ b/dora/integration/tools/hms/pom.xml
@@ -32,7 +32,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>

--- a/dora/integration/tools/pom.xml
+++ b/dora/integration/tools/pom.xml
@@ -36,7 +36,6 @@
   </modules>
 
   <dependencies>
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/integration/tools/pom.xml
+++ b/dora/integration/tools/pom.xml
@@ -14,20 +14,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-integration</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-integration</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
+  <artifactId>alluxio-integration-tools</artifactId>
   <packaging>pom</packaging>
   <name>Alluxio Integration - Tools</name>
-  <artifactId>alluxio-integration-tools</artifactId>
 
   <properties>
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.basedir}/build</build.path>
-    <ufs.hadoop.version>3.3.1</ufs.hadoop.version>
     <failIfNoTests>false</failIfNoTests>
+    <ufs.hadoop.version>3.3.1</ufs.hadoop.version>
   </properties>
 
   <modules>

--- a/dora/integration/tools/validation/pom.xml
+++ b/dora/integration/tools/validation/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -30,26 +31,18 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jline</groupId>
-      <artifactId>jline</artifactId>
-    </dependency>
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+    </dependency>
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
 
     <!-- Internal dependencies -->
@@ -57,6 +50,14 @@
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jline</groupId>
+      <artifactId>jline</artifactId>
     </dependency>
 
     <!-- Test dependencies -->
@@ -78,16 +79,16 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/integration/tools/validation/pom.xml
+++ b/dora/integration/tools/validation/pom.xml
@@ -39,13 +39,10 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -60,7 +57,6 @@
       <artifactId>jline</artifactId>
     </dependency>
 
-    <!-- Test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/job/client/pom.xml
+++ b/dora/job/client/pom.xml
@@ -30,13 +30,12 @@
   </properties>
 
   <dependencies>
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-job-common</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- Internal test dependencies -->
+
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/job/client/pom.xml
+++ b/dora/job/client/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -11,12 +12,12 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-job</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-job</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
   <artifactId>alluxio-job-client</artifactId>
   <packaging>jar</packaging>
   <name>Alluxio Job Service - Client</name>

--- a/dora/job/common/pom.xml
+++ b/dora/job/common/pom.xml
@@ -34,9 +34,7 @@
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>
       <version>${project.version}</version>
-
     </dependency>
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/job/common/pom.xml
+++ b/dora/job/common/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -11,12 +12,12 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-job</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-job</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
   <artifactId>alluxio-job-common</artifactId>
   <packaging>jar</packaging>
   <name>Alluxio Job Service - Common Utilities</name>
@@ -29,17 +30,17 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-fs</artifactId>
+      <version>${project.version}</version>
+
+    </dependency>
     <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.alluxio</groupId>
-        <artifactId>alluxio-core-client-fs</artifactId>
-        <version>${project.version}</version>
-
     </dependency>
   </dependencies>
 

--- a/dora/job/pom.xml
+++ b/dora/job/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -11,22 +12,16 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-dora</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
   <artifactId>alluxio-job</artifactId>
   <packaging>pom</packaging>
   <name>Alluxio Job Service</name>
   <description>Parent POM for Alluxio job service</description>
-
-  <modules>
-    <module>client</module>
-    <module>common</module>
-    <module>server</module>
-  </modules>
 
   <properties>
     <!-- These need to be defined here as well as in the parent pom so that mvn can run
@@ -34,4 +29,10 @@
     <build.path>${project.parent.parent.basedir}/build</build.path>
     <license.dir>license</license.dir>
   </properties>
+
+  <modules>
+    <module>client</module>
+    <module>common</module>
+    <module>server</module>
+  </modules>
 </project>

--- a/dora/job/server/pom.xml
+++ b/dora/job/server/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -29,6 +30,10 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
     <!-- External dependencies -->
     <dependency>
       <groupId>com.github.oshi</groupId>
@@ -38,34 +43,6 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.orc</groupId>
-      <artifactId>orc-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-avro</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-cli</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.containers</groupId>
-      <artifactId>jersey-container-servlet-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.inject</groupId>
-      <artifactId>jersey-hk2</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>
 
     <!-- Internal dependencies -->
@@ -94,6 +71,30 @@
       <artifactId>alluxio-stress-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.orc</groupId>
+      <artifactId>orc-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-cli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+    </dependency>
 
     <!-- Internal test Dependencies -->
     <dependency>
@@ -112,15 +113,15 @@
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-local</artifactId>
+      <artifactId>alluxio-job-common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-job-common</artifactId>
+      <artifactId>alluxio-underfs-local</artifactId>
       <version>${project.version}</version>
-      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
 
@@ -132,50 +133,48 @@
   </dependencies>
 
   <build>
-  <plugins>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-jar-plugin</artifactId>
-      <executions>
-        <execution>
-          <goals>
-            <goal>test-jar</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 
-    <!-- REST API documentation -->
-    <plugin>
-      <groupId>com.github.kongchen</groupId>
-      <artifactId>swagger-maven-plugin</artifactId>
-      <configuration>
-        <apiSources>
-          <apiSource>
-            <springmvc>false</springmvc>
-            <schemes>http</schemes>
-            <host>[Alluxio Job Master or Job Worker Hostname]</host>
-            <basePath>/api/v1</basePath>
-            <info>
-              <version>v1</version>
-              <title>Alluxio Job Service REST API Documentation</title>
-              <description>
-                The Alluxio Job Master is a component of the Job Service that coordinates Alluxio Job Workers to execute distributed tasks scheduled by the Alluxio system.
-                The Alluxio Job Worker is a component of the Job Service that executes various I/O intensive tasks scheduled by the Alluxio system.
-              </description>
-            </info>
-            <locations>
-              <location>alluxio.master.AlluxioJobMasterRestServiceHandler</location>
-              <location>alluxio.worker.AlluxioJobWorkerRestServiceHandler</location>
-              <location>alluxio.master.job.JobMasterClientRestServiceHandler</location>
-            </locations>
-            <templatePath>${project.parent.parent.parent.basedir}/templates/strapdown.html.hbs</templatePath>
-            <outputPath>${project.parent.parent.parent.basedir}/generated/job/index.html</outputPath>
-            <swaggerDirectory>${project.parent.parent.parent.basedir}/generated/job/swagger-ui</swaggerDirectory>
-          </apiSource>
-        </apiSources>
-      </configuration>
-    </plugin>
-  </plugins>
+      <!-- REST API documentation -->
+      <plugin>
+        <groupId>com.github.kongchen</groupId>
+        <artifactId>swagger-maven-plugin</artifactId>
+        <configuration>
+          <apiSources>
+            <apiSource>
+              <springmvc>false</springmvc>
+              <schemes>http</schemes>
+              <host>[Alluxio Job Master or Job Worker Hostname]</host>
+              <basePath>/api/v1</basePath>
+              <info>
+                <version>v1</version>
+                <title>Alluxio Job Service REST API Documentation</title>
+                <description>The Alluxio Job Master is a component of the Job Service that coordinates Alluxio Job Workers to execute distributed tasks scheduled by the Alluxio system.
+                The Alluxio Job Worker is a component of the Job Service that executes various I/O intensive tasks scheduled by the Alluxio system.</description>
+              </info>
+              <locations>
+                <location>alluxio.master.AlluxioJobMasterRestServiceHandler</location>
+                <location>alluxio.worker.AlluxioJobWorkerRestServiceHandler</location>
+                <location>alluxio.master.job.JobMasterClientRestServiceHandler</location>
+              </locations>
+              <templatePath>${project.parent.parent.parent.basedir}/templates/strapdown.html.hbs</templatePath>
+              <outputPath>${project.parent.parent.parent.basedir}/generated/job/index.html</outputPath>
+              <swaggerDirectory>${project.parent.parent.parent.basedir}/generated/job/swagger-ui</swaggerDirectory>
+            </apiSource>
+          </apiSources>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/dora/job/server/pom.xml
+++ b/dora/job/server/pom.xml
@@ -34,7 +34,6 @@
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.github.oshi</groupId>
       <artifactId>oshi-core</artifactId>
@@ -44,8 +43,6 @@
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>
@@ -96,7 +93,6 @@
       <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>
 
-    <!-- Internal test Dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>

--- a/dora/microbench/pom.xml
+++ b/dora/microbench/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -18,20 +19,34 @@
     <version>303-SNAPSHOT</version>
   </parent>
   <artifactId>alluxio-microbench</artifactId>
+  <packaging>jar</packaging>
   <name>Alluxio Microbenchmarks</name>
   <description>Microbenchmarks of Alluxio</description>
-  <packaging>jar</packaging>
 
   <properties>
-    <jmh.version>1.35</jmh.version>
     <!-- These need to be defined here as well as in the parent pom so that mvn can run
          properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
+    <jmh.version>1.35</jmh.version>
     <!-- Name of the benchmark Uber-JAR to generate. -->
     <uberjar.name>benchmarks</uberjar.name>
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-fs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
@@ -44,7 +59,7 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
-        <dependency>
+    <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-server-worker</artifactId>
       <version>${project.version}</version>
@@ -57,9 +72,14 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-client-fs</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
     </dependency>
 
     <!-- external dependencies -->
@@ -70,28 +90,9 @@
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
-      <artifactId>jmh-core</artifactId>
-      <version>${jmh.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>${jmh.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
     </dependency>
   </dependencies>
 
@@ -125,17 +126,17 @@
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <finalName>${uberjar.name}</finalName>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.openjdk.jmh.Main</mainClass>
                 </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <filters>
                 <filter>

--- a/dora/microbench/pom.xml
+++ b/dora/microbench/pom.xml
@@ -47,7 +47,6 @@
       <artifactId>alluxio-core-client-fs</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-server-common</artifactId>
@@ -81,8 +80,6 @@
       <artifactId>jmh-core</artifactId>
       <version>${jmh.version}</version>
     </dependency>
-
-    <!-- external dependencies -->
     <dependency>
       <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>

--- a/dora/minicluster/pom.xml
+++ b/dora/minicluster/pom.xml
@@ -31,7 +31,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -41,15 +40,12 @@
       <artifactId>junit</artifactId>
       <scope>compile</scope>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>
       <version>${project.version}</version>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>

--- a/dora/minicluster/pom.xml
+++ b/dora/minicluster/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -11,12 +12,12 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-dora</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-dora</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>alluxio-minicluster</artifactId>
   <packaging>jar</packaging>
@@ -36,18 +37,8 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-test</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-reflect</artifactId>
       <scope>compile</scope>
     </dependency>
 
@@ -57,10 +48,24 @@
       <artifactId>alluxio-core-client-fs</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Internal test dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-fs</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+    </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
@@ -89,28 +94,24 @@
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-local</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <!-- Internal test dependencies -->
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-client-fs</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-common</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
       <artifactId>alluxio-job-server</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-local</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-reflect</artifactId>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/dora/pom.xml
+++ b/dora/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -22,6 +23,12 @@
   <name>Alluxio Dora</name>
   <description>Parent POM for Alluxio DORA</description>
 
+  <properties>
+    <!-- These need to be defined here as well as in the parent pom so that mvn can run
+         properly from sub-project directories -->
+    <build.path>${project.parent.basedir}/build</build.path>
+  </properties>
+
   <modules>
     <module>core</module>
     <module>examples</module>
@@ -35,10 +42,4 @@
     <module>tests</module>
     <module>underfs</module>
   </modules>
-
-  <properties>
-    <!-- These need to be defined here as well as in the parent pom so that mvn can run
-         properly from sub-project directories -->
-    <build.path>${project.parent.basedir}/build</build.path>
-  </properties>
 </project>

--- a/dora/shaded/client-hadoop3/pom.xml
+++ b/dora/shaded/client-hadoop3/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-shaded</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-shaded</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
   <artifactId>alluxio-shaded-hadoop3-client</artifactId>
@@ -32,6 +33,19 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-fs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Internal dependencies -->
+    <!-- This should include all Alluxio client implementations -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-hdfs3</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- External dependencies -->
     <!-- Have hadoop-client dependency in provided scope by default -->
     <dependency>
@@ -40,27 +54,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.rocksdb</groupId>
-      <artifactId>rocksdbjni</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!-- Runtime logging dependencies -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <scope>runtime</scope>
-    </dependency>
-    <!-- Move log4j to optional, since it is mainly used in test-->
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -74,69 +70,25 @@
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
-
-    <!-- Internal dependencies -->
-    <!-- This should include all Alluxio client implementations -->
+    <!-- Move log4j to optional, since it is mainly used in test-->
     <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-client-hdfs3</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-client-fs</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.rocksdb</groupId>
+      <artifactId>rocksdbjni</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- Runtime logging dependencies -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>includeHadoopClient</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-client</artifactId>
-          <scope>compile</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>com.fasterxml.jackson.core</groupId>
-              <artifactId>jackson-core</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <!-- Creates the client jar symlink pointing to the shaded hadoop3 client jar -->
-    <profile>
-      <id>hadoop-3</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>symlink-jar</id>
-                <phase>install</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <executable>ln</executable>
-                  <arguments>
-                    <argument>-fnsv</argument>
-                    <argument>build/alluxio-${project.version}-hadoop3-client.jar</argument>
-                    <argument>${project.parent.parent.parent.basedir}/client/alluxio-${project.version}-client.jar</argument>
-                  </arguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
   <build>
     <plugins>
@@ -149,10 +101,10 @@
         <executions>
           <execution>
             <id>empty-javadoc-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <classifier>javadoc</classifier>
               <classesDirectory>${basedir}/javadoc</classesDirectory>
@@ -160,10 +112,10 @@
           </execution>
           <execution>
             <id>sources-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <classifier>sources</classifier>
             </configuration>
@@ -195,10 +147,10 @@
         <executions>
           <execution>
             <id>uber-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <createSourcesJar>true</createSourcesJar>
               <shadeSourcesContent>true</shadeSourcesContent>
@@ -247,14 +199,12 @@
                 <!-- Relocate the native netty libraries to be prefixed with our shade prefix -->
                 <relocation>
                   <pattern>META-INF/native/libnetty_transport_native_epoll_x86_64.so</pattern>
-                  <shadedPattern>META-INF/native/liballuxio_shaded_client_netty_transport_native_epoll_x86_64.so
-                  </shadedPattern>
+                  <shadedPattern>META-INF/native/liballuxio_shaded_client_netty_transport_native_epoll_x86_64.so</shadedPattern>
                   <rawString>true</rawString>
                 </relocation>
                 <relocation>
                   <pattern>META-INF/native/libnetty_transport_native_epoll_aarch_64.so</pattern>
-                  <shadedPattern>META-INF/native/liballuxio_shaded_client_netty_transport_native_epoll_aarch_64.so
-                  </shadedPattern>
+                  <shadedPattern>META-INF/native/liballuxio_shaded_client_netty_transport_native_epoll_aarch_64.so</shadedPattern>
                   <rawString>true</rawString>
                 </relocation>
                 <relocation>
@@ -322,8 +272,8 @@
                 </relocation>
               </relocations>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                   <resources>
                     <resource>NOTICE.txt</resource>
@@ -355,18 +305,66 @@
         <executions>
           <execution>
             <id>copy-and-rename-file</id>
-            <phase>install</phase>
             <goals>
               <goal>copy</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <sourceFile>${basedir}/target/${project.artifactId}-${project.version}.jar</sourceFile>
-              <destinationFile>${project.parent.parent.parent.basedir}/client/build/alluxio-${project.version}-hadoop3-client.jar
-              </destinationFile>
+              <destinationFile>${project.parent.parent.parent.basedir}/client/build/alluxio-${project.version}-hadoop3-client.jar</destinationFile>
             </configuration>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>includeHadoopClient</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+          <scope>compile</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-core</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <!-- Creates the client jar symlink pointing to the shaded hadoop3 client jar -->
+    <profile>
+      <id>hadoop-3</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>symlink-jar</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>install</phase>
+                <configuration>
+                  <executable>ln</executable>
+                  <arguments>
+                    <argument>-fnsv</argument>
+                    <argument>build/alluxio-${project.version}-hadoop3-client.jar</argument>
+                    <argument>${project.parent.parent.parent.basedir}/client/alluxio-${project.version}-client.jar</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/dora/shaded/client-hadoop3/pom.xml
+++ b/dora/shaded/client-hadoop3/pom.xml
@@ -38,15 +38,12 @@
       <artifactId>alluxio-core-client-fs</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <!-- Internal dependencies -->
     <!-- This should include all Alluxio client implementations -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-hdfs3</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- External dependencies -->
     <!-- Have hadoop-client dependency in provided scope by default -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/dora/shaded/client/pom.xml
+++ b/dora/shaded/client/pom.xml
@@ -39,14 +39,12 @@
       <version>${project.version}</version>
     </dependency>
 
-    <!-- Internal dependencies -->
     <!-- This should include all Alluxio client implementations -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-hdfs</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- External dependencies -->
     <!-- Have hadoop-client dependency in provided scope by default -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/dora/shaded/client/pom.xml
+++ b/dora/shaded/client/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -32,6 +33,19 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-fs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Internal dependencies -->
+    <!-- This should include all Alluxio client implementations -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-client-hdfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- External dependencies -->
     <!-- Have hadoop-client dependency in provided scope by default -->
     <dependency>
@@ -40,27 +54,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.rocksdb</groupId>
-      <artifactId>rocksdbjni</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!-- Runtime logging dependencies -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <scope>runtime</scope>
-    </dependency>
-    <!-- Move log4j to optional, since it is mainly used in test-->
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -74,39 +70,25 @@
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
-
-    <!-- Internal dependencies -->
-    <!-- This should include all Alluxio client implementations -->
+    <!-- Move log4j to optional, since it is mainly used in test-->
     <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-client-hdfs</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-client-fs</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.rocksdb</groupId>
+      <artifactId>rocksdbjni</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- Runtime logging dependencies -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>includeHadoopClient</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-client</artifactId>
-          <scope>compile</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>com.fasterxml.jackson.core</groupId>
-              <artifactId>jackson-core</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 
   <build>
     <plugins>
@@ -119,10 +101,10 @@
         <executions>
           <execution>
             <id>empty-javadoc-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <classifier>javadoc</classifier>
               <classesDirectory>${basedir}/javadoc</classesDirectory>
@@ -130,10 +112,10 @@
           </execution>
           <execution>
             <id>sources-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <classifier>sources</classifier>
             </configuration>
@@ -165,10 +147,10 @@
         <executions>
           <execution>
             <id>uber-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <createSourcesJar>true</createSourcesJar>
               <shadeSourcesContent>true</shadeSourcesContent>
@@ -312,8 +294,8 @@
                 </relocation>
               </relocations>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                   <resources>
                     <resource>NOTICE.txt</resource>
@@ -345,10 +327,10 @@
         <executions>
           <execution>
             <id>copy-and-rename-file</id>
-            <phase>install</phase>
             <goals>
               <goal>copy</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <sourceFile>target/alluxio-shaded-client-${project.version}.jar</sourceFile>
               <destinationFile>../../../client/build/alluxio-${project.version}-hadoop2-client.jar</destinationFile>
@@ -363,10 +345,10 @@
         <executions>
           <execution>
             <id>symlink-jar</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>ln</executable>
               <arguments>
@@ -380,4 +362,23 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>includeHadoopClient</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+          <scope>compile</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-core</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/dora/shaded/hadoop/pom.xml
+++ b/dora/shaded/hadoop/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -18,19 +19,19 @@
     <version>303-SNAPSHOT</version>
   </parent>
   <artifactId>alluxio-shaded-hadoop</artifactId>
+  <version>${ufs.hadoop.version}</version>
   <packaging>jar</packaging>
   <name>Alluxio Shaded Libraries - Hadoop</name>
-  <version>${ufs.hadoop.version}</version>
   <description>Shaded Hadoop Module</description>
 
   <properties>
     <!-- The build path need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.basedir}/build</build.path>
-    <ufs.hadoop.version>3.3.1</ufs.hadoop.version>
-    <shading.prefix>alluxio.shaded.hdfs</shading.prefix>
     <!-- Composite jar name with both hadoop version and project version included -->
     <lib.jar.name>${project.artifactId}-${ufs.hadoop.version}-${project.version}.jar</lib.jar.name>
+    <shading.prefix>alluxio.shaded.hdfs</shading.prefix>
+    <ufs.hadoop.version>3.3.1</ufs.hadoop.version>
   </properties>
 
   <dependencies>
@@ -45,76 +46,16 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
-
-  <profiles>
-    <!-- Profile to build this UFS module connecting to hdfs 1 -->
-    <profile>
-      <!-- Decouple hadoop profiles: hadoop-1 to indicate north bound and ufs-hadoop-1 to indicate the south bound -->
-      <id>ufs-hadoop-1</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-core</artifactId>
-          <version>${ufs.hadoop.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <!-- Profile to build this UFS module connecting to hdfs 2 -->
-    <profile>
-      <!-- Decouple hadoop profiles: hadoop-2 to indicate north bound and ufs-hadoop-2 to indicate the south bound -->
-      <id>ufs-hadoop-2</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-common</artifactId>
-          <version>${ufs.hadoop.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-hdfs</artifactId>
-          <version>${ufs.hadoop.version}</version>
-        </dependency>
-        <dependency>	
-          <!-- using older version to match dependency version from Hadoop, guava introduced a breaking change between version 14 and later -->	
-          <groupId>com.google.guava</groupId>	
-          <artifactId>guava</artifactId>	
-          <version>14.0.1</version>	
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <!-- Profile to build this UFS module connecting to hdfs 3, this is the default profile -->
-    <profile>
-      <id>ufs-hadoop-3</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-common</artifactId>
-          <version>${ufs.hadoop.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-hdfs-client</artifactId>
-          <version>${ufs.hadoop.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
-
 
   <build>
     <plugins>
@@ -131,10 +72,10 @@
         <executions>
           <execution>
             <id>shade-alluxio</id>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <!-- Since we don't shade all artifacts, we need to promote the transitive dependencies -->
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
@@ -178,7 +119,7 @@
                 </relocation>
               </relocations>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <artifactSet>
                 <includes>
@@ -228,4 +169,63 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- Profile to build this UFS module connecting to hdfs 1 -->
+    <profile>
+      <!-- Decouple hadoop profiles: hadoop-1 to indicate north bound and ufs-hadoop-1 to indicate the south bound -->
+      <id>ufs-hadoop-1</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-core</artifactId>
+          <version>${ufs.hadoop.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <!-- Profile to build this UFS module connecting to hdfs 2 -->
+    <profile>
+      <!-- Decouple hadoop profiles: hadoop-2 to indicate north bound and ufs-hadoop-2 to indicate the south bound -->
+      <id>ufs-hadoop-2</id>
+      <dependencies>
+        <dependency>
+          <!-- using older version to match dependency version from Hadoop, guava introduced a breaking change between version 14 and later -->
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>14.0.1</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+          <version>${ufs.hadoop.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs</artifactId>
+          <version>${ufs.hadoop.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <!-- Profile to build this UFS module connecting to hdfs 3, this is the default profile -->
+    <profile>
+      <id>ufs-hadoop-3</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+          <version>${ufs.hadoop.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
+          <version>${ufs.hadoop.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/dora/shaded/pom.xml
+++ b/dora/shaded/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -22,15 +23,15 @@
   <name>Alluxio Shaded Libraries</name>
   <description>Parent POM for different shaded Libraries</description>
 
-  <modules>
-    <module>client</module>
-    <module>client-hadoop3</module>
-    <module>hadoop</module>
-  </modules>
-
   <properties>
     <!-- These need to be defined here as well as in the parent pom so that mvn can run
          properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
   </properties>
+
+  <modules>
+    <module>client</module>
+    <module>client-hadoop3</module>
+    <module>hadoop</module>
+  </modules>
 </project>

--- a/dora/shell/pom.xml
+++ b/dora/shell/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -30,6 +31,10 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+    </dependency>
     <!-- External dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -44,28 +49,8 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jline</groupId>
-      <artifactId>jline</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
     </dependency>
 
     <!-- Internal dependencies -->
@@ -84,8 +69,24 @@
       <artifactId>alluxio-job-client</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jline</groupId>
+      <artifactId>jline</artifactId>
+    </dependency>
 
-      <!-- Test dependencies -->
+    <!-- Test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/shell/pom.xml
+++ b/dora/shell/pom.xml
@@ -35,7 +35,6 @@
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -52,8 +51,6 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>
@@ -86,7 +83,6 @@
       <artifactId>jline</artifactId>
     </dependency>
 
-    <!-- Test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/stress/common/pom.xml
+++ b/dora/stress/common/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,13 +14,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-      <artifactId>alluxio-stress</artifactId>
-      <groupId>org.alluxio</groupId>
-      <version>303-SNAPSHOT</version>
+    <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-stress</artifactId>
+    <version>303-SNAPSHOT</version>
   </parent>
-  <name>Alluxio Stress - Common</name>
   <artifactId>alluxio-stress-common</artifactId>
   <packaging>jar</packaging>
+  <name>Alluxio Stress - Common</name>
   <description>Common between client and server</description>
 
   <properties>
@@ -38,10 +39,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.hdrhistogram</groupId>
-      <artifactId>HdrHistogram</artifactId>
-    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>
@@ -51,13 +48,17 @@
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-job-common</artifactId>
+      <artifactId>alluxio-core-server-worker</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-server-worker</artifactId>
+      <artifactId>alluxio-job-common</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/dora/stress/common/pom.xml
+++ b/dora/stress/common/pom.xml
@@ -30,7 +30,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
@@ -39,8 +38,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/stress/pom.xml
+++ b/dora/stress/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -22,14 +23,14 @@
   <name>Alluxio Stress</name>
   <description>Stress tests in Alluxio</description>
 
-  <modules>
-    <module>common</module>
-    <module>shell</module>
-  </modules>
-
   <properties>
     <!-- These need to be defined here as well as in the parent pom so that mvn can run
          properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
   </properties>
+
+  <modules>
+    <module>common</module>
+    <module>shell</module>
+  </modules>
 </project>

--- a/dora/stress/shell/pom.xml
+++ b/dora/stress/shell/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,13 +14,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-      <artifactId>alluxio-stress</artifactId>
-      <groupId>org.alluxio</groupId>
-      <version>303-SNAPSHOT</version>
+    <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-stress</artifactId>
+    <version>303-SNAPSHOT</version>
   </parent>
-  <name>Alluxio Stress - Shell</name>
   <artifactId>alluxio-stress-shell</artifactId>
   <packaging>jar</packaging>
+  <name>Alluxio Stress - Shell</name>
 
   <properties>
     <!-- These need to be defined here as well as in the parent pom so that mvn can run
@@ -32,14 +33,6 @@
       <!-- External dependencies -->
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hdrhistogram</groupId>
-      <artifactId>HdrHistogram</artifactId>
     </dependency>
 
     <!-- Internal dependencies -->
@@ -55,8 +48,19 @@
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-server-worker</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
       <artifactId>alluxio-job-client</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-shell</artifactId>
+      <version>303-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
@@ -64,15 +68,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-server-worker</artifactId>
-      <version>${project.version}</version>
-      <scope>compile</scope>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
     </dependency>
-      <dependency>
-          <groupId>org.alluxio</groupId>
-          <artifactId>alluxio-shell</artifactId>
-          <version>303-SNAPSHOT</version>
-      </dependency>
+    <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/dora/stress/shell/pom.xml
+++ b/dora/stress/shell/pom.xml
@@ -30,12 +30,9 @@
 
   <dependencies>
     <dependency>
-      <!-- External dependencies -->
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-hdfs</artifactId>

--- a/dora/tests/pom.xml
+++ b/dora/tests/pom.xml
@@ -31,7 +31,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
@@ -65,8 +64,6 @@
       <artifactId>junit</artifactId>
       <scope>compile</scope>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>

--- a/dora/tests/pom.xml
+++ b/dora/tests/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -56,11 +57,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
@@ -68,31 +64,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-minicluster</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-avro</artifactId>
     </dependency>
 
     <!-- Internal dependencies -->
@@ -143,11 +114,6 @@
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-transport</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-server-common</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -164,31 +130,22 @@
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-job-client</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-job-common</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-job-server</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-server-proxy</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-server-worker</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-transport</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-integration-fuse</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -212,13 +169,46 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-integration-fuse</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minicluster</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-s3a</artifactId>
+      <artifactId>alluxio-job-client</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-job-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-job-server</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
@@ -229,17 +219,70 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-s3a</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.gaul</groupId>
       <artifactId>s3proxy</artifactId>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Inject hadoop.version for tests to fetch at runtime -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <property>
+              <name>alluxio.hadoop.version</name>
+              <value>${hadoop.version}</value>
+            </property>
+          </systemProperties>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <testExcludes>
+            <!--By default we skip tests in hadoop/contract, unless contractTest profile is used-->
+            <exclude>**/hadoop/contract/**</exclude>
+          </testExcludes>
+        </configuration>
+      </plugin>
+
+      <!-- Export test classes in a test-jar so that other projects can use them for testing -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <!-- Profile to build tests module connecting to hdfs 2 -->
@@ -294,7 +337,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <testExcludes combine.self="override" />
+              <testExcludes combine.self="override"/>
             </configuration>
           </plugin>
         </plugins>
@@ -335,46 +378,4 @@
       </build>
     </profile>
   </profiles>
-
-  <build>
-    <plugins>
-      <!-- Inject hadoop.version for tests to fetch at runtime -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemProperties>
-            <property>
-              <name>alluxio.hadoop.version</name>
-              <value>${hadoop.version}</value>
-            </property>
-          </systemProperties>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <testExcludes>
-            <!--By default we skip tests in hadoop/contract, unless contractTest profile is used-->
-            <exclude>**/hadoop/contract/**</exclude>
-          </testExcludes>
-        </configuration>
-      </plugin>
-
-      <!-- Export test classes in a test-jar so that other projects can use them for testing -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/dora/underfs/abfs/pom.xml
+++ b/dora/underfs/abfs/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -11,126 +12,126 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <artifactId>alluxio-underfs</artifactId>
-        <groupId>org.alluxio</groupId>
-        <version>303-SNAPSHOT</version>
-    </parent>
-    <artifactId>alluxio-underfs-abfs</artifactId>
-    <name>Alluxio Under File System - Microsoft Azure DataLake Gen 2</name>
-    <description>Microsoft Azure DataLake Gen 2 Under File System implementation</description>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-underfs</artifactId>
+    <version>303-SNAPSHOT</version>
+  </parent>
+  <artifactId>alluxio-underfs-abfs</artifactId>
+  <name>Alluxio Under File System - Microsoft Azure DataLake Gen 2</name>
+  <description>Microsoft Azure DataLake Gen 2 Under File System implementation</description>
 
-    <properties>
-        <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
-        <!-- run properly from sub-project directories -->
-        <build.path>${project.parent.parent.parent.basedir}/build</build.path>
-        <ufs.hadoop.version>3.3.1</ufs.hadoop.version>
-    </properties>
+  <properties>
+    <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
+    <!-- run properly from sub-project directories -->
+    <build.path>${project.parent.parent.parent.basedir}/build</build.path>
+    <ufs.hadoop.version>3.3.1</ufs.hadoop.version>
+  </properties>
 
-    <dependencies>
-        <!-- External dependencies -->
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-azure</artifactId>
-            <version>${ufs.hadoop.version}</version>
-        </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-hdfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-azure</artifactId>
+      <version>${ufs.hadoop.version}</version>
+    </dependency>
 
-        <!-- Internal dependencies -->
-        <dependency>
-            <groupId>org.alluxio</groupId>
-            <artifactId>alluxio-core-common</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.alluxio</groupId>
-            <artifactId>alluxio-underfs-hdfs</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+    <!-- Internal dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
-        <!-- Internal test dependencies -->
-        <dependency>
-            <groupId>org.alluxio</groupId>
-            <artifactId>alluxio-core-common</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+    <!-- Internal test dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>shade</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>LICENSE</exclude>
-                                        <exclude>META-INF/LICENSE</exclude>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                        <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
-                                        <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>exec-maven-plugin</artifactId>
-                <groupId>org.codehaus.mojo</groupId>
-                <inherited>false</inherited>
-                <executions>
-                    <execution>
-                        <id>copy-lib-jars-selectively</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>${build.path}/lib/copy_jars.sh</executable>
-                            <arguments>
-                                <argument>${project.artifactId}</argument>
-                                <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${build.path}/../lib</directory>
-                            <includes>
-                                <include>**/${project.artifactId}-*.jar</include>
-                            </includes>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>LICENSE</exclude>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
+                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
+                  <excludes>
+                    <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>copy-lib-jars-selectively</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <executable>${build.path}/lib/copy_jars.sh</executable>
+              <arguments>
+                <argument>${project.artifactId}</argument>
+                <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${build.path}/../lib</directory>
+              <includes>
+                <include>**/${project.artifactId}-*.jar</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dora/underfs/abfs/pom.xml
+++ b/dora/underfs/abfs/pom.xml
@@ -35,14 +35,11 @@
       <artifactId>alluxio-underfs-hdfs</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- External dependencies -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure</artifactId>
       <version>${ufs.hadoop.version}</version>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -50,7 +47,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/underfs/adl/pom.xml
+++ b/dora/underfs/adl/pom.xml
@@ -35,14 +35,11 @@
       <artifactId>alluxio-underfs-hdfs</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- External dependencies -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure-datalake</artifactId>
       <version>${ufs.hadoop.version}</version>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -50,7 +47,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -58,8 +54,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-
-    <!-- External test dependencies -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/dora/underfs/adl/pom.xml
+++ b/dora/underfs/adl/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -29,6 +30,11 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-hdfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- External dependencies -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -43,18 +49,6 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-hdfs</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <!-- External test dependencies -->
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <!-- Internal test dependencies -->
     <dependency>
@@ -62,6 +56,13 @@
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- External test dependencies -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -74,10 +75,10 @@
         <executions>
           <execution>
             <id>shade</id>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <filters>
                 <filter>
@@ -104,16 +105,16 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/underfs/cephfs-hadoop/pom.xml
+++ b/dora/underfs/cephfs-hadoop/pom.xml
@@ -29,7 +29,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>io.github.opendataio</groupId>
       <artifactId>cephfs-hadoop</artifactId>
@@ -39,7 +38,6 @@
       <artifactId>alluxio-underfs-hdfs</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/underfs/cephfs-hadoop/pom.xml
+++ b/dora/underfs/cephfs-hadoop/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-underfs</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-underfs</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
 
@@ -33,17 +34,17 @@
       <groupId>io.github.opendataio</groupId>
       <artifactId>cephfs-hadoop</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-hdfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-hdfs</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <build>
@@ -54,10 +55,10 @@
         <executions>
           <execution>
             <id>shade</id>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <filters>
                 <filter>
@@ -82,16 +83,16 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/underfs/cephfs/pom.xml
+++ b/dora/underfs/cephfs/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -68,16 +69,16 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>
@@ -105,4 +106,3 @@
     </plugins>
   </build>
 </project>
-

--- a/dora/underfs/cephfs/pom.xml
+++ b/dora/underfs/cephfs/pom.xml
@@ -27,14 +27,11 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>io.github.opendataio</groupId>
       <artifactId>libcephfs</artifactId>
       <scope>provided</scope>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -42,7 +39,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/underfs/cos/pom.xml
+++ b/dora/underfs/cos/pom.xml
@@ -29,7 +29,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.qcloud</groupId>
       <artifactId>cos_api</artifactId>
@@ -38,8 +37,6 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -47,7 +44,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/underfs/cos/pom.xml
+++ b/dora/underfs/cos/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -63,16 +64,16 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/underfs/cosn/pom.xml
+++ b/dora/underfs/cosn/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -41,17 +42,17 @@
       <artifactId>hadoop-cos</artifactId>
       <version>${ufs.cosn.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-hdfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-hdfs</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>
@@ -64,52 +65,52 @@
 
   <build>
     <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>shade</id>
-              <phase>package</phase>
-              <goals>
-                <goal>shade</goal>
-              </goals>
-              <configuration>
-                <filters>
-                  <filter>
-                    <artifact>*:*</artifact>
-                    <excludes>
-                      <exclude>LICENSE</exclude>
-                      <exclude>META-INF/LICENSE</exclude>
-                      <exclude>META-INF/*.SF</exclude>
-                      <exclude>META-INF/*.DSA</exclude>
-                      <exclude>META-INF/*.RSA</exclude>
-                      <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
-                      <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
-                    </excludes>
-                  </filter>
-                  <filter>
-                    <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
-                    <excludes>
-                      <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>
-                    </excludes>
-                  </filter>
-                </filters>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>LICENSE</exclude>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
+                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
+                  <excludes>
+                    <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/underfs/cosn/pom.xml
+++ b/dora/underfs/cosn/pom.xml
@@ -32,7 +32,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.qcloud</groupId>
       <artifactId>cos_api-bundle</artifactId>
@@ -47,7 +46,6 @@
       <artifactId>alluxio-underfs-hdfs</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/underfs/gcs/pom.xml
+++ b/dora/underfs/gcs/pom.xml
@@ -37,13 +37,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <!-- External dependencies -->
     <dependency>
       <groupId>net.java.dev.jets3t</groupId>
       <artifactId>jets3t</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -51,7 +48,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/underfs/gcs/pom.xml
+++ b/dora/underfs/gcs/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -28,11 +29,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
-    <dependency>
-      <groupId>net.java.dev.jets3t</groupId>
-      <artifactId>jets3t</artifactId>
-    </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
@@ -40,6 +36,11 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+    </dependency>
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>net.java.dev.jets3t</groupId>
+      <artifactId>jets3t</artifactId>
     </dependency>
 
     <!-- Internal dependencies -->
@@ -67,16 +68,16 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>Copy liob jars selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/underfs/hdfs/pom.xml
+++ b/dora/underfs/hdfs/pom.xml
@@ -31,14 +31,11 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <!-- Hadoop dependencies are included in individual profiles -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -46,7 +43,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/underfs/hdfs/pom.xml
+++ b/dora/underfs/hdfs/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -55,128 +56,19 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <!-- Profile to build this UFS module connecting to hdfs 2 -->
-    <profile>
-      <!-- Decouple hadoop profiles: hadoop-2 to indicate north bound and ufs-hadoop-2 to indicate the south bound -->
-      <id>ufs-hadoop-2</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.alluxio</groupId>
-          <artifactId>alluxio-shaded-hadoop</artifactId>
-          <version>${ufs.hadoop.version}</version>
-        </dependency>
-      </dependencies>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default-testCompile</id>
-                <phase>test-compile</phase>
-                <configuration>
-                  <testExcludes>
-                    <!-- Skip hdfs3 related tests in hdfs2 profile -->
-                    <exclude>**/hdfs3/**</exclude>
-                  </testExcludes>
-                </configuration>
-                <goals>
-                  <goal>testCompile</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- Profile to build this UFS module connecting to hdfs 3, this is the default profile -->
-    <profile>
-      <id>ufs-hadoop-3</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.alluxio</groupId>
-          <artifactId>alluxio-shaded-hadoop</artifactId>
-          <version>${ufs.hadoop.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-minicluster</artifactId>
-          <version>${ufs.hadoop.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>hdfsAclandActiveSync</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <excludes combine.self="override">
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>hdfsAcl</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <excludes combine.self="override">
-                <exclude>**/SupportedHdfsActiveSyncProvider.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>hdfsActiveSync</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <excludes combine.self="override">
-                <exclude>**/SupportedHdfsAclProvider.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
       <!-- Export test classes in a test-jar so that other projects can use them for testing -->
       <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-jar-plugin</artifactId>
-      <executions>
-        <execution>
-          <goals>
-            <goal>test-jar</goal>
-          </goals>
-        </execution>
-      </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -193,16 +85,16 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>
@@ -245,4 +137,112 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- Profile to build this UFS module connecting to hdfs 2 -->
+    <profile>
+      <!-- Decouple hadoop profiles: hadoop-2 to indicate north bound and ufs-hadoop-2 to indicate the south bound -->
+      <id>ufs-hadoop-2</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.alluxio</groupId>
+          <artifactId>alluxio-shaded-hadoop</artifactId>
+          <version>${ufs.hadoop.version}</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-testCompile</id>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <phase>test-compile</phase>
+                <configuration>
+                  <testExcludes>
+                    <!-- Skip hdfs3 related tests in hdfs2 profile -->
+                    <exclude>**/hdfs3/**</exclude>
+                  </testExcludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Profile to build this UFS module connecting to hdfs 3, this is the default profile -->
+    <profile>
+      <id>ufs-hadoop-3</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.alluxio</groupId>
+          <artifactId>alluxio-shaded-hadoop</artifactId>
+          <version>${ufs.hadoop.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-minicluster</artifactId>
+          <version>${ufs.hadoop.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>hdfsAclandActiveSync</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <excludes combine.self="override"/>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>hdfsAcl</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <excludes combine.self="override">
+                <exclude>**/SupportedHdfsActiveSyncProvider.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>hdfsActiveSync</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <excludes combine.self="override">
+                <exclude>**/SupportedHdfsAclProvider.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/dora/underfs/kodo/pom.xml
+++ b/dora/underfs/kodo/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -11,89 +12,88 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>alluxio-underfs</artifactId>
-        <groupId>org.alluxio</groupId>
-        <version>303-SNAPSHOT</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-underfs</artifactId>
+    <version>303-SNAPSHOT</version>
+  </parent>
 
+  <artifactId>alluxio-underfs-kodo</artifactId>
+  <name>Alluxio Under File System - Qiniu Kodo</name>
+  <description>Qiniu Kodo Under File System implementation</description>
 
-    <artifactId>alluxio-underfs-kodo</artifactId>
-    <name>Alluxio Under File System - Qiniu Kodo</name>
-    <description>Qiniu Kodo Under File System implementation</description>
+  <properties>
+    <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
+    <!-- run properly from sub-project directories -->
+    <build.path>${project.parent.parent.parent.basedir}/build</build.path>
+  </properties>
 
-    <properties>
-        <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
-        <!-- run properly from sub-project directories -->
-        <build.path>${project.parent.parent.parent.basedir}/build</build.path>
-    </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.qiniu</groupId>
+      <artifactId>qiniu-java-sdk</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.qiniu</groupId>
-            <artifactId>qiniu-java-sdk</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.alluxio</groupId>
-            <artifactId>alluxio-core-common</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.alluxio</groupId>
-            <artifactId>alluxio-core-common</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>exec-maven-plugin</artifactId>
-                <groupId>org.codehaus.mojo</groupId>
-                <inherited>false</inherited>
-                <executions>
-                    <execution>
-                        <id>copy-lib-jars-selectively</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>${build.path}/lib/copy_jars.sh</executable>
-                            <arguments>
-                                <argument>${project.artifactId}</argument>
-                                <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${build.path}/../lib</directory>
-                            <includes>
-                                <include>**/${project.artifactId}-*.jar</include>
-                            </includes>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>copy-lib-jars-selectively</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <executable>${build.path}/lib/copy_jars.sh</executable>
+              <arguments>
+                <argument>${project.artifactId}</argument>
+                <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${build.path}/../lib</directory>
+              <includes>
+                <include>**/${project.artifactId}-*.jar</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dora/underfs/local/pom.xml
+++ b/dora/underfs/local/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -52,16 +53,16 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/underfs/local/pom.xml
+++ b/dora/underfs/local/pom.xml
@@ -29,14 +29,13 @@
   </properties>
 
   <dependencies>
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <!-- Internal test dependencies -->
+
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/underfs/obs/pom.xml
+++ b/dora/underfs/obs/pom.xml
@@ -29,21 +29,18 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.huaweicloud</groupId>
       <artifactId>esdk-obs-java</artifactId>
       <version>${obs.version}</version>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <!-- Internal test dependencies -->
+
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -51,8 +48,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-
-    <!-- External test dependencies -->
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>

--- a/dora/underfs/obs/pom.xml
+++ b/dora/underfs/obs/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -11,101 +12,101 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <artifactId>alluxio-underfs</artifactId>
-        <groupId>org.alluxio</groupId>
-        <version>303-SNAPSHOT</version>
-    </parent>
-    <artifactId>alluxio-underfs-obs</artifactId>
-    <name>Alluxio Under File System - Huawei OBS</name>
-    <description>Huawei OBS Under File System implementation</description>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-underfs</artifactId>
+    <version>303-SNAPSHOT</version>
+  </parent>
+  <artifactId>alluxio-underfs-obs</artifactId>
+  <name>Alluxio Under File System - Huawei OBS</name>
+  <description>Huawei OBS Under File System implementation</description>
 
-    <properties>
-        <build.path>${project.parent.parent.parent.basedir}/build</build.path>
-        <hamcrest.version>1.3</hamcrest.version>
-        <obs.version>3.20.6</obs.version>
-    </properties>
+  <properties>
+    <build.path>${project.parent.parent.parent.basedir}/build</build.path>
+    <hamcrest.version>1.3</hamcrest.version>
+    <obs.version>3.20.6</obs.version>
+  </properties>
 
-    <dependencies>
-        <!-- External dependencies -->
-        <dependency>
-            <groupId>com.huaweicloud</groupId>
-            <artifactId>esdk-obs-java</artifactId>
-            <version>${obs.version}</version>
-        </dependency>
+  <dependencies>
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>com.huaweicloud</groupId>
+      <artifactId>esdk-obs-java</artifactId>
+      <version>${obs.version}</version>
+    </dependency>
 
-        <!-- Internal dependencies -->
-        <dependency>
-            <groupId>org.alluxio</groupId>
-            <artifactId>alluxio-core-common</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
+    <!-- Internal dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Internal test dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
 
-        <!-- External test dependencies -->
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <!-- Internal test dependencies -->
-        <dependency>
-            <groupId>org.alluxio</groupId>
-            <artifactId>alluxio-core-common</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+    <!-- External test dependencies -->
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>exec-maven-plugin</artifactId>
-                <groupId>org.codehaus.mojo</groupId>
-                <inherited>false</inherited>
-                <executions>
-                    <execution>
-                        <id>copy-lib-jars-selectively</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>${build.path}/lib/copy_jars.sh</executable>
-                            <arguments>
-                                <argument>${project.artifactId}</argument>
-                                <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
-                                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${build.path}/../lib</directory>
-                            <includes>
-                                <include>**/${project.artifactId}-*.jar</include>
-                            </includes>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>copy-lib-jars-selectively</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <executable>${build.path}/lib/copy_jars.sh</executable>
+              <arguments>
+                <argument>${project.artifactId}</argument>
+                <argument>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</argument>
+                <argument>${build.path}/../lib/${project.artifactId}-${project.version}.jar</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${build.path}/../lib</directory>
+              <includes>
+                <include>**/${project.artifactId}-*.jar</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dora/underfs/oss/pom.xml
+++ b/dora/underfs/oss/pom.xml
@@ -29,7 +29,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.aliyun.oss</groupId>
       <artifactId>aliyun-sdk-oss</artifactId>
@@ -38,8 +37,6 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>
-
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -47,7 +44,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/underfs/oss/pom.xml
+++ b/dora/underfs/oss/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -68,16 +69,16 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/underfs/ozone/pom.xml
+++ b/dora/underfs/ozone/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -13,8 +14,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>alluxio-underfs</artifactId>
     <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-underfs</artifactId>
     <version>303-SNAPSHOT</version>
   </parent>
 
@@ -25,12 +26,34 @@
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.basedir}/build</build.path>
-    <ufs.ozone.version>1.2.1</ufs.ozone.version>
-    <shading.prefix>alluxio.shaded.hdfs</shading.prefix>
     <ozone.metrics.version>3.2.5</ozone.metrics.version>
+    <shading.prefix>alluxio.shaded.hdfs</shading.prefix>
+    <ufs.ozone.version>1.2.1</ufs.ozone.version>
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>${ozone.metrics.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-hdfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-client</artifactId>
+      <version>${ufs.ozone.version}</version>
+    </dependency>
+    <!-- Internal dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- External dependencies -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -43,76 +66,16 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.ozone</groupId>
-      <artifactId>ozone-client</artifactId>
-      <version>${ufs.ozone.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>${ozone.metrics.version}</version>
-    </dependency>
-    <!-- Internal dependencies -->
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-common</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-hdfs</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>ufs-hadoop-2</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.ozone</groupId>
-          <artifactId>ozone-filesystem-hadoop2</artifactId>
-          <version>${ufs.ozone.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>io.dropwizard.metrics</groupId>
-              <artifactId>metrics-core</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>ufs-hadoop-3</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.ozone</groupId>
-          <artifactId>ozone-filesystem-hadoop3</artifactId>
-          <version>${ufs.ozone.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>io.dropwizard.metrics</groupId>
-              <artifactId>metrics-core</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 
   <build>
     <plugins>
@@ -122,10 +85,10 @@
         <executions>
           <execution>
             <id>shade</id>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <relocations>
                 <relocation>
@@ -134,7 +97,7 @@
                 </relocation>
               </relocations>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <artifactSet>
                 <excludes>
@@ -171,16 +134,16 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>
@@ -223,4 +186,42 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>ufs-hadoop-2</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.ozone</groupId>
+          <artifactId>ozone-filesystem-hadoop2</artifactId>
+          <version>${ufs.ozone.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>io.dropwizard.metrics</groupId>
+              <artifactId>metrics-core</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>ufs-hadoop-3</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.ozone</groupId>
+          <artifactId>ozone-filesystem-hadoop3</artifactId>
+          <version>${ufs.ozone.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>io.dropwizard.metrics</groupId>
+              <artifactId>metrics-core</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/dora/underfs/ozone/pom.xml
+++ b/dora/underfs/ozone/pom.xml
@@ -47,14 +47,13 @@
       <artifactId>ozone-client</artifactId>
       <version>${ufs.ozone.version}</version>
     </dependency>
-    <!-- Internal dependencies -->
+
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <!-- External dependencies -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>

--- a/dora/underfs/pom.xml
+++ b/dora/underfs/pom.xml
@@ -50,7 +50,6 @@
   </modules>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/dora/underfs/pom.xml
+++ b/dora/underfs/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -22,6 +23,12 @@
   <name>Alluxio Under File System</name>
   <description>Parent POM for different implementations of Alluxio under file system</description>
 
+  <properties>
+    <!-- These need to be defined here as well as in the parent pom so that mvn can run
+         properly from sub-project directories -->
+    <build.path>${project.parent.parent.basedir}/build</build.path>
+  </properties>
+
   <modules>
     <module>abfs</module>
     <module>adl</module>
@@ -42,12 +49,6 @@
     <module>obs</module>
   </modules>
 
-  <properties>
-    <!-- These need to be defined here as well as in the parent pom so that mvn can run
-         properly from sub-project directories -->
-    <build.path>${project.parent.parent.basedir}/build</build.path>
-  </properties>
-
   <dependencies>
     <!-- External dependencies -->
     <dependency>
@@ -66,9 +67,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.gaul</groupId>
-      <artifactId>s3proxy</artifactId>
-      <scope>test</scope>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -76,9 +77,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <scope>provided</scope>
+      <groupId>org.gaul</groupId>
+      <artifactId>s3proxy</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -91,14 +92,14 @@
           <executions>
             <execution>
               <id>shade</id>
-              <phase>package</phase>
               <goals>
                 <goal>shade</goal>
               </goals>
+              <phase>package</phase>
               <configuration>
                 <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
                 <transformers>
-                  <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                  <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 </transformers>
                 <filters>
                   <filter>

--- a/dora/underfs/s3a/pom.xml
+++ b/dora/underfs/s3a/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -42,26 +43,20 @@
       <artifactId>aws-java-sdk-sts</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>s3</artifactId>
+      <artifactId>netty-nio-client</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>netty-nio-client</artifactId>
-    </dependency>
-    <!--aws sdk requires jaxb binding at runtime-->
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
+      <artifactId>s3</artifactId>
     </dependency>
 
     <!-- Internal dependencies -->
@@ -70,6 +65,12 @@
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <!--aws sdk requires jaxb binding at runtime-->
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Internal test dependencies -->
@@ -89,16 +90,16 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/underfs/s3a/pom.xml
+++ b/dora/underfs/s3a/pom.xml
@@ -29,7 +29,6 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
@@ -59,7 +58,6 @@
       <artifactId>s3</artifactId>
     </dependency>
 
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -73,7 +71,6 @@
       <scope>runtime</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/underfs/swift/pom.xml
+++ b/dora/underfs/swift/pom.xml
@@ -29,13 +29,11 @@
   </properties>
 
   <dependencies>
-    <!-- External dependencies -->
     <dependency>
       <groupId>org.javaswift</groupId>
       <artifactId>joss</artifactId>
     </dependency>
 
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -43,7 +41,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/dora/underfs/swift/pom.xml
+++ b/dora/underfs/swift/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -59,16 +60,16 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/underfs/wasb/pom.xml
+++ b/dora/underfs/wasb/pom.xml
@@ -35,14 +35,12 @@
       <artifactId>alluxio-underfs-hdfs</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- External dependencies -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure</artifactId>
       <version>${ufs.hadoop.version}</version>
     </dependency>
 
-    <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -50,7 +48,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
@@ -58,8 +55,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-
-    <!-- External test dependencies -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/dora/underfs/wasb/pom.xml
+++ b/dora/underfs/wasb/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -29,6 +30,11 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-hdfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- External dependencies -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -43,18 +49,6 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-hdfs</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <!-- External test dependencies -->
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <!-- Internal test dependencies -->
     <dependency>
@@ -62,6 +56,13 @@
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- External test dependencies -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -74,10 +75,10 @@
         <executions>
           <execution>
             <id>shade</id>
-            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <filters>
                 <filter>
@@ -104,16 +105,16 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/underfs/web/pom.xml
+++ b/dora/underfs/web/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -28,17 +29,17 @@
   </properties>
 
   <dependencies>
+
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+    </dependency>
     <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
     </dependency>
   </dependencies>
 
@@ -49,16 +50,16 @@
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>copy-lib-jars-selectively</id>
-            <phase>install</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>install</phase>
             <configuration>
               <executable>${build.path}/lib/copy_jars.sh</executable>
               <arguments>

--- a/dora/underfs/web/pom.xml
+++ b/dora/underfs/web/pom.xml
@@ -34,7 +34,7 @@
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
     </dependency>
-    <!-- Internal dependencies -->
+
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1106,6 +1106,11 @@
           <artifactId>templating-maven-plugin</artifactId>
           <version>1.0.0</version>
         </plugin>
+        <plugin>
+          <groupId>com.github.ekryd.sortpom</groupId>
+          <artifactId>sortpom-maven-plugin</artifactId>
+          <version>3.0.1</version>
+        </plugin>
         <!-- REST Documentation plugin -->
         <plugin>
           <groupId>com.github.kongchen</groupId>
@@ -1408,6 +1413,45 @@
             <configuration>
               <executable>${build.path}/version/write_version.sh</executable>
               <arguments>${project.version}</arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.github.ekryd.sortpom</groupId>
+        <artifactId>sortpom-maven-plugin</artifactId>
+        <configuration>
+          <encoding>${project.build.sourceEncoding}</encoding>
+          <expandEmptyElements>false</expandEmptyElements>
+          <keepBlankLines>true</keepBlankLines>
+          <lineSeparator>\n</lineSeparator>
+          <sortOrderFile>build/sortpom/alluxio_pom.xml</sortOrderFile>
+          <sortDependencies>scope,groupId,artifactId</sortDependencies>
+          <sortProperties>true</sortProperties>
+        </configuration>
+        <executions>
+          <execution>
+            <!-- validate if a pom file is sorted, fail the build if it is not sorted -->
+            <id>default-cli</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <verifyFail>stop</verifyFail>
+              <verifyFailOn>strict</verifyFailOn>
+              <violationFilename>target/sortpom_reports/violation.xml</violationFilename>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- sort a pom file in place, note this will modify the pom file -->
+            <id>manual-sort</id>
+            <goals>
+              <goal>sort</goal>
+            </goals>
+            <configuration>
+              <createBackupFile>true</createBackupFile>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -12,6 +13,12 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+  </parent>
   <groupId>org.alluxio</groupId>
   <artifactId>alluxio-parent</artifactId>
   <version>303-SNAPSHOT</version>
@@ -29,9 +36,13 @@
   <scm>
     <connection>scm:git:git@github.com:alluxio/alluxio.git</connection>
     <developerConnection>scm:git:git@github.com:alluxio/alluxio.git</developerConnection>
-    <url>scm:git:git@github.com:alluxio/alluxio.git</url>
     <tag>alluxio-parent-303-SNAPSHOT</tag>
+    <url>scm:git:git@github.com:alluxio/alluxio.git</url>
   </scm>
+  <issueManagement>
+    <system>jira</system>
+    <url>https://alluxio.atlassian.net</url>
+  </issueManagement>
   <developers>
     <developer>
       <id>haoyuan</id>
@@ -42,57 +53,43 @@
       <organizationUrl>https://alluxio.io/</organizationUrl>
     </developer>
   </developers>
-  <issueManagement>
-    <system>jira</system>
-    <url>https://alluxio.atlassian.net</url>
-  </issueManagement>
-
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
 
   <repositories>
     <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
       <id>central</id>
       <!-- This should be at top, it makes maven try the central repo first and then others and hence faster dep resolution -->
       <name>Maven Repository</name>
       <url>https://repo1.maven.org/maven2</url>
+    </repository>
+    <repository>
       <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-    </repository>
-    <repository>
       <id>apache-repo</id>
       <name>Apache Repository</name>
       <url>https://repository.apache.org/content/repositories/releases</url>
+    </repository>
+    <repository>
       <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-    </repository>
-    <repository>
       <id>cloudera-repo</id>
       <name>Cloudera Repository</name>
       <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
     </repository>
     <repository>
-      <id>HDPReleases</id>
-      <name>HDP Releases</name>
-      <url>https://repo.hortonworks.com/content/repositories/releases/</url>
-      <layout>default</layout>
       <releases>
         <enabled>true</enabled>
         <updatePolicy>always</updatePolicy>
@@ -103,17 +100,21 @@
         <updatePolicy>never</updatePolicy>
         <checksumPolicy>fail</checksumPolicy>
       </snapshots>
+      <id>HDPReleases</id>
+      <name>HDP Releases</name>
+      <url>https://repo.hortonworks.com/content/repositories/releases/</url>
+      <layout>default</layout>
     </repository>
     <repository>
-      <id>bintray-repo</id>
-      <name>bintray</name>
-      <url>https://jcenter.bintray.com</url>
       <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+      <id>bintray-repo</id>
+      <name>bintray</name>
+      <url>https://jcenter.bintray.com</url>
     </repository>
     <repository>
       <id>alluxio.artifacts</id>
@@ -123,7 +124,7 @@
 
   <properties>
     <apache.curator.version>4.2.0</apache.curator.version>
-    <argLine />
+    <argLine/>
     <aws.amazonaws.version>1.11.815</aws.amazonaws.version>
     <awssdk.version>2.20.56</awssdk.version>
     <build.path>build</build.path>
@@ -190,6 +191,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>s3</artifactId>
+        <version>${awssdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- Compile scope -->
       <dependency>
         <groupId>com.aliyun.oss</groupId>
@@ -203,12 +211,12 @@
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-sts</artifactId>
+        <artifactId>aws-java-sdk-s3</artifactId>
         <version>${aws.amazonaws.version}</version>
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-s3</artifactId>
+        <artifactId>aws-java-sdk-sts</artifactId>
         <version>${aws.amazonaws.version}</version>
       </dependency>
       <dependency>
@@ -257,6 +265,11 @@
         <version>${stateless4j.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-storage</artifactId>
+        <version>1.79.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${gson.version}</version>
@@ -265,11 +278,6 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-storage</artifactId>
-        <version>1.79.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject</groupId>
@@ -338,14 +346,14 @@
         <version>1.13</version>
       </dependency>
       <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>1.2</version>
-      </dependency>
-      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.7</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.2</version>
       </dependency>
       <dependency>
         <groupId>io.atomix.catalyst</groupId>
@@ -364,18 +372,23 @@
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
-        <artifactId>metrics-json</artifactId>
+        <artifactId>metrics-jmx</artifactId>
         <version>${metrics.version}</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
-        <artifactId>metrics-jmx</artifactId>
+        <artifactId>metrics-json</artifactId>
         <version>${metrics.version}</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-jvm</artifactId>
         <version>${metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.etcd</groupId>
+        <artifactId>jetcd-core</artifactId>
+        <version>0.7.5</version>
       </dependency>
       <dependency>
         <groupId>io.github.opendataio</groupId>
@@ -386,11 +399,6 @@
         <groupId>io.github.opendataio</groupId>
         <artifactId>libcephfs</artifactId>
         <version>${libcephfs.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.etcd</groupId>
-        <artifactId>jetcd-core</artifactId>
-        <version>0.7.5</version>
       </dependency>
       <dependency>
         <groupId>io.grpc</groupId>
@@ -451,18 +459,23 @@
       </dependency>
       <dependency>
         <groupId>io.prometheus</groupId>
-        <artifactId>simpleclient_servlet</artifactId>
+        <artifactId>simpleclient_dropwizard</artifactId>
         <version>${prometheus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.prometheus</groupId>
-        <artifactId>simpleclient_dropwizard</artifactId>
+        <artifactId>simpleclient_servlet</artifactId>
         <version>${prometheus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-annotations</artifactId>
         <version>1.6.2</version>
+      </dependency>
+      <dependency>
+        <groupId>it.unimi.dsi</groupId>
+        <artifactId>fastutil-core</artifactId>
+        <version>${fastutil.version}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.ws.rs</groupId>
@@ -656,16 +669,6 @@
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.lz4</groupId>
-        <artifactId>lz4-java</artifactId>
-        <version>1.8.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jline</groupId>
-        <artifactId>jline</artifactId>
-        <version>3.16.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>jersey-container-servlet-core</artifactId>
         <version>${jersey.version}</version>
@@ -695,11 +698,21 @@
         <artifactId>joss</artifactId>
         <version>0.10.4</version>
       </dependency>
+      <dependency>
+        <groupId>org.jline</groupId>
+        <artifactId>jline</artifactId>
+        <version>3.16.0</version>
+      </dependency>
       <!-- https://mvnrepository.com/artifact/org.jsoup/jsoup -->
       <dependency>
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
         <version>1.15.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>1.8.0</version>
       </dependency>
       <dependency>
         <groupId>org.reflections</groupId>
@@ -718,13 +731,6 @@
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
-        <artifactId>s3</artifactId>
-        <version>${awssdk.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
         <artifactId>netty-nio-client</artifactId>
         <version>${awssdk.version}</version>
       </dependency>
@@ -732,11 +738,6 @@
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3</artifactId>
         <version>${awssdk.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>it.unimi.dsi</groupId>
-        <artifactId>fastutil-core</artifactId>
-        <version>${fastutil.version}</version>
       </dependency>
 
       <!-- Test scope -->
@@ -921,8 +922,8 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <artifactId>xstream</artifactId>
           <groupId>com.thoughtworks.xstream</groupId>
+          <artifactId>xstream</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1116,14 +1117,6 @@
           <groupId>com.github.kongchen</groupId>
           <artifactId>swagger-maven-plugin</artifactId>
           <version>3.1.7</version>
-          <executions>
-            <execution>
-              <phase>compile</phase>
-              <goals>
-                <goal>generate</goal>
-              </goals>
-            </execution>
-          </executions>
           <dependencies>
             <dependency>
               <groupId>javax.xml.bind</groupId>
@@ -1131,6 +1124,14 @@
               <version>2.3.1</version>
             </dependency>
           </dependencies>
+          <executions>
+            <execution>
+              <goals>
+                <goal>generate</goal>
+              </goals>
+              <phase>compile</phase>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -1213,15 +1214,6 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>get-the-git-infos</id>
-            <goals>
-              <goal>revision</goal>
-            </goals>
-            <phase>initialize</phase>
-          </execution>
-        </executions>
         <configuration>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
           <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
@@ -1233,6 +1225,15 @@
           </includeOnlyProperties>
           <commitIdGenerationMode>full</commitIdGenerationMode>
         </configuration>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
       </plugin>
 
       <!-- SpotBugs -->
@@ -1255,10 +1256,10 @@
         </configuration>
         <executions>
           <execution>
-            <phase>compile</phase>
             <goals>
               <goal>check</goal>
             </goals>
+            <phase>compile</phase>
           </execution>
         </executions>
       </plugin>
@@ -1268,13 +1269,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.1.2</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>9.0.1</version>
-          </dependency>
-        </dependencies>
         <configuration>
           <configLocation>${build.path}/checkstyle/alluxio_checks.xml</configLocation>
           <suppressionsLocation>${build.path}/checkstyle/suppressions.xml</suppressionsLocation>
@@ -1291,13 +1285,20 @@
           <failsOnError>true</failsOnError>
           <linkXRef>false</linkXRef>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>9.0.1</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>checkstyle</id>
-            <phase>validate</phase>
             <goals>
               <goal>check</goal>
             </goals>
+            <phase>validate</phase>
           </execution>
         </executions>
       </plugin>
@@ -1379,26 +1380,26 @@
         </configuration>
         <executions>
           <execution>
-            <phase>validate</phase>
             <goals>
               <goal>check</goal>
             </goals>
+            <phase>validate</phase>
           </execution>
         </executions>
       </plugin>
 
       <plugin>
-        <artifactId>exec-maven-plugin</artifactId>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
         <inherited>false</inherited>
         <executions>
           <!-- Prevent Windows line endings -->
           <execution>
             <id>Check that there are no Windows line endings</id>
-            <phase>compile</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>compile</phase>
             <configuration>
               <executable>${build.path}/style/check_no_windows_line_endings.sh</executable>
             </configuration>
@@ -1406,10 +1407,10 @@
           <!-- Create libexec/version.sh -->
           <execution>
             <id>Write version string in generated packaged script</id>
-            <phase>compile</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>compile</phase>
             <configuration>
               <executable>${build.path}/version/write_version.sh</executable>
               <arguments>${project.version}</arguments>
@@ -1550,16 +1551,16 @@
       <build>
         <plugins>
           <plugin>
-            <artifactId>exec-maven-plugin</artifactId>
             <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
             <inherited>false</inherited>
             <executions>
               <execution>
                 <id>Generate documentation</id>
-                <phase>compile</phase>
                 <goals>
                   <goal>exec</goal>
                 </goals>
+                <phase>compile</phase>
                 <configuration>
                   <executable>jekyll</executable>
                   <arguments>
@@ -1583,8 +1584,8 @@
           <!-- to use instrument, jacoco must be on the classpath -->
           <groupId>org.jacoco</groupId>
           <artifactId>org.jacoco.agent</artifactId>
-          <classifier>runtime</classifier>
           <version>${jacoco.version}</version>
+          <classifier>runtime</classifier>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -1615,10 +1616,10 @@
               <execution>
                 <!-- offline instrumentation is required, for jacoco to work with powermock tests -->
                 <id>jacoco-unit-restore-instrumented-classes</id>
-                <phase>test</phase>
                 <goals>
                   <goal>restore-instrumented-classes</goal>
                 </goals>
+                <phase>test</phase>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1427,7 +1427,7 @@
           <expandEmptyElements>false</expandEmptyElements>
           <keepBlankLines>true</keepBlankLines>
           <lineSeparator>\n</lineSeparator>
-          <sortOrderFile>build/sortpom/alluxio_pom.xml</sortOrderFile>
+          <sortOrderFile>${build.path}/sortpom/alluxio_pom.xml</sortOrderFile>
           <sortDependencies>scope,groupId,artifactId</sortDependencies>
           <sortProperties>true</sortProperties>
         </configuration>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -59,17 +60,17 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
-        <groupId>org.codehaus.mojo</groupId>
         <inherited>false</inherited>
         <executions>
           <execution>
             <id>Remove cached node modules and built web applications</id>
-            <phase>clean</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>clean</phase>
             <configuration>
               <executable>rm</executable>
               <arguments>
@@ -87,10 +88,10 @@
           </execution>
           <execution>
             <id>Install npm dependencies for packages</id>
-            <phase>process-sources</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>process-sources</phase>
             <configuration>
               <executable>node/node</executable>
               <arguments>
@@ -102,10 +103,10 @@
           </execution>
           <execution>
             <id>Build all packages</id>
-            <phase>generate-resources</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>generate-resources</phase>
             <configuration>
               <executable>node/node</executable>
               <arguments>
@@ -119,16 +120,17 @@
           </execution>
           <execution>
             <id>Test all packages</id>
-            <phase>test</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>test</phase>
             <configuration>
               <executable>node/node</executable>
               <arguments>
                 <argument>node_modules/.bin/lerna</argument>
                 <argument>run</argument>
-                <argument>test-ci</argument> <!-- NOTE: using the "test" command here will hang execution -->
+                <argument>test-ci</argument>
+                <!-- NOTE: using the "test" command here will hang execution -->
                 <argument>--</argument>
                 <argument>--production  --no-save --no-package-lock --no-shrinkwrap</argument>
               </arguments>
@@ -136,10 +138,10 @@
           </execution>
           <execution>
             <id>run-linter</id>
-            <phase>verify</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>verify</phase>
             <configuration>
               <executable>node/node</executable>
               <arguments>
@@ -189,9 +191,9 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.4.0</version>
-            <groupId>org.codehaus.mojo</groupId>
             <inherited>false</inherited>
             <executions>
               <execution>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Sort sections in pom files.

1. A new maven plugin `sortpom` is introduced to sort the pom files.

2. A template file `build/sortpom/alluxio_pom.xml` is used as a reference for the orders of the sections in the pom files. Notably, dependencies will be sorted by their scope first, then by group ID and artifact ID.

3. A build time check is added to validate if the pom files are well sorted. If changes to the pom files will cause them to be unsorted, the sortpom plugin will fail the build with an error. The plugin offers a way to automatically fix unsorted poms by running `mvn sortpom:sort`.

4. Differentiation between internal and external dependencies, is removed. They exist now as comments in the pom files. However, the convention of separating external and internal dependencies is not well observed, and multiple violations occur throughout the codebase. After this PR, the dependencies are sorted lexically, which ensures all Alluxio internal dependencies are always grouped together.

### Why are the changes needed?

A sorted pom file helps reduce merge conflicts, easier to spot duplicate dependencies.

### Does this PR introduce any user facing changes?

No.
