### PR TITLE
Remove unused thread pools and rename netty/grpc pools

### DIFF
--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4597,14 +4597,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
-
-  public static final PropertyKey WORKER_NETWORK_NETTY_ASYNC_CACHE_MANAGER_THREADS_MAX =
-      intBuilder(Name.WORKER_NETWORK_NETTY_ASYNC_CACHE_MANAGER_THREADS_MAX)
-          .setDefaultValue(8)
-          .setDescription("The maximum number of threads used to cache blocks asynchronously in "
-              + "the netty data server.")
-          .build();
-
   public static final PropertyKey WORKER_NETWORK_NETTY_READER_THREADS_MAX =
       intBuilder(Name.WORKER_NETWORK_NETTY_READER_THREADS_MAX)
           .setDefaultValue(2048)
@@ -8903,10 +8895,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String WORKER_MASTER_PERIODICAL_RPC_TIMEOUT =
         "alluxio.worker.master.periodical.rpc.timeout";
     public static final String WORKER_MEMORY_SIZE = "alluxio.worker.memory.size";
-    public static final String WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX =
-        "alluxio.worker.network.async.cache.manager.threads.max";
-    public static final String WORKER_NETWORK_ASYNC_CACHE_MANAGER_QUEUE_MAX =
-        "alluxio.worker.network.async.cache.manager.queue.max";
     public static final String WORKER_NETWORK_GRPC_READER_THREADS_MAX =
         "alluxio.worker.network.grpc.reader.threads.max";
     public static final String WORKER_NETWORK_GRPC_WRITER_THREADS_MAX =
@@ -8914,8 +8902,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String WORKER_NETWORK_WRITER_BUFFER_SIZE_MESSAGES =
         "alluxio.worker.network.writer.buffer.size.messages";
 
-    public static final String WORKER_NETWORK_NETTY_ASYNC_CACHE_MANAGER_THREADS_MAX =
-        "alluxio.worker.network.netty.async.cache.manager.threads.max";
     public static final String WORKER_NETWORK_NETTY_READER_THREADS_MAX =
         "alluxio.worker.network.netty.reader.threads.max";
     public static final String WORKER_NETWORK_NETTY_WRITER_THREADS_MAX =

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4622,25 +4622,28 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "the netty data server.")
           .build();
 
-  public static final PropertyKey WORKER_NETWORK_NETTY_BLOCK_READER_THREADS_MAX =
-      intBuilder(Name.WORKER_NETWORK_NETTY_BLOCK_READER_THREADS_MAX)
+  public static final PropertyKey WORKER_NETWORK_NETTY_READER_THREADS_MAX =
+      intBuilder(Name.WORKER_NETWORK_NETTY_READER_THREADS_MAX)
           .setDefaultValue(2048)
