### PR TITLE
Skip sortpom when running tests and during build

### DIFF
--- a/dev/github/run_tests.sh
+++ b/dev/github/run_tests.sh
@@ -38,7 +38,7 @@ PATH_BACKUP=${PATH}
 JAVA_HOME=/usr/local/openjdk-8
 PATH=$JAVA_HOME/bin:$PATH
 mvn -Duser.home=/home/jenkins -T 4C clean install -Dfindbugs.skip -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip \
--Dlicense.skip ${mvn_args}
+-Dlicense.skip -Dsort.skip ${mvn_args}
 
 # Set things up so that the current user has a real name and can authenticate.
 myuid=$(id -u)
@@ -56,4 +56,4 @@ fi
 
 # Run tests
 mvn -Duser.home=/home/jenkins test -Dmaven.main.skip -Dskip.protoc=true -Dmaven.javadoc.skip -Dlicense.skip=true \
--Dcheckstyle.skip=true -Dfindbugs.skip=true -Dsurefire.forkCount=${ALLUXIO_FORK_COUNT} ${mvn_args}
+-Dcheckstyle.skip=true -Dfindbugs.skip=true -Dsort.skip -Dsurefire.forkCount=${ALLUXIO_FORK_COUNT} ${mvn_args}

--- a/pom.xml
+++ b/pom.xml
@@ -1464,6 +1464,9 @@
             <goals>
               <goal>sort</goal>
             </goals>
+            <!-- Empty phase to skip automatically running this as part of a build process -->
+            <!-- Still invokable by running `mvn sortpom:sort@manual-sort` from the command line -->
+            <phase/>
             <configuration>
               <createBackupFile>true</createBackupFile>
             </configuration>


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Skip validating if the poms are sorted when running UT/integration tests in GitHub CI.
2. Skip sorting the pom files in-place during build. 

### Why are the changes needed?

1. Avoid failing tests just because a developer forgets to sort the pom files. The `Checkstyle, findbugs, etc.` checks will still catch it.
2. This is undesirable during CI as it silently modifies the pom file without giving a warning. However, the auto sort is still accessible by directly running `mvn sortpom:sort@manual-sort` from the command line. This can be handy for a developer that needs to incorporate large chunks of pom changes.

### Does this PR introduce any user facing changes?

No.
