### PR TITLE
Turn off client side metrics sink since the master will be removed

### DIFF
--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6486,7 +6486,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_METRICS_COLLECTION_ENABLED =
       booleanBuilder(Name.USER_METRICS_COLLECTION_ENABLED)
-          .setDefaultValue(true)
+          .setDefaultValue(false)
           .setDescription("Enable collecting the client-side metrics and heartbeat them to master")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Turn off client side metrics sink since the master will be removed.

### Why are the changes needed?

Turn off client side metrics sink by default since the master will be removed.

### Does this PR introduce any user facing changes?

NA