-          .setDescription("The maximum number of threads used to read blocks in the netty "
+          .setDescription("The maximum number of threads used to read pages in the netty "
               + "data server.")
+          .setAlias("alluxio.worker.network.netty.block.reader.threads.max")
           .build();
 
-  public static final PropertyKey WORKER_NETWORK_NETTY_BLOCK_WRITER_THREADS_MAX =
-      intBuilder(Name.WORKER_NETWORK_NETTY_BLOCK_WRITER_THREADS_MAX)
+  public static final PropertyKey WORKER_NETWORK_NETTY_WRITER_THREADS_MAX =
+      intBuilder(Name.WORKER_NETWORK_NETTY_WRITER_THREADS_MAX)
           .setDefaultValue(1024)
-          .setDescription("The maximum number of threads used to write blocks in the netty "
+          .setDescription("The maximum number of threads used to write pages in the netty "
               + "data server.")
+          .setAlias("alluxio.worker.network.netty.block.writer.threads.max")
           .build();
 
-  public static final PropertyKey WORKER_NETWORK_NETTY_FILE_WRITER_THREADS_MAX =
-      intBuilder(Name.WORKER_NETWORK_NETTY_FILE_WRITER_THREADS_MAX)
+  public static final PropertyKey WORKER_NETWORK_NETTY_UFS_WRITER_THREADS_MAX =
+      intBuilder(Name.WORKER_NETWORK_NETTY_UFS_WRITER_THREADS_MAX)
           .setDefaultValue(1024)
           .setDescription("The maximum number of threads used to write files to UFS in the "
               + "netty data server.")
+          .setAlias("alluxio.worker.network.netty.file.writer.threads.max")
           .build();
 
   public static final PropertyKey WORKER_NETWORK_NETTY_RPC_THREADS_MAX =
@@ -8930,14 +8933,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
 
     public static final String WORKER_NETWORK_NETTY_ASYNC_CACHE_MANAGER_THREADS_MAX =
         "alluxio.worker.network.netty.async.cache.manager.threads.max";
-    public static final String WORKER_NETWORK_NETTY_BLOCK_READER_THREADS_MAX =
-        "alluxio.worker.network.netty.block.reader.threads.max";
-    public static final String WORKER_NETWORK_NETTY_BLOCK_WRITER_THREADS_MAX =
-        "alluxio.worker.network.netty.block.writer.threads.max";
-    public static final String WORKER_NETWORK_NETTY_FILE_READER_THREADS_MAX =
-        "alluxio.worker.network.netty.file.reader.threads.max";
-    public static final String WORKER_NETWORK_NETTY_FILE_WRITER_THREADS_MAX =
-        "alluxio.worker.network.netty.file.writer.threads.max";
+    public static final String WORKER_NETWORK_NETTY_READER_THREADS_MAX =
+        "alluxio.worker.network.netty.reader.threads.max";
+    public static final String WORKER_NETWORK_NETTY_WRITER_THREADS_MAX =
+        "alluxio.worker.network.netty.writer.threads.max";
+    public static final String WORKER_NETWORK_NETTY_UFS_WRITER_THREADS_MAX =
+        "alluxio.worker.network.netty.ufs.writer.threads.max";
     public static final String WORKER_NETWORK_NETTY_RPC_THREADS_MAX =
         "alluxio.worker.network.netty.rpc.threads.max";
     public static final String WORKER_NETWORK_NETTY_WRITER_BUFFER_SIZE_PACKETS =

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4573,37 +4573,20 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
-  public static final PropertyKey WORKER_NETWORK_ASYNC_CACHE_MANAGER_QUEUE_MAX =
-      intBuilder(Name.WORKER_NETWORK_ASYNC_CACHE_MANAGER_QUEUE_MAX)
-          .setDefaultValue(512)
-          .setDescription("The maximum number of outstanding async caching requests to cache "
-              + "blocks in each data server")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
-  // In Java8 in container environment Runtime.availableProcessors() always returns 1,
-  // which is not the actual number of cpus, so we set a safe default value 8.
-  public static final PropertyKey WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX =
-      intBuilder(Name.WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX)
-          .setDefaultSupplier(() -> Math.max(8, 2 * Runtime.getRuntime().availableProcessors()),
-              "2 * {CPU core count}")
-          .setDescription("The maximum number of threads used to cache blocks asynchronously in "
-              + "the data server.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
-  public static final PropertyKey WORKER_NETWORK_BLOCK_READER_THREADS_MAX =
-      intBuilder(Name.WORKER_NETWORK_BLOCK_READER_THREADS_MAX)
+  public static final PropertyKey WORKER_NETWORK_GRPC_READER_THREADS_MAX =
+      intBuilder(Name.WORKER_NETWORK_GRPC_READER_THREADS_MAX)
           .setDefaultValue(2048)
-          .setDescription("The maximum number of threads used to read blocks in the data server.")
+          .setDescription("The maximum number of threads used to read files in the data server.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setAlias("alluxio.worker.network.block.reader.threads.max")
           .setScope(Scope.WORKER)
           .build();
-  public static final PropertyKey WORKER_NETWORK_BLOCK_WRITER_THREADS_MAX =
-      intBuilder(Name.WORKER_NETWORK_BLOCK_WRITER_THREADS_MAX)
+  public static final PropertyKey WORKER_NETWORK_GRPC_WRITER_THREADS_MAX =
+      intBuilder(Name.WORKER_NETWORK_GRPC_WRITER_THREADS_MAX)
           .setDefaultValue(1024)
-          .setDescription("The maximum number of threads used to write blocks in the data server.")
+          .setDescription("The maximum number of threads used to write files in the data server.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setAlias("alluxio.worker.network.block.write.threads.max")
           .setScope(Scope.WORKER)
           .build();
   public static final PropertyKey WORKER_NETWORK_WRITER_BUFFER_SIZE_MESSAGES =
@@ -8924,10 +8907,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.network.async.cache.manager.threads.max";
     public static final String WORKER_NETWORK_ASYNC_CACHE_MANAGER_QUEUE_MAX =
         "alluxio.worker.network.async.cache.manager.queue.max";
-    public static final String WORKER_NETWORK_BLOCK_READER_THREADS_MAX =
-        "alluxio.worker.network.block.reader.threads.max";
-    public static final String WORKER_NETWORK_BLOCK_WRITER_THREADS_MAX =
-        "alluxio.worker.network.block.writer.threads.max";
+    public static final String WORKER_NETWORK_GRPC_READER_THREADS_MAX =
+        "alluxio.worker.network.grpc.reader.threads.max";
+    public static final String WORKER_NETWORK_GRPC_WRITER_THREADS_MAX =
+        "alluxio.worker.network.grpc.writer.threads.max";
     public static final String WORKER_NETWORK_WRITER_BUFFER_SIZE_MESSAGES =
         "alluxio.worker.network.writer.buffer.size.messages";
 

--- a/dora/core/common/src/main/java/alluxio/conf/RemovedKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/RemovedKey.java
@@ -140,8 +140,6 @@ public final class RemovedKey {
           PropertyKey.Name.WORKER_RAMDISK_SIZE));
       put("alluxio.worker.network.netty.async.cache.manager.threads.max", removedSince(V2_0_0));
       put("alluxio.worker.network.netty.backlog", removedSince(V2_0_0));
-      put("alluxio.worker.network.netty.block.reader.threads.max", removedSince(V2_0_0));
-      put("alluxio.worker.network.netty.block.writer.threads.max", removedSince(V2_0_0));
       put("alluxio.worker.network.netty.buffer.receive", removedSince(V2_0_0));
       put("alluxio.worker.network.netty.buffer.send", removedSince(V2_0_0));
       put("alluxio.worker.network.netty.file.transfer", removedSince(V2_0_0));

--- a/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -2047,13 +2047,6 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.GAUGE)
           .setIsClusterAggregated(false)
           .build();
-  public static final MetricKey WORKER_CACHE_MANAGER_COMPLETED_TASK_COUNT =
-      new Builder("Worker.CacheManagerCompleteTaskCount")
-          .setDescription("The approximate total number of block cache tasks "
-              + "that have completed execution")
-          .setMetricType(MetricType.GAUGE)
-          .setIsClusterAggregated(false)
-          .build();
   public static final MetricKey WORKER_BLOCK_READER_THREAD_ACTIVE_COUNT =
       new Builder("Worker.BlockReaderThreadActiveCount")
           .setDescription("The approximate number of block read "

--- a/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -2047,34 +2047,6 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.GAUGE)
           .setIsClusterAggregated(false)
           .build();
-  public static final MetricKey WORKER_CACHE_MANAGER_THREAD_ACTIVE_COUNT =
-      new Builder("Worker.CacheManagerThreadActiveCount")
-          .setDescription("The approximate number of block cache "
-              + "threads that are actively executing tasks in the cache manager thread pool")
-          .setMetricType(MetricType.GAUGE)
-          .setIsClusterAggregated(false)
-          .build();
-  public static final MetricKey WORKER_CACHE_MANAGER_THREAD_CURRENT_COUNT =
-      new Builder("Worker.CacheManagerThreadCurrentCount")
-          .setDescription("The current number of cache threads in the cache manager thread pool")
-          .setMetricType(MetricType.GAUGE)
-          .setIsClusterAggregated(false)
-          .build();
-  public static final MetricKey WORKER_CACHE_MANAGER_THREAD_QUEUE_WAITING_TASK_COUNT =
-      new Builder("Worker.CacheManagerThreadQueueWaitingTaskCount")
-          .setDescription("The current number of tasks waiting in the work queue "
-              + "in the cache manager thread pool, bounded by "
-              + PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_QUEUE_MAX)
-          .setMetricType(MetricType.GAUGE)
-          .setIsClusterAggregated(false)
-          .build();
-  public static final MetricKey WORKER_CACHE_MANAGER_THREAD_MAX_COUNT =
-      new Builder("Worker.CacheManagerThreadMaxCount")
-          .setDescription("The maximum allowed number of block cache "
-              + "thread in the cache manager thread pool")
-          .setMetricType(MetricType.GAUGE)
-          .setIsClusterAggregated(false)
-          .build();
   public static final MetricKey WORKER_CACHE_MANAGER_COMPLETED_TASK_COUNT =
       new Builder("Worker.CacheManagerCompleteTaskCount")
           .setDescription("The approximate total number of block cache tasks "

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -534,7 +534,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
                   .setRetryable(t.isRetryable() && permissionCheckSucceeded)
                   .setMessage(t.getMessage()).build());
             }
-          }, GrpcExecutors.BLOCK_READER_EXECUTOR);
+          }, GrpcExecutors.READER_EXECUTOR);
           futures.add(loadFuture);
         } catch (RejectedExecutionException ex) {
           LOG.warn("BlockDataReaderExecutor overloaded.");
@@ -546,7 +546,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
         }
       }
     }
