### PR TITLE
Support display all log files on web UI

### DIFF
--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -235,7 +235,7 @@ public final class Constants {
 
   // Log file pattern
   public static final Pattern LOG_FILE_PATTERN =
-      Pattern.compile(".*\\.log[\\d+]|.*.out|.*.txt|.*.json");
+      Pattern.compile(".*(\\.log|\\.out)(\\.\\d+)?$|.*.txt|.*.json");
 
   private Constants() {} // prevent instantiation
 }

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -235,7 +235,7 @@ public final class Constants {
 
   // Log file pattern
   public static final Pattern LOG_FILE_PATTERN =
-      Pattern.compile(".*(\\.log|\\.out)(\\.\\d+)?$|.*.txt|.*.json");
+      Pattern.compile(".*(\\.log|\\.out)(\\.[0-9-]+)?$|.*.txt|.*.json");
 
   private Constants() {} // prevent instantiation
 }

--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -11,6 +11,7 @@
 
 package alluxio;
 
+import java.util.regex.Pattern;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -231,6 +232,10 @@ public final class Constants {
   public static final String MEDIUM_MEM = "MEM";
   public static final String MEDIUM_HDD = "HDD";
   public static final String MEDIUM_SSD = "SSD";
+
+  // Log file pattern
+  public static final Pattern LOG_FILE_PATTERN =
+      Pattern.compile(".*\\.log[\\d+]|.*.out|.*.txt|.*.json");
 
   private Constants() {} // prevent instantiation
 }

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -689,8 +689,8 @@ public final class AlluxioMasterRestServiceHandler {
       @DefaultValue("") @QueryParam("end") String requestEnd,
       @DefaultValue("20") @QueryParam("limit") String requestLimit) {
     return RestUtils.call(() -> {
-      FilenameFilter filenameFilter = (dir, name) -> name.toLowerCase()
-          .matches(".*\\.log[\\d+]|.*.out|.*.txt|.*.json");
+      FilenameFilter filenameFilter = (dir, name) ->
+          Constants.LOG_FILE_PATTERN.matcher(name.toLowerCase()).matches();
       MasterWebUILogs response = new MasterWebUILogs();
 
       if (!Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -97,7 +97,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
@@ -689,7 +688,6 @@ public final class AlluxioMasterRestServiceHandler {
       @DefaultValue("") @QueryParam("end") String requestEnd,
       @DefaultValue("20") @QueryParam("limit") String requestLimit) {
     return RestUtils.call(() -> {
-      FilenameFilter filenameFilter = (dir, name) -> name.toLowerCase().endsWith(".log");
       MasterWebUILogs response = new MasterWebUILogs();
 
       if (!Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
@@ -706,7 +704,7 @@ public final class AlluxioMasterRestServiceHandler {
         // List all log files in the log/ directory.
 
         List<UIFileInfo> fileInfos = new ArrayList<>();
-        File[] logFiles = logsDir.listFiles(filenameFilter);
+        File[] logFiles = logsDir.listFiles();
         if (logFiles != null) {
           for (File logFile : logFiles) {
             String logFileName = logFile.getName();

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -97,6 +97,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
@@ -688,6 +689,8 @@ public final class AlluxioMasterRestServiceHandler {
       @DefaultValue("") @QueryParam("end") String requestEnd,
       @DefaultValue("20") @QueryParam("limit") String requestLimit) {
     return RestUtils.call(() -> {
+      FilenameFilter filenameFilter = (dir, name) -> name.toLowerCase()
+          .matches(".*\\.log[\\d+]|.*.out|.*.txt|.*.json");
       MasterWebUILogs response = new MasterWebUILogs();
 
       if (!Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
@@ -704,7 +707,7 @@ public final class AlluxioMasterRestServiceHandler {
         // List all log files in the log/ directory.
 
         List<UIFileInfo> fileInfos = new ArrayList<>();
-        File[] logFiles = logsDir.listFiles();
+        File[] logFiles = logsDir.listFiles(filenameFilter);
         if (logFiles != null) {
           for (File logFile : logFiles) {
             String logFileName = logFile.getName();

--- a/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
@@ -310,27 +310,30 @@ public final class AlluxioMasterRestServiceHandlerTest {
   public void testGetWebUILogsByRegex() throws IOException {
     File logsDir = mTestFolder.newFolder("logs");
     logsDir.mkdirs();
-    String[] fileArray0 = new String[] {
+    String[] wantedFiles = new String[] {
         "master.log",
         "master.log.1",
         "master.log.100",
-        "master.log",
-        "master.log.1",
-        "master.log.100",
+        "master.out",
+        "master.out.1",
+        "master.out.100",
         "master.txt",
+        "master.gc.log",
+        "master.gc.log.2023-09-15-14",
         "alluxio-master-exit-metrics-20230526-085548.json"
     };
-    String[] fileArray1 = new String[] {
+    Arrays.sort(wantedFiles);
+    String[] unwantedFiles = new String[] {
         "master.log.a",
         "master.loga",
         "master.bin",
     };
 
-    for (String fileName : fileArray0) {
+    for (String fileName : wantedFiles) {
       File file0 = new File(logsDir, fileName);
       file0.createNewFile();
     }
-    for (String fileName : fileArray1) {
+    for (String fileName : unwantedFiles) {
       File file0 = new File(logsDir, fileName);
       file0.createNewFile();
     }
@@ -356,6 +359,7 @@ public final class AlluxioMasterRestServiceHandlerTest {
     List<UIFileInfo> fileInfos = ((MasterWebUILogs) response.getEntity()).getFileInfos();
     String[] actualFileNameArray =
         fileInfos.stream().map(fileInfo -> fileInfo.getName()).toArray(String[]::new);
-    Arrays.equals(fileArray0, actualFileNameArray);
+    Arrays.sort(actualFileNameArray);
+    Assert.assertArrayEquals(wantedFiles, actualFileNameArray);
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
@@ -83,7 +83,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.servlet.ServletContext;
 import javax.ws.rs.core.Response;
 

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -83,6 +83,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.servlet.ServletContext;
 import javax.ws.rs.DefaultValue;
@@ -464,8 +465,8 @@ public final class AlluxioWorkerRestServiceHandler {
       @QueryParam("end") String requestEnd,
       @DefaultValue("20") @QueryParam("limit") String requestLimit) {
     return RestUtils.call(() -> {
-      FilenameFilter filenameFilter = (dir, name) -> name.toLowerCase()
-          .matches(".*\\.log[\\d+]|.*.out|.*.txt|.*.json");
+      FilenameFilter filenameFilter = (dir, name) ->
+          Constants.LOG_FILE_PATTERN.matcher(name.toLowerCase()).matches();
       WorkerWebUILogs response = new WorkerWebUILogs();
 
       if (!Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -70,7 +70,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -464,7 +463,6 @@ public final class AlluxioWorkerRestServiceHandler {
       @QueryParam("end") String requestEnd,
       @DefaultValue("20") @QueryParam("limit") String requestLimit) {
     return RestUtils.call(() -> {
-      FilenameFilter filenameFilter = (dir, name) -> name.toLowerCase().endsWith(".log");
       WorkerWebUILogs response = new WorkerWebUILogs();
 
       if (!Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
@@ -481,7 +479,7 @@ public final class AlluxioWorkerRestServiceHandler {
         // List all log files in the log/ directory.
 
         List<UIFileInfo> fileInfos = new ArrayList<>();
-        File[] logFiles = logsDir.listFiles(filenameFilter);
+        File[] logFiles = logsDir.listFiles();
         if (logFiles != null) {
           for (File logFile : logFiles) {
             String logFileName = logFile.getName();

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -83,7 +83,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.regex.Matcher;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.servlet.ServletContext;
 import javax.ws.rs.DefaultValue;

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -70,6 +70,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -463,6 +464,8 @@ public final class AlluxioWorkerRestServiceHandler {
       @QueryParam("end") String requestEnd,
       @DefaultValue("20") @QueryParam("limit") String requestLimit) {
     return RestUtils.call(() -> {
+      FilenameFilter filenameFilter = (dir, name) -> name.toLowerCase()
+          .matches(".*\\.log[\\d+]|.*.out|.*.txt|.*.json");
       WorkerWebUILogs response = new WorkerWebUILogs();
 
       if (!Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
@@ -479,7 +482,7 @@ public final class AlluxioWorkerRestServiceHandler {
         // List all log files in the log/ directory.
 
         List<UIFileInfo> fileInfos = new ArrayList<>();
-        File[] logFiles = logsDir.listFiles();
+        File[] logFiles = logsDir.listFiles(filenameFilter);
         if (logFiles != null) {
           for (File logFile : logFiles) {
             String logFileName = logFile.getName();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Before: Web UI displays only files ending with ".log" in name.

After: Web UI displays logs files like `.log.XXX`, which are rolled over log files. Also the displayed files include `.out` and captured `txt` and `json` files like metrics and jstack.

### Why are the changes needed?

Better observability for admin.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
