### PR TITLE
Add job subcommand to CLI

### DIFF
--- a/cli/src/alluxio.org/cli/cmd/job/cancel.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cancel.go
@@ -38,7 +38,7 @@ func (c *CancelCommand) Base() *env.BaseJavaCommand {
 }
 
 func (c *CancelCommand) ToCommand() *cobra.Command {
-	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+	command := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   Cancel.CommandName,
 		Short: "Cancels a job asynchronously.",
 		Args:  cobra.NoArgs,
@@ -46,9 +46,9 @@ func (c *CancelCommand) ToCommand() *cobra.Command {
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().IntVar(&c.jobId, "id", 0, "Determine a job ID to cancel")
-	cmd.MarkFlagRequired("id")
-	return cmd
+	command.Flags().IntVar(&c.jobId, "id", 0, "Determine a job ID to cancel")
+	command.MarkFlagRequired("id")
+	return command
 }
 
 func (c *CancelCommand) Run(args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/cancel.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cancel.go
@@ -1,0 +1,60 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package job
+
+import (
+	"strconv"
+
+	"alluxio.org/cli/env"
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+)
+
+var Cancel = &CancelCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "cancel",
+		JavaClassName: "alluxio.cli.job.JobShell",
+	},
+}
+
+type CancelCommand struct {
+	*env.BaseJavaCommand
+	jobId int
+}
+
+func (c *CancelCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *CancelCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   Cancel.CommandName,
+		Short: "Cancels a job asynchronously.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	cmd.Flags().IntVar(&c.jobId, "id", 0, "Determine a job ID to cancel.")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func (c *CancelCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.jobId <= 0 {
+		stacktrace.Propagate(nil, "Flag --id should be a positive integer")
+	}
+	javaArgs = append(javaArgs, "cancel")
+	javaArgs = append(javaArgs, strconv.Itoa(c.jobId))
+	return c.Base().Run(args)
+}

--- a/cli/src/alluxio.org/cli/cmd/job/cancel.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cancel.go
@@ -17,13 +17,14 @@ import (
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 
+	"alluxio.org/cli/cmd"
 	"alluxio.org/cli/env"
 )
 
 var Cancel = &CancelCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "cancel",
-		JavaClassName: "alluxio.cli.job.JobShell",
+		JavaClassName: cmd.JobShellJavaClass,
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/job/cancel.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cancel.go
@@ -40,7 +40,7 @@ func (c *CancelCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   Cancel.CommandName,
 		Short: "Cancels a job asynchronously.",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.Run(args)
 		},
