### PR TITLE
Fix the duplicated metrics counting

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -197,11 +197,8 @@ public class LocalCacheFileInStream extends FileInStream {
         mCacheManager.get(pageId, currentPageOffset, bytesToReadInPage, bytesBuffer, mCacheContext);
     stopwatch.stop();
     if (bytesRead > 0) {
-      MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE.getName()).mark(bytesRead);
       MetricsSystem.counter(MetricKey.CLIENT_CACHE_HIT_REQUESTS.getName()).inc();
       if (cacheContext != null) {
-        cacheContext.incrementCounter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE.getMetricName(), BYTE,
-            bytesRead);
         cacheContext.incrementCounter(
             MetricKey.CLIENT_CACHE_PAGE_READ_CACHE_TIME_NS.getMetricName(), NANO,
             stopwatch.elapsed(TimeUnit.NANOSECONDS));

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -433,8 +433,6 @@ public class LocalCacheFileInStreamTest {
 
     // cache hit
     stream.read();
-    Assert.assertEquals(1,
-        MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE.getName()).getCount());
     Assert.assertEquals(readSize, MetricsSystem.meter(
         MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getName()).getCount());
     Assert.assertEquals(fileSize,


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove the duplicated metrics counting

### Why are the changes needed?

We count CLIENT_CACHE_BYTES_READ_CACHE twice

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
