### PR TITLE
Disable proxy and job services to start by default

### DIFF
--- a/bin/alluxio-monitor-bash.sh
+++ b/bin/alluxio-monitor-bash.sh
@@ -19,8 +19,8 @@ BIN=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
 
 USAGE="Usage: alluxio-monitor-bash.sh [-hL] ACTION [host1,host2,...]
 Where ACTION is one of:
-  all                \tStart monitors for all masters, proxies, and workers nodes.
-  local              \tStart monitors for all process locally.
+  all                \tStart monitors for all masters, and workers nodes.
+  local              \tStart monitors the master and worker process locally.
   master             \tStart a master monitor on this node.
   masters            \tStart monitors for all masters nodes.
   worker             \tStart a worker monitor on this node.
@@ -271,18 +271,12 @@ main() {
     all)
       prepare_monitor "Starting to monitor ${CYAN}all remote${NC} services."
       run_monitors "master"     "" "${MODE}"
-      run_monitors "job_master" "" "${MODE}"
       run_monitors "worker"     "" "${MODE}"
-      run_monitors "job_worker" "" "${MODE}"
-      run_monitors "proxy"      "" "${MODE}"
       ;;
     local)
       prepare_monitor "Starting to monitor ${CYAN}all local${NC} services."
       run_monitor "master"      "${MODE}"
-      run_monitor "job_master"  "${MODE}"
       run_monitor "worker"      "${MODE}"
-      run_monitor "job_worker"  "${MODE}"
-      run_monitor "proxy"       "${MODE}"
       ;;
     master)
       run_monitor "master" "${MODE}"

--- a/bin/alluxio-start-bash.sh
+++ b/bin/alluxio-start-bash.sh
@@ -16,12 +16,12 @@
 
 USAGE="Usage: alluxio-start-bash.sh [-hNwm] ACTION [MOPT] [-f] [-c cache]
 Where ACTION is one of:
-  all [MOPT] [-c cache]     \tStart all masters, proxies, and workers.
+  all [MOPT] [-c cache]     \tStart all masters, and workers.
   job_master                \tStart the job_master on this node.
   job_masters               \tStart job_masters on master nodes.
   job_worker                \tStart a job_worker on this node.
   job_workers               \tStart job_workers on worker nodes.
-  local [MOPT] [-c cache]   \tStart all processes locally.
+  local [MOPT] [-c cache]   \tStart a master and a worker process locally.
   master                    \tStart the local master on this node.
   masters                   \tStart masters on master nodes.
   proxy                     \tStart the proxy on this node.
@@ -388,11 +388,8 @@ main() {
   case "${ACTION}" in
     all)
       start_masters "${FORMAT}"
-      start_job_masters
       sleep 2
       start_workers "${MOPT}"
-      start_job_workers
-      start_proxies
       ;;
     local)
       local master_hostname=$(${BIN}/alluxio-bash getConf alluxio.master.hostname)
@@ -421,11 +418,8 @@ main() {
         ${LAUNCHER} ${BIN}/alluxio-bash formatWorker
       fi
       start_master
-      start_job_master
       sleep 2
       start_worker "${MOPT}"
-      start_job_worker
-      start_proxy
       ;;
     job_master)
       start_job_master


### PR DESCRIPTION
### What changes are proposed in this pull request?

Disable proxy and job services to start by default

### Why are the changes needed?

Proxy (standalone), job services are deprecated in 3.0

### Does this PR introduce any user facing changes?

When launching Alluxio, by default no job service or proxy processes will be started