-    return Futures.whenAllComplete(futures).call(() -> errors, GrpcExecutors.BLOCK_READER_EXECUTOR);
+    return Futures.whenAllComplete(futures).call(() -> errors, GrpcExecutors.READER_EXECUTOR);
   }
 
   protected void loadData(String ufsPath, long mountId, long length)
@@ -606,7 +606,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
             }
             errors.add(builder.build());
           }
-        }, GrpcExecutors.BLOCK_WRITER_EXECUTOR);
+        }, GrpcExecutors.WRITER_EXECUTOR);
         futures.add(future);
       } catch (IOException e) {
         // ignore close error
@@ -619,7 +619,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
         errors.add(builder.build());
       }
     }
-    return Futures.whenAllComplete(futures).call(() -> errors, GrpcExecutors.BLOCK_WRITER_EXECUTOR);
+    return Futures.whenAllComplete(futures).call(() -> errors, GrpcExecutors.WRITER_EXECUTOR);
   }
 
   protected UnderFileSystem getUnderFileSystem(String ufsPath) {
@@ -670,7 +670,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
             }
             errors.add(builder.build());
           }
-        }, GrpcExecutors.BLOCK_WRITER_EXECUTOR);
+        }, GrpcExecutors.WRITER_EXECUTOR);
         futures.add(future);
       } catch (IOException e) {
         // ignore close error
@@ -683,7 +683,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
         errors.add(builder.build());
       }
     }
