### PR TITLE
Support unmount and remount in one atomic operation

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3608,11 +3608,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         }
         mMountTable.checkUnderWritableMountPoint(alluxioPath);
 
-        MountInfo mountInfo = mMountTable.getMountTable().get(alluxioPath);
-        Map<String, String> propertyMap = context.getOptions().getPropertiesMap();
-        if (mountInfo != null && propertyMap != null
-            && Boolean.parseBoolean(propertyMap.get("remount"))) {
-          context.getOptions().removeProperties("remount");
+        if (context.getOptions().getRemount()) {
           unmountInternal(rpcContext, inodePath);
         }
         mountInternal(rpcContext, inodePath, ufsPath, context);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3609,6 +3609,8 @@ public class DefaultFileSystemMaster extends CoreMaster
         mMountTable.checkUnderWritableMountPoint(alluxioPath);
 
         if (context.getOptions().getRemount()) {
+          LOG.info("Mount {} with remount options, so it will be unmounted first.",
+              inodePath.getUri());
           unmountInternal(rpcContext, inodePath);
         }
         mountInternal(rpcContext, inodePath, ufsPath, context);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3608,6 +3608,13 @@ public class DefaultFileSystemMaster extends CoreMaster
         }
         mMountTable.checkUnderWritableMountPoint(alluxioPath);
 
+        MountInfo mountInfo = mMountTable.getMountTable().get(alluxioPath);
+        Map<String, String> propertyMap = context.getOptions().getPropertiesMap();
+        if (mountInfo != null && propertyMap != null
+            && Boolean.parseBoolean(propertyMap.get("remount"))) {
+          context.getOptions().removeProperties("remount");
+          unmountInternal(rpcContext, inodePath);
+        }
         mountInternal(rpcContext, inodePath, ufsPath, context);
         auditContext.setSucceeded(true);
         Metrics.PATHS_MOUNTED.inc();

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -411,6 +411,7 @@ message MountPOptions {
   map<string, string> properties = 2;
   optional bool shared = 3;
   optional FileSystemMasterCommonPOptions commonOptions = 4;
+  optional bool remount = 5;
 }
 message MountPRequest {
   /** the path of alluxio mount point */

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -3276,6 +3276,11 @@
                 "id": 4,
                 "name": "commonOptions",
                 "type": "FileSystemMasterCommonPOptions"
+              },
+              {
+                "id": 5,
+                "name": "remount",
+                "type": "bool"
               }
             ],
             "maps": [

--- a/shell/src/main/java/alluxio/cli/fs/command/MountCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/MountCommand.java
@@ -51,6 +51,13 @@ public final class MountCommand extends AbstractFileSystemCommand {
           .hasArg(false)
           .desc("mount point is shared")
           .build();
+  private static final Option REMOUNT_OPTION =
+      Option.builder()
+          .longOpt("remount")
+          .required(false)
+          .hasArg(false)
+          .desc("unmount and mount together")
+          .build();
   private static final Option OPTION_OPTION =
       Option.builder()
           .longOpt("option")
@@ -77,7 +84,7 @@ public final class MountCommand extends AbstractFileSystemCommand {
   @Override
   public Options getOptions() {
     return new Options().addOption(READONLY_OPTION).addOption(SHARED_OPTION)
-        .addOption(OPTION_OPTION);
+        .addOption(REMOUNT_OPTION).addOption(OPTION_OPTION);
   }
 
   @Override
@@ -98,6 +105,9 @@ public final class MountCommand extends AbstractFileSystemCommand {
     if (cl.hasOption(SHARED_OPTION.getLongOpt())) {
       optionsBuilder.setShared(true);
     }
+    if (cl.hasOption(REMOUNT_OPTION.getLongOpt())) {
+      optionsBuilder.setRemount(true);
+    }
     if (cl.hasOption(OPTION_OPTION.getLongOpt())) {
       Properties properties = cl.getOptionProperties(OPTION_OPTION.getLongOpt());
       optionsBuilder.putAllProperties(Maps.fromProperties(properties));
@@ -109,7 +119,7 @@ public final class MountCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "mount [--readonly] [--shared] [--option <key=val>] <alluxioPath> <ufsURI>";
+    return "mount [--readonly] [--shared] [--remount] [--option <key=val>] <alluxioPath> <ufsURI>";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/MountCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/MountCommand.java
@@ -56,7 +56,7 @@ public final class MountCommand extends AbstractFileSystemCommand {
           .longOpt("remount")
           .required(false)
           .hasArg(false)
-          .desc("unmount and mount together")
+          .desc("unmount and remount in one locked operation, with atomicity")
           .build();
   private static final Option OPTION_OPTION =
       Option.builder()


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support unmount and mount to another mount point within the same lock

### Why are the changes needed?

Support replace ufs for a mount point. The operation is atomic so no user operations should fail due to observing the middle state.

### Does this PR introduce any user facing changes?

A new rpc field and cmd options are added.
