### PR TITLE
Add cache subcommand to CLI

### DIFF
--- a/cli/src/alluxio.org/cli/cmd/cache/cache.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/cache.go
@@ -21,5 +21,6 @@ var Service = &env.Service{
 	Commands: []env.Command{
 		Format,
 		Free,
+		Persist,
 	},
 }

--- a/cli/src/alluxio.org/cli/cmd/cache/cache.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/cache.go
@@ -22,5 +22,6 @@ var Service = &env.Service{
 		Format,
 		Free,
 		Persist,
+		Ttl,
 	},
 }

--- a/cli/src/alluxio.org/cli/cmd/cache/cache.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/cache.go
@@ -1,0 +1,24 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package cache
+
+import (
+	"alluxio.org/cli/env"
+)
+
+var Service = &env.Service{
+	Name:        "cache",
+	Description: "Worker-related file system and format operations.",
+	Commands: []env.Command{
+		Format,
+	},
+}

--- a/cli/src/alluxio.org/cli/cmd/cache/cache.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/cache.go
@@ -20,5 +20,6 @@ var Service = &env.Service{
 	Description: "Worker-related file system and format operations.",
 	Commands: []env.Command{
 		Format,
+		Free,
 	},
 }

--- a/cli/src/alluxio.org/cli/cmd/cache/format.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/format.go
@@ -1,0 +1,53 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package cache
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Format = &FormatCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "format",
+		JavaClassName: "alluxio.cli.Format",
+		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
+	},
+}
+
+type FormatCommand struct {
+	*env.BaseJavaCommand
+}
+
+func (c *FormatCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *FormatCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   Format.CommandName,
+		Short: "Format Alluxio worker nodes.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	return cmd
+}
+
+func (c *FormatCommand) Run(args []string) error {
+	javaArgs := []string{"worker"}
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/cache/free.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/free.go
@@ -1,0 +1,82 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package cache
+
+import (
+	"fmt"
+
+	"alluxio.org/cli/cmd"
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Free = &FreeFormat{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "free",
+		JavaClassName: cmd.FileSystemShellJavaClass,
+		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
+	},
+}
+
+type FreeFormat struct {
+	*env.BaseJavaCommand
+	worker string
+	path   string
+	force  bool
+}
+
+func (c *FreeFormat) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *FreeFormat) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use: Free.CommandName,
+		Short: "Synchronously free all blocks and directories of specific worker, " +
+			"or free the space occupied by a file or a directory in Alluxio",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	cmd.Flags().StringVar(&c.worker, "worker", "", "The worker to free")
+	cmd.Flags().StringVar(&c.path, "path", "", "The file or directory to free")
+	cmd.Flags().BoolVarP(&c.force, "force", "f", false,
+		"Force freeing pinned files in the directory")
+	cmd.MarkFlagsMutuallyExclusive("worker", "path")
+	return cmd
+}
+
+func (c *FreeFormat) Run(args []string) error {
+	var javaArgs []string
+	if c.worker == "" {
+		if c.path != "" {
+			// free directory
+			if c.force {
+				javaArgs = append(javaArgs, "-f")
+			}
+			javaArgs = append(javaArgs, c.path)
+		} else {
+			return stacktrace.NewError("neither worker nor path to free specified")
+		}
+	} else {
+		if c.path == "" {
+			// free workers
+			javaArgs = append(javaArgs, c.worker)
+		} else {
+			return stacktrace.NewError("both worker and path to free specified")
+		}
+	}
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/cache/free.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/free.go
@@ -14,10 +14,10 @@ package cache
 import (
 	"fmt"
 
-	"alluxio.org/cli/cmd"
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 
+	"alluxio.org/cli/cmd"
 	"alluxio.org/cli/env"
 )
 
@@ -41,7 +41,7 @@ func (c *FreeFormat) Base() *env.BaseJavaCommand {
 }
 
 func (c *FreeFormat) ToCommand() *cobra.Command {
-	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+	command := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use: Free.CommandName,
 		Short: "Synchronously free all blocks and directories of specific worker, " +
 			"or free the space occupied by a file or a directory in Alluxio",
@@ -50,12 +50,12 @@ func (c *FreeFormat) ToCommand() *cobra.Command {
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().StringVar(&c.worker, "worker", "", "The worker to free")
-	cmd.Flags().StringVar(&c.path, "path", "", "The file or directory to free")
-	cmd.Flags().BoolVarP(&c.force, "force", "f", false,
+	command.Flags().StringVar(&c.worker, "worker", "", "The worker to free")
+	command.Flags().StringVar(&c.path, "path", "", "The file or directory to free")
+	command.Flags().BoolVarP(&c.force, "force", "f", false,
 		"Force freeing pinned files in the directory")
-	cmd.MarkFlagsMutuallyExclusive("worker", "path")
-	return cmd
+	command.MarkFlagsMutuallyExclusive("worker", "path")
+	return command
 }
 
 func (c *FreeFormat) Run(args []string) error {
@@ -63,6 +63,7 @@ func (c *FreeFormat) Run(args []string) error {
 	if c.worker == "" {
 		if c.path != "" {
 			// free directory
+			javaArgs = append(javaArgs, "free")
 			if c.force {
 				javaArgs = append(javaArgs, "-f")
 			}
@@ -73,7 +74,7 @@ func (c *FreeFormat) Run(args []string) error {
 	} else {
 		if c.path == "" {
 			// free workers
-			javaArgs = append(javaArgs, c.worker)
+			javaArgs = append(javaArgs, "freeWorker", c.worker)
 		} else {
 			return stacktrace.NewError("both worker and path to free specified")
 		}

--- a/cli/src/alluxio.org/cli/cmd/cache/free.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/free.go
@@ -12,8 +12,6 @@
 package cache
 
 import (
-	"fmt"
-
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 
@@ -21,26 +19,25 @@ import (
 	"alluxio.org/cli/env"
 )
 
-var Free = &FreeFormat{
+var Free = &FreeCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "free",
 		JavaClassName: cmd.FileSystemShellJavaClass,
-		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
 	},
 }
 
-type FreeFormat struct {
+type FreeCommand struct {
 	*env.BaseJavaCommand
 	worker string
 	path   string
 	force  bool
 }
 
-func (c *FreeFormat) Base() *env.BaseJavaCommand {
+func (c *FreeCommand) Base() *env.BaseJavaCommand {
 	return c.BaseJavaCommand
 }
 
-func (c *FreeFormat) ToCommand() *cobra.Command {
+func (c *FreeCommand) ToCommand() *cobra.Command {
 	command := c.Base().InitRunJavaClassCmd(&cobra.Command{
 		Use: Free.CommandName,
 		Short: "Synchronously free all blocks and directories of specific worker, " +
@@ -58,7 +55,7 @@ func (c *FreeFormat) ToCommand() *cobra.Command {
 	return command
 }
 
-func (c *FreeFormat) Run(args []string) error {
+func (c *FreeCommand) Run(args []string) error {
 	var javaArgs []string
 	if c.worker == "" {
 		if c.path != "" {

--- a/cli/src/alluxio.org/cli/cmd/cache/persist.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/persist.go
@@ -12,7 +12,6 @@
 package cache
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/palantir/stacktrace"
@@ -26,7 +25,6 @@ var Persist = &PersistCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "persist",
 		JavaClassName: cmd.FileSystemShellJavaClass,
-		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/cache/persist.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/persist.go
@@ -1,0 +1,85 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package cache
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/cmd"
+	"alluxio.org/cli/env"
+)
+
+var Persist = &PersistCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "persist",
+		JavaClassName: cmd.FileSystemShellJavaClass,
+		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
+	},
+}
+
+type PersistCommand struct {
+	*env.BaseJavaCommand
+	parallelism int
+	timeout     int
+	wait        int
+	path        []string
+}
+
+func (c *PersistCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *PersistCommand) ToCommand() *cobra.Command {
+	command := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   Persist.CommandName,
+		Short: "Persists files or directories currently stored only in Alluxio to the UnderFileSystem.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	command.Flags().IntVarP(&c.parallelism, "parallelism", "p", 4,
+		"Number of concurrent persist operations")
+	command.Flags().IntVarP(&c.timeout, "timeout", "t", 1200000,
+		"Time in milliseconds for a single file persist to time out")
+	command.Flags().IntVarP(&c.wait, "wait", "w", 0,
+		"The time to wait before persisting")
+	command.Flags().StringSliceVar(&c.path, "path", nil, "The path(s) to persist")
+	return command
+}
+
+func (c *PersistCommand) Run(args []string) error {
+	if c.parallelism <= 0 {
+		return stacktrace.NewError("Flag -p should be a positive integer")
+	}
+	if c.timeout < 0 {
+		return stacktrace.NewError("Flag -t should be a non-negative integer")
+	}
+	if c.wait < 0 {
+		return stacktrace.NewError("Flag -w should be a non-negative integer")
+	}
+	if len(c.path) == 0 {
+		return stacktrace.NewError("Path not specified, at least one path needed")
+	}
+	javaArgs := []string{
+		"persist",
+		"-p", strconv.Itoa(c.parallelism),
+		"-t", strconv.Itoa(c.timeout),
+		"-w", strconv.Itoa(c.wait),
+	}
+	javaArgs = append(javaArgs, c.path...)
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/cache/ttl.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/ttl.go
@@ -12,12 +12,12 @@
 package cache
 
 import (
-	"alluxio.org/cli/cmd"
-	"alluxio.org/log"
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 
+	"alluxio.org/cli/cmd"
 	"alluxio.org/cli/env"
+	"alluxio.org/log"
 )
 
 var Ttl = &TtlCommand{

--- a/cli/src/alluxio.org/cli/cmd/cache/ttl.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/ttl.go
@@ -1,0 +1,83 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package cache
+
+import (
+	"alluxio.org/cli/cmd"
+	"alluxio.org/log"
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var Ttl = &TtlCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "ttl",
+		JavaClassName: cmd.FileSystemShellJavaClass,
+	},
+}
+
+type TtlCommand struct {
+	*env.BaseJavaCommand
+	set      string
+	unset    string
+	duration string
+	action   string
+}
+
+func (c *TtlCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *TtlCommand) ToCommand() *cobra.Command {
+	command := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   Format.CommandName,
+		Short: "Format Alluxio worker nodes.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	command.Flags().StringVar(&c.set, "set", "", "the path of set ttl operation")
+	command.Flags().StringVar(&c.duration, "duration", "", "time to live")
+	command.Flags().StringVar(&c.action, "action", "delete",
+		"Action to take after TTL expiry, delete or free the target")
+	command.Flags().StringVar(&c.unset, "unset", "", "the path of unset ttl operation")
+	command.MarkFlagsRequiredTogether("set", "duration")
+	command.MarkFlagsMutuallyExclusive("set", "unset")
+	command.MarkFlagsMutuallyExclusive("duration", "unset")
+	command.MarkFlagsMutuallyExclusive("action", "unset")
+	return command
+}
+
+func (c *TtlCommand) Run(args []string) error {
+	var javaArgs []string
+	if c.set != "" {
+		// set ttl
+		javaArgs = append(javaArgs, "setTtl", c.set, c.duration)
+		if c.action == "delete" || c.action == "free" {
+			log.Logger.Infof("Running action " + c.action)
+			javaArgs = append(javaArgs, "--action", c.action)
+		} else {
+			return stacktrace.NewError(
+				"invalid action, must use one of [delete, free]")
+		}
+	} else if c.unset != "" {
+		// unset ttl
+		javaArgs = append(javaArgs, "unsetTtl", c.unset)
+	} else {
+		return stacktrace.NewError(
+			"operation and path not specified, must use one of the following flags: [set, unset]")
+	}
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/main.go
+++ b/cli/src/alluxio.org/cli/main.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"alluxio.org/cli/cmd/cache"
 	"github.com/spf13/viper"
 
 	"alluxio.org/cli/cmd/conf"
@@ -51,6 +52,7 @@ func main() {
 	}
 
 	for _, c := range []*env.Service{
+		cache.Service,
 		conf.Service,
 		exec.Service,
 		fs.Service,

--- a/cli/src/alluxio.org/cli/main.go
+++ b/cli/src/alluxio.org/cli/main.go
@@ -17,9 +17,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"alluxio.org/cli/cmd/cache"
 	"github.com/spf13/viper"
 
+	"alluxio.org/cli/cmd/cache"
 	"alluxio.org/cli/cmd/conf"
 	"alluxio.org/cli/cmd/exec"
 	"alluxio.org/cli/cmd/fs"


### PR DESCRIPTION
Add `cache` commands to golang CLI as part of https://github.com/Alluxio/alluxio/issues/17522
`bin/alluxio-bash formatWorker` -> `bin/cli cache format`
`bin/alluxio-bash fs freeWorker` -> `bin/cli cache free --worker`
`bin/alluxio-bash fs free` -> `bin/cli cache free [-f] --path`
`bin/alluxio-bash fs persist` -> `bin/cli cache persist --path`
`bin/alluxio-bash fs setTtl` -> `bin/cli cache ttl --set --duration --action`
`bin/alluxio-bash fs unsetTtl` -> `bin/cli cache ttl --unset`