### PR TITLE
Support read bytebuffer for non ByteBufferReadable input stream

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
@@ -59,19 +59,20 @@ public class AlluxioHdfsInputStream extends FileInStream {
     } else {
       int off = buf.position();
       int len = buf.remaining();
-      byte[] byteArray;
+      final int totalBytesRead;
       if (buf.hasArray()) {
-        byteArray = buf.array();
+        byte[] byteArray = buf.array();
+        totalBytesRead = read(byteArray, buf.arrayOffset() + off, len);
+        if (totalBytesRead > 0) {
+          buf.position(off + totalBytesRead);
+        }
       } else {
-        byteArray = new byte[len];
+        byte[] byteArray = new byte[len];
+        totalBytesRead = read(byteArray);
+        if (totalBytesRead > 0) {
+          buf.put(byteArray, 0, totalBytesRead);
+        }
       }
-
-      int totalBytesRead = read(byteArray);
-      if (totalBytesRead <= 0) {
-        return totalBytesRead;
-      }
-      buf.position(off).limit(off + len);
-      buf.put(byteArray, 0, totalBytesRead);
       return totalBytesRead;
     }
   }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
@@ -51,12 +51,21 @@ public class AlluxioHdfsInputStream extends FileInStream {
 
   @Override
   public int read(ByteBuffer buf) throws IOException {
+    // @see <a href="https://github.com/apache/hadoop/blob/rel/release-3.3.6/
+    // * hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/
+    // * fs/FSDataInputStream.java#L154">FSDataInputStream.java</a>
     if (mInput.getWrappedStream() instanceof ByteBufferReadable) {
       return mInput.read(buf);
     } else {
       int off = buf.position();
       int len = buf.remaining();
-      byte[] byteArray = new byte[len];
+      byte[] byteArray;
+      if (buf.hasArray()) {
+        byteArray = buf.array();
+      } else {
+        byteArray = new byte[len];
+      }
+
       int totalBytesRead = read(byteArray);
       if (totalBytesRead <= 0) {
         return totalBytesRead;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support read bytebuffer for non ByteBufferReadable input stream

### Why are the changes needed?

Without this changes, a non ByteBufferReadable input stream can throw exception when the bytebuffer apis are called.

### Does this PR introduce any user facing changes?

No
