### PR TITLE
Clean up multiprocess golang code bug fix

### DIFF
--- a/cli/src/alluxio.org/cli/env/process_start.go
+++ b/cli/src/alluxio.org/cli/env/process_start.go
@@ -36,7 +36,9 @@ func (c *StartProcessCommand) ToCommand() *cobra.Command {
 			Args: cobra.NoArgs,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if !c.SkipKillOnStart {
-					_ = p.Stop(&StopProcessCommand{})
+					_ = p.Stop(&StopProcessCommand{
+						Name: "stop",
+					})
 				}
 				return p.Start(c)
 			},

--- a/cli/src/alluxio.org/cli/env/process_stop.go
+++ b/cli/src/alluxio.org/cli/env/process_stop.go
@@ -31,9 +31,7 @@ func (c *StopProcessCommand) ToCommand() *cobra.Command {
 		cmd.AddCommand(p.StopCmd(&cobra.Command{
 			Args: cobra.NoArgs,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return p.Stop(&StopProcessCommand{
-					SoftKill: c.SoftKill,
-				})
+				return p.Stop(c)
 			},
 		}))
 	}

--- a/cli/src/alluxio.org/cli/processes/common.go
+++ b/cli/src/alluxio.org/cli/processes/common.go
@@ -194,6 +194,11 @@ func getHostnames(hostGroups []string) ([]string, error) {
 	for _, hostGroup := range hostGroups {
 		switch hostGroup {
 		case HostGroupMasters:
+			hostnames, err := NewHostnamesFile(hostGroup).getHostnames()
+			if err != nil {
+				return nil, stacktrace.Propagate(err, "error listing hostnames from %v", hostGroup)
+			}
+			hosts = append(hosts, hostnames...)
 		case HostGroupWorkers:
 			hostnames, err := NewHostnamesFile(hostGroup).getHostnames()
 			if err != nil {


### PR DESCRIPTION
Fixed the following bugs:

- cannot get masters hostnames (go `switch` breaks after each `case`)
- cannot run stop commands when stopping (`process-stop.go` is not sending command name)
- cannot run stop commands when starting (`process-start.go` is not sending stop command name)