### PR TITLE
Require Java version 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1202,7 +1202,7 @@
                   <version>${maven.version}</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>${java.version}</version>
+                  <version>[1.8, 1.9)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
### What changes are proposed in this pull request?

After this PR, when building the source with Java 11, following error will be raised

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.3.0:enforce (enforce-versions) on project alluxio-parent: 
[ERROR] Rule 1: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
[ERROR] Detected JDK version 11.0.19 (JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Home) is not in the allowed range [1.8,1.8].
```

### Why are the changes needed?

The previous Java version requirement in enforce plugin is "soft recommendation".
Change it to a hard requirement following version range syntax:
https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html


### Does this PR introduce any user facing changes?

No