-    return Futures.whenAllComplete(futures).call(() -> errors, GrpcExecutors.BLOCK_WRITER_EXECUTOR);
+    return Futures.whenAllComplete(futures).call(() -> errors, GrpcExecutors.WRITER_EXECUTOR);
   }
 
   @Override

--- a/dora/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractWriteHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractWriteHandler.java
@@ -95,7 +95,7 @@ abstract class AbstractWriteHandler<T extends WriteRequestContext<?>> {
       AuthenticatedUserInfo userInfo) {
     mResponseObserver = responseObserver;
     mUserInfo = userInfo;
-    mSerializingExecutor = new SerializingExecutor(GrpcExecutors.BLOCK_WRITER_EXECUTOR);
+    mSerializingExecutor = new SerializingExecutor(GrpcExecutors.WRITER_EXECUTOR);
   }
 
   /**

--- a/dora/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -121,7 +121,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
       callStreamObserver =
           new DataMessageServerStreamObserver<>(callStreamObserver, mReadResponseMarshaller);
     }
-    FileReadHandler readHandler = new FileReadHandler(GrpcExecutors.BLOCK_READER_EXECUTOR,
+    FileReadHandler readHandler = new FileReadHandler(GrpcExecutors.READER_EXECUTOR,
         mWorker, callStreamObserver);
     callStreamObserver.setOnReadyHandler(readHandler::onReady);
     return readHandler;
@@ -142,7 +142,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
         }
         LoadFileResponse.Builder response = LoadFileResponse.newBuilder();
         return response.addAllFailures(fail).setStatus(taskStatus).build();
-      }, GrpcExecutors.BLOCK_WRITER_EXECUTOR);
+      }, GrpcExecutors.WRITER_EXECUTOR);
       RpcUtils.invoke(LOG, future, "loadFile", "request=%s", responseObserver, request);
     } catch (Exception e) {
       LOG.debug(String.format("Failed to load file %s: ", request.getUfsStatusList()), e);
@@ -164,7 +164,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
         }
         CopyResponse.Builder response = CopyResponse.newBuilder();
         return response.addAllFailures(fail).setStatus(taskStatus).build();
-      }, GrpcExecutors.BLOCK_WRITER_EXECUTOR);
+      }, GrpcExecutors.WRITER_EXECUTOR);
       RpcUtils.invoke(LOG, future, "loadFile", "request=%s", responseObserver, request);
     } catch (Exception e) {
       LOG.debug(String.format("Failed to load file %s: ", request.getRoutesList()), e);
@@ -186,7 +186,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
         }
         MoveResponse.Builder response = MoveResponse.newBuilder();
         return response.addAllFailures(fail).setStatus(taskStatus).build();
-      }, GrpcExecutors.BLOCK_WRITER_EXECUTOR);
+      }, GrpcExecutors.WRITER_EXECUTOR);
       RpcUtils.invoke(LOG, future, "moveFile", "request=%s", responseObserver, request);
     } catch (Exception e) {
       LOG.debug(String.format("Failed to move file %s: ", request.getRoutesList()), e);

--- a/dora/core/server/worker/src/main/java/alluxio/worker/grpc/FileReadHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/grpc/FileReadHandler.java
@@ -98,7 +98,7 @@ public class FileReadHandler implements StreamObserver<ReadRequest> {
     mDataReaderExecutor = executorService;
     mResponseObserver = responseObserver;
     mSerializingExecutor =
-        new SerializingExecutor(GrpcExecutors.BLOCK_READER_SERIALIZED_RUNNER_EXECUTOR);
+        new SerializingExecutor(GrpcExecutors.READER_SERIALIZED_RUNNER_EXECUTOR);
     mWorker = worker;
     mIsReaderBufferPooled =
         Configuration.getBoolean(PropertyKey.WORKER_NETWORK_READER_BUFFER_POOLED);

--- a/dora/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
@@ -46,16 +46,6 @@ public final class GrpcExecutors {
   private static final long THREAD_STOP_MS = Constants.SECOND_MS * 10;
   private static final int THREADS_MIN = 4;
 
-  private static final ThreadPoolExecutor CACHE_MANAGER_THREAD_POOL_EXECUTOR =
-      new ThreadPoolExecutor(THREADS_MIN,
-          Configuration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX),
-          THREAD_STOP_MS, TimeUnit.MILLISECONDS, new UniqueBlockingQueue<>(
-          Configuration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_QUEUE_MAX)),
-          ThreadFactoryUtils.build("CacheManagerExecutor-%d", true));
-  // Async caching is an optimization internal to Alluxio, which can be aborted any time
-  public static final ExecutorService CACHE_MANAGER_EXECUTOR =
-      new ImpersonateThreadPoolExecutor(CACHE_MANAGER_THREAD_POOL_EXECUTOR, false);
-
   // Used by BlockWorkerClientServiceHandler.readBlock() by DataReader threads,
   // where each DataReader reads a block content for reply.
   // The thread pool queue is always empty.
@@ -88,24 +78,6 @@ public final class GrpcExecutors {
           new ImpersonateThreadPoolExecutor(BLOCK_WRITE_THREAD_POOL_EXECUTOR, true);
 
   static {
-    MetricsSystem.registerCachedGaugeIfAbsent(MetricsSystem.getMetricName(
-        MetricKey.WORKER_CACHE_MANAGER_THREAD_ACTIVE_COUNT.getName()),
-        CACHE_MANAGER_THREAD_POOL_EXECUTOR::getActiveCount, 5, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(MetricsSystem.getMetricName(
-        MetricKey.WORKER_CACHE_MANAGER_THREAD_CURRENT_COUNT.getName()),
-        CACHE_MANAGER_THREAD_POOL_EXECUTOR::getPoolSize, 5, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(MetricsSystem.getMetricName(
-        MetricKey.WORKER_CACHE_MANAGER_THREAD_QUEUE_WAITING_TASK_COUNT.getName()),
-        CACHE_MANAGER_THREAD_POOL_EXECUTOR.getQueue()::size, 5, TimeUnit.SECONDS);
-    // This value is not updated after the process starts,
-    // so it can be cached for a long time to reduce the number of queries
-    MetricsSystem.registerCachedGaugeIfAbsent(MetricsSystem.getMetricName(
-        MetricKey.WORKER_CACHE_MANAGER_THREAD_MAX_COUNT.getName()),
-        CACHE_MANAGER_THREAD_POOL_EXECUTOR::getMaximumPoolSize, 30, TimeUnit.MINUTES);
-    MetricsSystem.registerCachedGaugeIfAbsent(MetricsSystem.getMetricName(
-        MetricKey.WORKER_CACHE_MANAGER_COMPLETED_TASK_COUNT.getName()),
-        CACHE_MANAGER_THREAD_POOL_EXECUTOR::getCompletedTaskCount, 5, TimeUnit.SECONDS);
-
     MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(
         MetricKey.WORKER_BLOCK_READER_THREAD_ACTIVE_COUNT.getName()),
         BLOCK_READER_THREAD_POOL_EXECUTOR::getActiveCount);

--- a/dora/core/server/worker/src/main/java/alluxio/worker/netty/NettyExecutors.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/netty/NettyExecutors.java
@@ -17,7 +17,6 @@ import alluxio.conf.PropertyKey;
 import alluxio.util.ThreadFactoryUtils;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -31,35 +30,23 @@ public final class NettyExecutors {
   private static final long THREAD_STOP_MS = Constants.SECOND_MS * 10;
   private static final int THREADS_MIN = 4;
 
-  public static final ExecutorService ASYNC_CACHE_MANAGER_EXECUTOR =
+  public static final ExecutorService READER_EXECUTOR =
       new ThreadPoolExecutor(THREADS_MIN,
-          Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_ASYNC_CACHE_MANAGER_THREADS_MAX),
-          THREAD_STOP_MS, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(512),
-          ThreadFactoryUtils.build("AsyncCacheManagerExecutor-%d", true));
-
-  public static final ExecutorService BLOCK_READER_EXECUTOR =
-      new ThreadPoolExecutor(THREADS_MIN,
-          Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_BLOCK_READER_THREADS_MAX),
+          Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_READER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
-          ThreadFactoryUtils.build("BlockPacketReaderExecutor-%d", true));
+          ThreadFactoryUtils.build("ReaderExecutor-%d", true));
 
-  public static final ExecutorService BLOCK_WRITER_EXECUTOR =
+  public static final ExecutorService WRITER_EXECUTOR =
       new ThreadPoolExecutor(THREADS_MIN,
-          Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_BLOCK_WRITER_THREADS_MAX),
+          Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_WRITER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
-          ThreadFactoryUtils.build("BlockPacketWriterExecutor-%d", true));
+          ThreadFactoryUtils.build("WriterExecutor-%d", true));
 
-  public static final ExecutorService FILE_WRITER_EXECUTOR =
+  public static final ExecutorService UFS_WRITER_EXECUTOR =
       new ThreadPoolExecutor(THREADS_MIN,
-          Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_FILE_WRITER_THREADS_MAX),
+          Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_UFS_WRITER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
-          ThreadFactoryUtils.build("FilePacketWriterExecutor-%d", true));
-
-  public static final ExecutorService RPC_EXECUTOR =
-      new ThreadPoolExecutor(THREADS_MIN,
-          Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_RPC_THREADS_MAX),
-          THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
-          ThreadFactoryUtils.build("BlockOpenExecutor-%d", true));
+          ThreadFactoryUtils.build("UfsWriterExecutor-%d", true));
 
   /**
    * Private constructor.

--- a/dora/core/server/worker/src/main/java/alluxio/worker/netty/NettyExecutors.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/netty/NettyExecutors.java
@@ -34,19 +34,19 @@ public final class NettyExecutors {
       new ThreadPoolExecutor(THREADS_MIN,
           Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_READER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
-          ThreadFactoryUtils.build("ReaderExecutor-%d", true));
+          ThreadFactoryUtils.build("NettyReaderExecutor-%d", true));
 
   public static final ExecutorService WRITER_EXECUTOR =
       new ThreadPoolExecutor(THREADS_MIN,
           Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_WRITER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
-          ThreadFactoryUtils.build("WriterExecutor-%d", true));
+          ThreadFactoryUtils.build("NettyWriterExecutor-%d", true));
 
   public static final ExecutorService UFS_WRITER_EXECUTOR =
       new ThreadPoolExecutor(THREADS_MIN,
           Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_UFS_WRITER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
-          ThreadFactoryUtils.build("UfsWriterExecutor-%d", true));
+          ThreadFactoryUtils.build("NettyUfsWriterExecutor-%d", true));
 
   /**
    * Private constructor.

--- a/dora/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
@@ -74,16 +74,16 @@ final class PipelineHandler extends ChannelInitializer<Channel> {
 
     // UFS Handlers
     pipeline.addLast("ufsFileWriteHandler", new UfsFileWriteHandler(
-        NettyExecutors.FILE_WRITER_EXECUTOR, mUfsManager));
+        NettyExecutors.UFS_WRITER_EXECUTOR, mUfsManager));
     // Unsupported Message Handler
     pipeline.addLast("unsupportedMessageHandler", new UnsupportedMessageHandler());
   }
 
   private void addBlockHandlerForDora(ChannelPipeline pipeline) {
     pipeline.addLast("fileReadHandler",
-        new FileReadHandler(NettyExecutors.BLOCK_READER_EXECUTOR, mDoraWorker, mFileTransferType));
+        new FileReadHandler(NettyExecutors.READER_EXECUTOR, mDoraWorker, mFileTransferType));
     //TODO(JiamingMai): WriteHandle also needs to be replaced, but it has not been implemented yet
     pipeline.addLast("fileWriteHandler",
-        new FileWriteHandler(NettyExecutors.BLOCK_WRITER_EXECUTOR, mDoraWorker));
+        new FileWriteHandler(NettyExecutors.WRITER_EXECUTOR, mDoraWorker));
   }
 }

--- a/dora/core/server/worker/src/test/java/alluxio/worker/grpc/GrpcExecutorsTest.java
+++ b/dora/core/server/worker/src/test/java/alluxio/worker/grpc/GrpcExecutorsTest.java
@@ -52,11 +52,11 @@ public class GrpcExecutorsTest {
 
   @Test
   public void impersonationPassedToBlockReader() {
-    validateAuthenticatedClientUser(GrpcExecutors.BLOCK_READER_EXECUTOR);
+    validateAuthenticatedClientUser(GrpcExecutors.READER_EXECUTOR);
   }
 
   @Test
   public void impersonationPassedToBlockWriter() {
-    validateAuthenticatedClientUser(GrpcExecutors.BLOCK_WRITER_EXECUTOR);
+    validateAuthenticatedClientUser(GrpcExecutors.WRITER_EXECUTOR);
   }
 }

--- a/dora/core/server/worker/src/test/java/alluxio/worker/grpc/GrpcExecutorsTest.java
+++ b/dora/core/server/worker/src/test/java/alluxio/worker/grpc/GrpcExecutorsTest.java
@@ -59,9 +59,4 @@ public class GrpcExecutorsTest {
   public void impersonationPassedToBlockWriter() {
     validateAuthenticatedClientUser(GrpcExecutors.BLOCK_WRITER_EXECUTOR);
   }
-
-  @Test
-  public void impersonationPassedToAsyncCacheManager() {
-    validateAuthenticatedClientUser(GrpcExecutors.CACHE_MANAGER_EXECUTOR);
-  }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Removed two unused thread pools in the worker:
a. GRPC async cache manager
b. Netty async cache thread pool

2. Removed property keys and metrics related to those thread pools.

3. Renamed many property keys and variables to remove the "block" keyword 

### Why are the changes needed?

Reduce the number of threads on worker and remove obsolete logic

### Does this PR introduce any user facing changes?

Some property keys are removed.