@@ -52,7 +52,7 @@ func (c *CancelCommand) ToCommand() *cobra.Command {
 
 func (c *CancelCommand) Run(args []string) error {
 	if c.jobId <= 0 {
-		stacktrace.NewError("Flag --id should be a positive integer")
+		return stacktrace.NewError("Flag --id should be a positive integer")
 	}
 	javaArgs := []string{"cancel", strconv.Itoa(c.jobId)}
 	return c.Base().Run(javaArgs)

--- a/cli/src/alluxio.org/cli/cmd/job/cancel.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cancel.go
@@ -46,7 +46,7 @@ func (c *CancelCommand) ToCommand() *cobra.Command {
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().IntVar(&c.jobId, "id", 0, "Determine a job ID to cancel.")
+	cmd.Flags().IntVar(&c.jobId, "id", 0, "Determine a job ID to cancel")
 	cmd.MarkFlagRequired("id")
 	return cmd
 }

--- a/cli/src/alluxio.org/cli/cmd/job/cancel.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cancel.go
@@ -51,11 +51,9 @@ func (c *CancelCommand) ToCommand() *cobra.Command {
 }
 
 func (c *CancelCommand) Run(args []string) error {
-	var javaArgs []string
 	if c.jobId <= 0 {
-		stacktrace.Propagate(nil, "Flag --id should be a positive integer")
+		stacktrace.NewError("Flag --id should be a positive integer")
 	}
-	javaArgs = append(javaArgs, "cancel")
-	javaArgs = append(javaArgs, strconv.Itoa(c.jobId))
-	return c.Base().Run(args)
+	javaArgs := []string{"cancel", strconv.Itoa(c.jobId)}
+	return c.Base().Run(javaArgs)
 }

--- a/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
@@ -38,7 +38,7 @@ func (c *CmdStatusCommand) Base() *env.BaseJavaCommand {
 }
 
 func (c *CmdStatusCommand) ToCommand() *cobra.Command {
-	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+	command := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   CmdStatus.CommandName,
 		Short: "Get the status information for a distributed command.",
 		Args:  cobra.NoArgs,
@@ -46,10 +46,10 @@ func (c *CmdStatusCommand) ToCommand() *cobra.Command {
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().IntVar(&c.jobControlId, "id", 0,
+	command.Flags().IntVar(&c.jobControlId, "id", 0,
 		"Determine the job control ID to get the status information")
-	cmd.MarkFlagRequired("id")
-	return cmd
+	command.MarkFlagRequired("id")
+	return command
 }
 
 func (c *CmdStatusCommand) Run(args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
@@ -40,7 +40,7 @@ func (c *CStatusCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   CStatus.CommandName,
 		Short: "Get the status information for a distributed command.",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.Run(args)
 		},
@@ -53,7 +53,7 @@ func (c *CStatusCommand) ToCommand() *cobra.Command {
 
 func (c *CStatusCommand) Run(args []string) error {
 	if c.jobControlId <= 0 {
-		stacktrace.Propagate(nil, "Flag --id should be a positive integer")
+		return stacktrace.Propagate(nil, "Flag --id should be a positive integer")
 	}
 	javaArgs := []string{"getCmdStatus", strconv.Itoa(c.jobControlId)}
 	return c.Base().Run(javaArgs)

--- a/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
@@ -45,16 +45,16 @@ func (c *CStatusCommand) ToCommand() *cobra.Command {
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().IntVar(&c.jobControlId, "jobControlId", 0,
-		"Determine the jobControl ID to get the status information.")
-	cmd.MarkFlagRequired("jobControlId")
+	cmd.Flags().IntVar(&c.jobControlId, "id", 0,
+		"Determine the job control ID to get the status information.")
+	cmd.MarkFlagRequired("id")
 	return cmd
 }
 
 func (c *CStatusCommand) Run(args []string) error {
 	var javaArgs []string
 	if c.jobControlId <= 0 {
-		stacktrace.Propagate(nil, "Flag --jobControlId should be a positive integer")
+		stacktrace.Propagate(nil, "Flag --id should be a positive integer")
 	}
 	javaArgs = append(javaArgs, "getCmdStatus")
 	javaArgs = append(javaArgs, strconv.Itoa(c.jobControlId))

--- a/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
@@ -1,0 +1,62 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package job
+
+import (
+	"strconv"
+
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var CStatus = &CStatusCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "cmdStatus",
+		JavaClassName: "alluxio.cli.job.JobShell",
+	},
+}
+
+type CStatusCommand struct {
+	*env.BaseJavaCommand
+	jobControlId int
+}
+
+func (c *CStatusCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *CStatusCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   Cancel.CommandName,
+		Short: "Get the status information for a distributed command.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	cmd.Flags().IntVar(&c.jobControlId, "jobControlId", 0,
+		"Determine the jobControl ID to get the status information.")
+	cmd.MarkFlagRequired("jobControlId")
+	return cmd
+}
+
+func (c *CStatusCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.jobControlId <= 0 {
+		stacktrace.Propagate(nil, "Flag --jobControlId should be a positive integer")
+	}
+	javaArgs = append(javaArgs, "getCmdStatus")
+	javaArgs = append(javaArgs, strconv.Itoa(c.jobControlId))
+	return c.Base().Run(args)
+}

--- a/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
@@ -38,7 +38,7 @@ func (c *CStatusCommand) Base() *env.BaseJavaCommand {
 
 func (c *CStatusCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
-		Use:   Cancel.CommandName,
+		Use:   CStatus.CommandName,
 		Short: "Get the status information for a distributed command.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
@@ -21,25 +21,25 @@ import (
 	"alluxio.org/cli/env"
 )
 
-var CStatus = &CStatusCommand{
+var CmdStatus = &CmdStatusCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "cmdStatus",
 		JavaClassName: cmd.JobShellJavaClass,
 	},
 }
 
-type CStatusCommand struct {
+type CmdStatusCommand struct {
 	*env.BaseJavaCommand
 	jobControlId int
 }
 
-func (c *CStatusCommand) Base() *env.BaseJavaCommand {
+func (c *CmdStatusCommand) Base() *env.BaseJavaCommand {
 	return c.BaseJavaCommand
 }
 
-func (c *CStatusCommand) ToCommand() *cobra.Command {
+func (c *CmdStatusCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
-		Use:   CStatus.CommandName,
+		Use:   CmdStatus.CommandName,
 		Short: "Get the status information for a distributed command.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -47,14 +47,14 @@ func (c *CStatusCommand) ToCommand() *cobra.Command {
 		},
 	})
 	cmd.Flags().IntVar(&c.jobControlId, "id", 0,
-		"Determine the job control ID to get the status information.")
+		"Determine the job control ID to get the status information")
 	cmd.MarkFlagRequired("id")
 	return cmd
 }
 
-func (c *CStatusCommand) Run(args []string) error {
+func (c *CmdStatusCommand) Run(args []string) error {
 	if c.jobControlId <= 0 {
-		return stacktrace.Propagate(nil, "Flag --id should be a positive integer")
+		return stacktrace.NewError("Flag --id should be a positive integer")
 	}
 	javaArgs := []string{"getCmdStatus", strconv.Itoa(c.jobControlId)}
 	return c.Base().Run(javaArgs)

--- a/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
@@ -17,13 +17,14 @@ import (
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 
+	"alluxio.org/cli/cmd"
 	"alluxio.org/cli/env"
 )
 
 var CStatus = &CStatusCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "cmdStatus",
-		JavaClassName: "alluxio.cli.job.JobShell",
+		JavaClassName: cmd.JobShellJavaClass,
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/cmd_status.go
@@ -52,11 +52,9 @@ func (c *CStatusCommand) ToCommand() *cobra.Command {
 }
 
 func (c *CStatusCommand) Run(args []string) error {
-	var javaArgs []string
 	if c.jobControlId <= 0 {
 		stacktrace.Propagate(nil, "Flag --id should be a positive integer")
 	}
-	javaArgs = append(javaArgs, "getCmdStatus")
-	javaArgs = append(javaArgs, strconv.Itoa(c.jobControlId))
-	return c.Base().Run(args)
+	javaArgs := []string{"getCmdStatus", strconv.Itoa(c.jobControlId)}
+	return c.Base().Run(javaArgs)
 }

--- a/cli/src/alluxio.org/cli/cmd/job/job.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job.go
@@ -16,5 +16,7 @@ import "alluxio.org/cli/env"
 var Service = &env.Service{
 	Name:        "job",
 	Description: "Command line tool for interacting with the job service.",
-	Commands:    []env.Command{},
+	Commands: []env.Command{
+		Cancel,
+	},
 }

--- a/cli/src/alluxio.org/cli/cmd/job/job.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job.go
@@ -22,6 +22,7 @@ var Service = &env.Service{
 		JStatus,
 		Leader,
 		List,
+		Load,
 		Submit,
 	},
 }

--- a/cli/src/alluxio.org/cli/cmd/job/job.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job.go
@@ -22,5 +22,6 @@ var Service = &env.Service{
 		JStatus,
 		Leader,
 		List,
+		Submit,
 	},
 }

--- a/cli/src/alluxio.org/cli/cmd/job/job.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job.go
@@ -18,5 +18,6 @@ var Service = &env.Service{
 	Description: "Command line tool for interacting with the job service.",
 	Commands: []env.Command{
 		Cancel,
+		Leader,
 	},
 }

--- a/cli/src/alluxio.org/cli/cmd/job/job.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job.go
@@ -1,0 +1,20 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package job
+
+import "alluxio.org/cli/env"
+
+var Service = &env.Service{
+	Name:        "job",
+	Description: "Command line tool for interacting with the job service.",
+	Commands:    []env.Command{},
+}

--- a/cli/src/alluxio.org/cli/cmd/job/job.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job.go
@@ -18,8 +18,8 @@ var Service = &env.Service{
 	Description: "Command line tool for interacting with the job service.",
 	Commands: []env.Command{
 		Cancel,
-		CStatus,
-		JStatus,
+		CmdStatus,
+		JobStatus,
 		Leader,
 		List,
 		Load,

--- a/cli/src/alluxio.org/cli/cmd/job/job.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job.go
@@ -18,6 +18,8 @@ var Service = &env.Service{
 	Description: "Command line tool for interacting with the job service.",
 	Commands: []env.Command{
 		Cancel,
+		CStatus,
+		JStatus,
 		Leader,
 		List,
 	},

--- a/cli/src/alluxio.org/cli/cmd/job/job.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job.go
@@ -19,5 +19,6 @@ var Service = &env.Service{
 	Commands: []env.Command{
 		Cancel,
 		Leader,
+		List,
 	},
 }

--- a/cli/src/alluxio.org/cli/cmd/job/job_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job_status.go
@@ -41,7 +41,7 @@ func (c *JStatusCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   JStatus.CommandName,
 		Short: "Displays the status info for the specific job.",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.Run(args)
 		},
@@ -56,7 +56,7 @@ func (c *JStatusCommand) ToCommand() *cobra.Command {
 
 func (c *JStatusCommand) Run(args []string) error {
 	if c.jobId <= 0 {
-		stacktrace.NewError("Flag --id should be a positive integer")
+		return stacktrace.NewError("Flag --id should be a positive integer")
 	}
 	javaArgs := []string{"stat"}
 	if c.everyTask {

--- a/cli/src/alluxio.org/cli/cmd/job/job_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job_status.go
@@ -17,13 +17,14 @@ import (
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 
+	"alluxio.org/cli/cmd"
 	"alluxio.org/cli/env"
 )
 
 var JStatus = &JStatusCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "jobStatus",
-		JavaClassName: "alluxio.cli.job.JobShell",
+		JavaClassName: cmd.JobShellJavaClass,
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/job/job_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job_status.go
@@ -1,0 +1,68 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package job
+
+import (
+	"strconv"
+
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var JStatus = &JStatusCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "jobStatus",
+		JavaClassName: "alluxio.cli.job.JobShell",
+	},
+}
+
+type JStatusCommand struct {
+	*env.BaseJavaCommand
+	jobId     int
+	everyTask bool
+}
+
+func (c *JStatusCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *JStatusCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   Cancel.CommandName,
+		Short: "Displays the status info for the specific job.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	cmd.Flags().IntVar(&c.jobId, "id", 0,
+		"Determine the job ID to get status info.")
+	cmd.Flags().BoolVarP(&c.everyTask, "every-task", "v", false,
+		"Determine display the status of every task.")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func (c *JStatusCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.jobId <= 0 {
+		stacktrace.Propagate(nil, "Flag --id should be a positive integer")
+	}
+	javaArgs = append(javaArgs, "stat")
+	if c.everyTask {
+		javaArgs = append(javaArgs, "-v")
+	}
+	javaArgs = append(javaArgs, strconv.Itoa(c.jobId))
+	return c.Base().Run(args)
+}

--- a/cli/src/alluxio.org/cli/cmd/job/job_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job_status.go
@@ -39,7 +39,7 @@ func (c *JobStatusCommand) Base() *env.BaseJavaCommand {
 }
 
 func (c *JobStatusCommand) ToCommand() *cobra.Command {
-	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+	command := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   JobStatus.CommandName,
 		Short: "Displays the status info for the specific job.",
 		Args:  cobra.NoArgs,
@@ -47,12 +47,12 @@ func (c *JobStatusCommand) ToCommand() *cobra.Command {
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().IntVar(&c.jobId, "id", 0,
+	command.Flags().IntVar(&c.jobId, "id", 0,
 		"Determine the job ID to get status info")
-	cmd.Flags().BoolVarP(&c.everyTask, "every-task", "v", false,
+	command.Flags().BoolVarP(&c.everyTask, "every-task", "v", false,
 		"Determine display the status of every task")
-	cmd.MarkFlagRequired("id")
-	return cmd
+	command.MarkFlagRequired("id")
+	return command
 }
 
 func (c *JobStatusCommand) Run(args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/job_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job_status.go
@@ -21,26 +21,26 @@ import (
 	"alluxio.org/cli/env"
 )
 
-var JStatus = &JStatusCommand{
+var JobStatus = &JobStatusCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "jobStatus",
 		JavaClassName: cmd.JobShellJavaClass,
 	},
 }
 
-type JStatusCommand struct {
+type JobStatusCommand struct {
 	*env.BaseJavaCommand
 	jobId     int
 	everyTask bool
 }
 
-func (c *JStatusCommand) Base() *env.BaseJavaCommand {
+func (c *JobStatusCommand) Base() *env.BaseJavaCommand {
 	return c.BaseJavaCommand
 }
 
-func (c *JStatusCommand) ToCommand() *cobra.Command {
+func (c *JobStatusCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
-		Use:   JStatus.CommandName,
+		Use:   JobStatus.CommandName,
 		Short: "Displays the status info for the specific job.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -48,14 +48,14 @@ func (c *JStatusCommand) ToCommand() *cobra.Command {
 		},
 	})
 	cmd.Flags().IntVar(&c.jobId, "id", 0,
-		"Determine the job ID to get status info.")
+		"Determine the job ID to get status info")
 	cmd.Flags().BoolVarP(&c.everyTask, "every-task", "v", false,
-		"Determine display the status of every task.")
+		"Determine display the status of every task")
 	cmd.MarkFlagRequired("id")
 	return cmd
 }
 
-func (c *JStatusCommand) Run(args []string) error {
+func (c *JobStatusCommand) Run(args []string) error {
 	if c.jobId <= 0 {
 		return stacktrace.NewError("Flag --id should be a positive integer")
 	}

--- a/cli/src/alluxio.org/cli/cmd/job/job_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job_status.go
@@ -55,14 +55,13 @@ func (c *JStatusCommand) ToCommand() *cobra.Command {
 }
 
 func (c *JStatusCommand) Run(args []string) error {
-	var javaArgs []string
 	if c.jobId <= 0 {
-		stacktrace.Propagate(nil, "Flag --id should be a positive integer")
+		stacktrace.NewError("Flag --id should be a positive integer")
 	}
-	javaArgs = append(javaArgs, "stat")
+	javaArgs := []string{"stat"}
 	if c.everyTask {
 		javaArgs = append(javaArgs, "-v")
 	}
 	javaArgs = append(javaArgs, strconv.Itoa(c.jobId))
-	return c.Base().Run(args)
+	return c.Base().Run(javaArgs)
 }

--- a/cli/src/alluxio.org/cli/cmd/job/job_status.go
+++ b/cli/src/alluxio.org/cli/cmd/job/job_status.go
@@ -39,7 +39,7 @@ func (c *JStatusCommand) Base() *env.BaseJavaCommand {
 
 func (c *JStatusCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
-		Use:   Cancel.CommandName,
+		Use:   JStatus.CommandName,
 		Short: "Displays the status info for the specific job.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/leader.go
+++ b/cli/src/alluxio.org/cli/cmd/job/leader.go
@@ -12,50 +12,41 @@
 package job
 
 import (
-	"strconv"
-
-	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 
 	"alluxio.org/cli/env"
 )
 
-var Cancel = &CancelCommand{
+var Leader = &LeaderCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
-		CommandName:   "cancel",
+		CommandName:   "leader",
 		JavaClassName: "alluxio.cli.job.JobShell",
 	},
 }
 
-type CancelCommand struct {
+type LeaderCommand struct {
 	*env.BaseJavaCommand
 	jobId int
 }
 
-func (c *CancelCommand) Base() *env.BaseJavaCommand {
+func (c *LeaderCommand) Base() *env.BaseJavaCommand {
 	return c.BaseJavaCommand
 }
 
-func (c *CancelCommand) ToCommand() *cobra.Command {
+func (c *LeaderCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   Cancel.CommandName,
-		Short: "Cancels a job asynchronously.",
-		Args:  cobra.ExactArgs(1),
+		Short: "Prints the hostname of the job master service leader.",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().IntVar(&c.jobId, "id", 0, "Determine a job ID to cancel.")
-	cmd.MarkFlagRequired("id")
 	return cmd
 }
 
-func (c *CancelCommand) Run(args []string) error {
+func (c *LeaderCommand) Run(args []string) error {
 	var javaArgs []string
-	if c.jobId <= 0 {
-		stacktrace.Propagate(nil, "Flag --id should be a positive integer")
-	}
-	javaArgs = append(javaArgs, "cancel")
-	javaArgs = append(javaArgs, strconv.Itoa(c.jobId))
+	javaArgs = append(javaArgs, "leader")
 	return c.Base().Run(args)
 }

--- a/cli/src/alluxio.org/cli/cmd/job/leader.go
+++ b/cli/src/alluxio.org/cli/cmd/job/leader.go
@@ -14,13 +14,14 @@ package job
 import (
 	"github.com/spf13/cobra"
 
+	"alluxio.org/cli/cmd"
 	"alluxio.org/cli/env"
 )
 
 var Leader = &LeaderCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "leader",
-		JavaClassName: "alluxio.cli.job.JobShell",
+		JavaClassName: cmd.JobShellJavaClass,
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/job/leader.go
+++ b/cli/src/alluxio.org/cli/cmd/job/leader.go
@@ -34,7 +34,7 @@ func (c *LeaderCommand) Base() *env.BaseJavaCommand {
 
 func (c *LeaderCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
-		Use:   Cancel.CommandName,
+		Use:   Leader.CommandName,
 		Short: "Prints the hostname of the job master service leader.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/leader.go
+++ b/cli/src/alluxio.org/cli/cmd/job/leader.go
@@ -34,7 +34,7 @@ func (c *LeaderCommand) Base() *env.BaseJavaCommand {
 }
 
 func (c *LeaderCommand) ToCommand() *cobra.Command {
-	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+	command := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   Leader.CommandName,
 		Short: "Prints the hostname of the job master service leader.",
 		Args:  cobra.NoArgs,
@@ -42,7 +42,7 @@ func (c *LeaderCommand) ToCommand() *cobra.Command {
 			return c.Run(args)
 		},
 	})
-	return cmd
+	return command
 }
 
 func (c *LeaderCommand) Run(args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/leader.go
+++ b/cli/src/alluxio.org/cli/cmd/job/leader.go
@@ -26,7 +26,6 @@ var Leader = &LeaderCommand{
 
 type LeaderCommand struct {
 	*env.BaseJavaCommand
-	jobId int
 }
 
 func (c *LeaderCommand) Base() *env.BaseJavaCommand {
@@ -46,7 +45,6 @@ func (c *LeaderCommand) ToCommand() *cobra.Command {
 }
 
 func (c *LeaderCommand) Run(args []string) error {
-	var javaArgs []string
-	javaArgs = append(javaArgs, "leader")
-	return c.Base().Run(args)
+	javaArgs := []string{"leader"}
+	return c.Base().Run(javaArgs)
 }

--- a/cli/src/alluxio.org/cli/cmd/job/list.go
+++ b/cli/src/alluxio.org/cli/cmd/job/list.go
@@ -26,7 +26,6 @@ var List = &ListCommand{
 
 type ListCommand struct {
 	*env.BaseJavaCommand
-	jobId int
 }
 
 func (c *ListCommand) Base() *env.BaseJavaCommand {
@@ -47,7 +46,6 @@ func (c *ListCommand) ToCommand() *cobra.Command {
 }
 
 func (c *ListCommand) Run(args []string) error {
-	var javaArgs []string
-	javaArgs = append(javaArgs, "ls")
-	return c.Base().Run(args)
+	javaArgs := []string{"ls"}
+	return c.Base().Run(javaArgs)
 }

--- a/cli/src/alluxio.org/cli/cmd/job/list.go
+++ b/cli/src/alluxio.org/cli/cmd/job/list.go
@@ -34,7 +34,7 @@ func (c *ListCommand) Base() *env.BaseJavaCommand {
 
 func (c *ListCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
-		Use: Cancel.CommandName,
+		Use: List.CommandName,
 		Short: "Prints the IDs of the most recent jobs, running and finished, " +
 			"in the history up to the capacity set in alluxio.job.master.job.capacity",
 		Args: cobra.NoArgs,

--- a/cli/src/alluxio.org/cli/cmd/job/list.go
+++ b/cli/src/alluxio.org/cli/cmd/job/list.go
@@ -34,7 +34,7 @@ func (c *ListCommand) Base() *env.BaseJavaCommand {
 }
 
 func (c *ListCommand) ToCommand() *cobra.Command {
-	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+	command := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use: List.CommandName,
 		Short: "Prints the IDs of the most recent jobs, running and finished, " +
 			"in the history up to the capacity set in alluxio.job.master.job.capacity",
@@ -43,7 +43,7 @@ func (c *ListCommand) ToCommand() *cobra.Command {
 			return c.Run(args)
 		},
 	})
-	return cmd
+	return command
 }
 
 func (c *ListCommand) Run(args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/list.go
+++ b/cli/src/alluxio.org/cli/cmd/job/list.go
@@ -14,13 +14,14 @@ package job
 import (
 	"github.com/spf13/cobra"
 
+	"alluxio.org/cli/cmd"
 	"alluxio.org/cli/env"
 )
 
 var List = &ListCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "list",
-		JavaClassName: "alluxio.cli.job.JobShell",
+		JavaClassName: cmd.JobShellJavaClass,
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/job/list.go
+++ b/cli/src/alluxio.org/cli/cmd/job/list.go
@@ -1,0 +1,53 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package job
+
+import (
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var List = &ListCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "list",
+		JavaClassName: "alluxio.cli.job.JobShell",
+	},
+}
+
+type ListCommand struct {
+	*env.BaseJavaCommand
+	jobId int
+}
+
+func (c *ListCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *ListCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use: Cancel.CommandName,
+		Short: "Prints the IDs of the most recent jobs, running and finished, " +
+			"in the history up to the capacity set in alluxio.job.master.job.capacity",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	return cmd
+}
+
+func (c *ListCommand) Run(args []string) error {
+	var javaArgs []string
+	javaArgs = append(javaArgs, "ls")
+	return c.Base().Run(args)
+}

--- a/cli/src/alluxio.org/cli/cmd/job/load.go
+++ b/cli/src/alluxio.org/cli/cmd/job/load.go
@@ -35,7 +35,7 @@ func (c *LoadCommand) Base() *env.BaseJavaCommand {
 }
 
 func (c *LoadCommand) ToCommand() *cobra.Command {
-	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+	command := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   Load.CommandName,
 		Short: "Submit load job to Alluxio master, update job options if already exists",
 		Args:  cobra.NoArgs,
@@ -43,9 +43,9 @@ func (c *LoadCommand) ToCommand() *cobra.Command {
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().StringVar(&c.path, "path", "", "Determine the path of the load job to submit")
-	cmd.MarkFlagRequired("path")
-	return cmd
+	command.Flags().StringVar(&c.path, "path", "", "Determine the path of the load job to submit")
+	command.MarkFlagRequired("path")
+	return command
 }
 
 func (c *LoadCommand) Run(args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/load.go
+++ b/cli/src/alluxio.org/cli/cmd/job/load.go
@@ -1,0 +1,53 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package job
+
+import (
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Load = &LoadCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "load",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+	},
+}
+
+type LoadCommand struct {
+	*env.BaseJavaCommand
+	path string
+}
+
+func (c *LoadCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *LoadCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   Cancel.CommandName,
+		Short: "Submit load job to Alluxio master, update job options if already exists",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	cmd.Flags().StringVar(&c.path, "path", "", "Determine the path of the load job to submit")
+	cmd.MarkFlagRequired("path")
+	return cmd
+}
+
+func (c *LoadCommand) Run(args []string) error {
+	javaArgs := []string{"load", c.path, "--submit"}
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/job/load.go
+++ b/cli/src/alluxio.org/cli/cmd/job/load.go
@@ -14,13 +14,14 @@ package job
 import (
 	"github.com/spf13/cobra"
 
+	"alluxio.org/cli/cmd"
 	"alluxio.org/cli/env"
 )
 
 var Load = &LoadCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "load",
-		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		JavaClassName: cmd.FileSystemShellJavaClass,
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/job/load.go
+++ b/cli/src/alluxio.org/cli/cmd/job/load.go
@@ -35,7 +35,7 @@ func (c *LoadCommand) Base() *env.BaseJavaCommand {
 
 func (c *LoadCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
-		Use:   Cancel.CommandName,
+		Use:   Load.CommandName,
 		Short: "Submit load job to Alluxio master, update job options if already exists",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/submit.go
+++ b/cli/src/alluxio.org/cli/cmd/job/submit.go
@@ -51,14 +51,12 @@ func (c *SubmitCommand) ToCommand() *cobra.Command {
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().StringVar(&c.operationType, "type", "", "Determine type, options: [cp, mv].")
-	cmd.Flags().StringVar(&c.src, "src", "", "The path to move/copy from.")
-	cmd.Flags().StringVar(&c.dst, "dst", "", "The path to move/copy to.")
+	cmd.Flags().StringVar(&c.operationType, "type", "", "Determine type, options: [cp, mv]")
+	cmd.Flags().StringVar(&c.src, "src", "", "The path to move/copy from")
+	cmd.Flags().StringVar(&c.dst, "dst", "", "The path to move/copy to")
 	cmd.Flags().IntVar(&c.activeJobs, "active-jobs", 3000,
-		"Number of active jobs that can run at the same time. Later jobs must wait."+
-			"The default upper limit is 3000.")
-	cmd.Flags().IntVar(&c.batchSize, "batch-size", 1,
-		"Number of files per request. The default batch size is 1.")
+		"Number of active jobs that can run at the same time, later jobs must wait")
+	cmd.Flags().IntVar(&c.batchSize, "batch-size", 1, "Number of files per request")
 	cmd.MarkFlagRequired("type")
 	cmd.MarkFlagRequired("src")
 	cmd.MarkFlagRequired("dst")

--- a/cli/src/alluxio.org/cli/cmd/job/submit.go
+++ b/cli/src/alluxio.org/cli/cmd/job/submit.go
@@ -17,6 +17,7 @@ import (
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 
+	"alluxio.org/cli/cmd"
 	"alluxio.org/cli/env"
 	"alluxio.org/log"
 )
@@ -24,7 +25,7 @@ import (
 var Submit = &SubmitCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "submit",
-		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+		JavaClassName: cmd.FileSystemShellJavaClass,
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/job/submit.go
+++ b/cli/src/alluxio.org/cli/cmd/job/submit.go
@@ -45,7 +45,7 @@ func (c *SubmitCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   Submit.CommandName,
 		Short: "Moves or copies a file or directory in parallel at file level.",
-		Args:  cobra.MinimumNArgs(3),
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.Run(args)
 		},
@@ -70,11 +70,11 @@ func (c *SubmitCommand) Run(args []string) error {
 	case "cp":
 		javaArgs = append(javaArgs, "distributedCp")
 		if c.activeJobs <= 0 {
-			stacktrace.NewError("Flag --active-jobs should be a positive integer")
+			return stacktrace.NewError("Flag --active-jobs should be a positive integer")
 		}
 		javaArgs = append(javaArgs, "--active-jobs", strconv.Itoa(c.activeJobs))
 		if c.batchSize <= 0 {
-			stacktrace.NewError("Flag --batch-size should be a positive integer")
+			return stacktrace.NewError("Flag --batch-size should be a positive integer")
 		}
 		javaArgs = append(javaArgs, "--batch-size", strconv.Itoa(c.batchSize))
 
@@ -88,7 +88,7 @@ func (c *SubmitCommand) Run(args []string) error {
 		}
 
 	default:
-		stacktrace.NewError("Invalid operation type. Must be one of [cp mv].")
+		return stacktrace.NewError("Invalid operation type. Must be one of [cp mv].")
 	}
 
 	javaArgs = append(javaArgs, c.src)

--- a/cli/src/alluxio.org/cli/cmd/job/submit.go
+++ b/cli/src/alluxio.org/cli/cmd/job/submit.go
@@ -1,0 +1,98 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package job
+
+import (
+	"strconv"
+
+	"alluxio.org/log"
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Submit = &SubmitCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "submit",
+		JavaClassName: "alluxio.cli.fs.FileSystemShell",
+	},
+}
+
+type SubmitCommand struct {
+	*env.BaseJavaCommand
+	operationType string
+	src           string
+	dst           string
+	activeJobs    int
+	batchSize     int
+}
+
+func (c *SubmitCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *SubmitCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   Cancel.CommandName,
+		Short: "Moves, or copies a file or directory in parallel at file level.",
+		Args:  cobra.MinimumNArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	cmd.Flags().StringVar(&c.operationType, "type", "", "Determine type, options: [cp, mv].")
+	cmd.Flags().StringVar(&c.src, "src", "", "The path to move/copy from.")
+	cmd.Flags().StringVar(&c.dst, "dst", "", "The path to move/copy to.")
+	cmd.Flags().IntVar(&c.activeJobs, "active-jobs", 3000,
+		"Number of active jobs that can run at the same time. Later jobs must wait."+
+			"The default upper limit is 3000.")
+	cmd.Flags().IntVar(&c.batchSize, "batch-size", 1,
+		"Number of files per request. The default batch size is 1.")
+	cmd.MarkFlagRequired("type")
+	cmd.MarkFlagRequired("src")
+	cmd.MarkFlagRequired("dst")
+	return cmd
+}
+
+func (c *SubmitCommand) Run(args []string) error {
+	var javaArgs []string
+	switch c.operationType {
+	case "cp":
+		javaArgs = append(javaArgs, "distributedCp")
+		javaArgs = append(javaArgs, c.src)
+		javaArgs = append(javaArgs, c.dst)
+		if c.activeJobs <= 0 {
+			stacktrace.NewError("Flag --active-jobs should be a positive integer")
+		}
+		javaArgs = append(javaArgs, "--active-jobs", strconv.Itoa(c.activeJobs))
+		if c.batchSize <= 0 {
+			stacktrace.NewError("Flag --batch-size should be a positive integer")
+		}
+		javaArgs = append(javaArgs, "--batch-size", strconv.Itoa(c.batchSize))
+
+	case "mv":
+		javaArgs = append(javaArgs, "distributedMv")
+		javaArgs = append(javaArgs, c.src)
+		javaArgs = append(javaArgs, c.dst)
+		if c.activeJobs != 3000 {
+			log.Logger.Warningf("Flag --active-jobs is set, but won't be used in this operation type")
+		}
+		if c.batchSize != 1 {
+			log.Logger.Warningf("Flag --batch-size is set, but won't be used in this operation type")
+		}
+
+	default:
+		stacktrace.NewError("Invalid operation type. Must be one of [cp mv].")
+	}
+	return c.Base().Run(args)
+}

--- a/cli/src/alluxio.org/cli/cmd/job/submit.go
+++ b/cli/src/alluxio.org/cli/cmd/job/submit.go
@@ -43,7 +43,7 @@ func (c *SubmitCommand) Base() *env.BaseJavaCommand {
 
 func (c *SubmitCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
-		Use:   Cancel.CommandName,
+		Use:   Submit.CommandName,
 		Short: "Moves or copies a file or directory in parallel at file level.",
 		Args:  cobra.MinimumNArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/submit.go
+++ b/cli/src/alluxio.org/cli/cmd/job/submit.go
@@ -43,7 +43,7 @@ func (c *SubmitCommand) Base() *env.BaseJavaCommand {
 }
 
 func (c *SubmitCommand) ToCommand() *cobra.Command {
-	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+	command := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   Submit.CommandName,
 		Short: "Moves or copies a file or directory in parallel at file level.",
 		Args:  cobra.NoArgs,
@@ -51,16 +51,16 @@ func (c *SubmitCommand) ToCommand() *cobra.Command {
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().StringVar(&c.operationType, "type", "", "Determine type, options: [cp, mv]")
-	cmd.Flags().StringVar(&c.src, "src", "", "The path to move/copy from")
-	cmd.Flags().StringVar(&c.dst, "dst", "", "The path to move/copy to")
-	cmd.Flags().IntVar(&c.activeJobs, "active-jobs", 3000,
+	command.Flags().StringVar(&c.operationType, "type", "", "Determine type, options: [cp, mv]")
+	command.Flags().StringVar(&c.src, "src", "", "The path to move/copy from")
+	command.Flags().StringVar(&c.dst, "dst", "", "The path to move/copy to")
+	command.Flags().IntVar(&c.activeJobs, "active-jobs", 3000,
 		"Number of active jobs that can run at the same time, later jobs must wait")
-	cmd.Flags().IntVar(&c.batchSize, "batch-size", 1, "Number of files per request")
-	cmd.MarkFlagRequired("type")
-	cmd.MarkFlagRequired("src")
-	cmd.MarkFlagRequired("dst")
-	return cmd
+	command.Flags().IntVar(&c.batchSize, "batch-size", 1, "Number of files per request")
+	command.MarkFlagRequired("type")
+	command.MarkFlagRequired("src")
+	command.MarkFlagRequired("dst")
+	return command
 }
 
 func (c *SubmitCommand) Run(args []string) error {

--- a/cli/src/alluxio.org/cli/cmd/job/submit.go
+++ b/cli/src/alluxio.org/cli/cmd/job/submit.go
@@ -14,11 +14,11 @@ package job
 import (
 	"strconv"
 
-	"alluxio.org/log"
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 
 	"alluxio.org/cli/env"
+	"alluxio.org/log"
 )
 
 var Submit = &SubmitCommand{
@@ -44,7 +44,7 @@ func (c *SubmitCommand) Base() *env.BaseJavaCommand {
 func (c *SubmitCommand) ToCommand() *cobra.Command {
 	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use:   Cancel.CommandName,
-		Short: "Moves, or copies a file or directory in parallel at file level.",
+		Short: "Moves or copies a file or directory in parallel at file level.",
 		Args:  cobra.MinimumNArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.Run(args)
@@ -69,8 +69,6 @@ func (c *SubmitCommand) Run(args []string) error {
 	switch c.operationType {
 	case "cp":
 		javaArgs = append(javaArgs, "distributedCp")
-		javaArgs = append(javaArgs, c.src)
-		javaArgs = append(javaArgs, c.dst)
 		if c.activeJobs <= 0 {
 			stacktrace.NewError("Flag --active-jobs should be a positive integer")
 		}
@@ -82,8 +80,6 @@ func (c *SubmitCommand) Run(args []string) error {
 
 	case "mv":
 		javaArgs = append(javaArgs, "distributedMv")
-		javaArgs = append(javaArgs, c.src)
-		javaArgs = append(javaArgs, c.dst)
 		if c.activeJobs != 3000 {
 			log.Logger.Warningf("Flag --active-jobs is set, but won't be used in this operation type")
 		}
@@ -94,5 +90,8 @@ func (c *SubmitCommand) Run(args []string) error {
 	default:
 		stacktrace.NewError("Invalid operation type. Must be one of [cp mv].")
 	}
-	return c.Base().Run(args)
+
+	javaArgs = append(javaArgs, c.src)
+	javaArgs = append(javaArgs, c.dst)
+	return c.Base().Run(javaArgs)
 }

--- a/cli/src/alluxio.org/cli/cmd/names.go
+++ b/cli/src/alluxio.org/cli/cmd/names.go
@@ -14,4 +14,5 @@ package cmd
 const (
 	FileSystemAdminShellJavaClass = "alluxio.cli.fsadmin.FileSystemAdminShell"
 	FileSystemShellJavaClass      = "alluxio.cli.fs.FileSystemShell"
+	JobShellJavaClass             = "alluxio.cli.job.JobShell"
 )

--- a/cli/src/alluxio.org/cli/main.go
+++ b/cli/src/alluxio.org/cli/main.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"alluxio.org/cli/cmd/job"
 	"github.com/spf13/viper"
 
 	"alluxio.org/cli/cmd/conf"
@@ -49,6 +50,7 @@ func main() {
 		fs.Service,
 		generate.Service,
 		info.Service,
+		job.Service,
 		journal.Service,
 		process.Service,
 		quorum.Service,

--- a/cli/src/alluxio.org/cli/main.go
+++ b/cli/src/alluxio.org/cli/main.go
@@ -17,7 +17,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"alluxio.org/cli/cmd/job"
 	"github.com/spf13/viper"
 
 	"alluxio.org/cli/cmd/conf"
@@ -25,6 +24,7 @@ import (
 	"alluxio.org/cli/cmd/fs"
 	"alluxio.org/cli/cmd/generate"
 	"alluxio.org/cli/cmd/info"
+	"alluxio.org/cli/cmd/job"
 	"alluxio.org/cli/cmd/journal"
 	"alluxio.org/cli/cmd/process"
 	"alluxio.org/cli/cmd/quorum"


### PR DESCRIPTION
Add job commands to golang CLI as part of https://github.com/Alluxio/alluxio/issues/17522

`bin/alluxio-bash job cancel id` -> `bin/alluxio job cancel --id`
`bin/alluxio-bash job leader` -> `bin/alluxio job leader`
`bin/alluxio-bash job ls` -> `bin/alluxio job list`
`bin/alluxio-bash job getCmdStatus jobControlId` -> `bin/alluxio job cmdStatus --id`
`bin/alluxio-bash job stat [-v] id` -> `bin/alluxio job jobStatus [-v] --id`
`bin/alluxio-bash fs distributedCp src dst` -> `bin/alluxio job submit --type cp --src --dst`
`bin/alluxio-bash fs distributedMv src dst` -> `bin/alluxio job submit --type mv --src --dst`
`bin/alluxio-bash fs load path --submit` -> `bin/alluxio job load --path`
