### PR TITLE
[DOCFIX] Update sitemap logic and relate checks

### DIFF
--- a/dev/scripts/src/alluxio.org/check-docs/main.go
+++ b/dev/scripts/src/alluxio.org/check-docs/main.go
@@ -275,15 +275,11 @@ func getSingleRegexMatch(re *regexp.Regexp, l string) (string, error) {
 	return namedMatch, nil
 }
 
-type Subfile struct {
-	Title string `yaml:"title"`
-	URL   string `yaml:"url"`
-}
-
 type File struct {
-	ButtonTitle string    `yaml:"buttonTitle"`
-	Subfiles    []Subfile `yaml:"subfiles"`
-	Subitems    []File    `yaml:"subitems"`
+	Title       string `yaml:"title"`
+	URL         string `yaml:"url"`
+	ButtonTitle string `yaml:"buttonTitle"`
+	Subfiles    []File `yaml:"subfiles"`
 }
 
 // get url from menuPath with two checks one is the buttonTitle check and the second is the url end checks
@@ -320,9 +316,9 @@ func checkAndSaveUrl(files []File, menuMap map[string]struct{}, errMsgs []string
 			// replace the url ending to .md in order to compare with actually list of docs in directory of docs
 			subfilePath := strings.Replace(subfile.URL, htmlType, mdType, 1)
 			menuMap[subfilePath] = struct{}{}
+			//recall the function until file.subFiles is empty
+			checkAndSaveUrl(file.Subfiles, menuMap, errMsgs)
 		}
-		//recall the function until file.subitem is empty
-		checkAndSaveUrl(file.Subitems, menuMap, errMsgs)
 	}
 }
 

--- a/dev/scripts/src/alluxio.org/check-docs/main.go
+++ b/dev/scripts/src/alluxio.org/check-docs/main.go
@@ -313,9 +313,12 @@ func checkAndSaveUrl(files []File, menuMap map[string]struct{}, errMsgs []string
 			if strings.HasSuffix(subfile.URL, mdType) {
 				errMsgs = append(errMsgs, fmt.Sprintf("error msg: docs %v with url %v is ended with %v, please replace %v with %v", subfile.Title, subfile.URL, mdType, mdType, htmlType))
 			}
-			// replace the url ending to .md in order to compare with actually list of docs in directory of docs
-			subfilePath := strings.Replace(subfile.URL, htmlType, mdType, 1)
-			menuMap[subfilePath] = struct{}{}
+			// ignore the folder path
+			if subfile.URL != "" {
+				// replace the url ending to .md in order to compare with actually list of docs in directory of docs
+				subfilePath := strings.Replace(subfile.URL, htmlType, mdType, 1)
+				menuMap[subfilePath] = struct{}{}
+			}
 			//recall the function until file.subFiles is empty
 			checkAndSaveUrl(file.Subfiles, menuMap, errMsgs)
 		}
@@ -355,7 +358,6 @@ func checkUrlMatch(docsPath, checkPath string, menuListOfURL map[string]struct{}
 	}); err != nil {
 		return fmt.Errorf("error walking thorugh %v with message: \n %v", docsPath, err)
 	}
-	// check the diff
 	switch {
 	case len(menuListOfURL) > len(filePaths):
 		result := compareDiff(menuListOfURL, filePaths)

--- a/docs/_includes/sitemap.html
+++ b/docs/_includes/sitemap.html
@@ -15,13 +15,15 @@
     </div>
     <div id="{{item.buttonTitle}}" class="collapse scrollable-content" >
         {% for files in item.subfiles %}
+        {% if files.url !=null %}
         <div>
             <a class="collapse-items" href="{{site.baseurl}}{{ files.url }}" >{{ files.title }}</a>
         </div>
-        {% endfor %}
-        {% if item.subitems %}
-        {% include sitemap.html map=item.subitems %}
         {% endif %}
+        {% if files.subfiles %}
+        {% include sitemap.html map= files.subfiles %}
+        {% endif %}
+        {% endfor %}
     </div>
     {% endif %}
     {% endfor %}


### PR DESCRIPTION
with following example in the `menu-en.yml`
``` 
 - title: example level 1
    buttonTitle: example_level_1
    subfiles:
      - title: Introduction
        url: /en/introduction/Introduction.html
      - title: Glossary
        url: /en/introduction/Glossary.html
      - subfiles: 
            - title: example level 2
              buttonTitle: example_level_2
              subfiles:
                - title: example level2 doc
                  url: /en/introduction/Introduction.html
                - subfiles:
                    - title: example level 3
                      buttonTitle: example_level_3
                      subfiles:
                        - title: example level3 doc
                          url: /en/introduction/Introduction.html
      - title: Glossary
        url: /en/introduction/Glossary.html
  - title: What is Alluxioxx
    buttonTitle: What_is_Alluxioxx
    subfiles:
      - title: Introduction
        url: /en/introduction/Introduction.html
```
The output with format will looks like 
![image](https://github.com/Alluxio/alluxio/assets/107361923/c449da89-0c88-42d2-b462-de2dbe085f76)
also update the checks-doc script