### PR TITLE
Fix non-existent tiered store property preventing worker from starting

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/netty/FileWriteHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/netty/FileWriteHandler.java
@@ -11,8 +11,6 @@
 
 package alluxio.worker.netty;
 
-import alluxio.DefaultStorageTierAssoc;
-import alluxio.StorageTierAssoc;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.metrics.MetricsSystem;
@@ -45,10 +43,6 @@ public class FileWriteHandler extends AbstractWriteHandler<BlockWriteRequestCont
 
   /** The Block Worker which handles blocks stored in the Alluxio storage of the worker. */
   private final DoraWorker mWorker;
-  /** An object storing the mapping of tier aliases to ordinals. */
-  private final StorageTierAssoc mStorageTierAssoc = new DefaultStorageTierAssoc(
-      PropertyKey.WORKER_TIERED_STORE_LEVELS,
-      PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS);
 
   /**
    * Creates an instance of {@link FileWriteHandler}.


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix non-existent property `WORKER_TIERED_STORE_LEVEL_ALIAS` preventing worker from starting.

### Why are the changes needed?

The property key was removed in #17948. 

See error stack

```
2023-08-15 12:04:46,377 WARN  [data-server-tcp-socket-worker-0](ChannelInitializer.java:97) - Failed to initialize a channel. Closing: [id: 0xe69bb935, L:/192.168.31.18:29997 - R:/192.168.31.18:52896]
java.lang.RuntimeException: No value set for configuration key alluxio.worker.tieredstore.level0.alias
        at alluxio.conf.InstancedConfiguration.get(InstancedConfiguration.java:108)
        at alluxio.conf.InstancedConfiguration.get(InstancedConfiguration.java:100)
        at alluxio.conf.InstancedConfiguration.getString(InstancedConfiguration.java:259)
        at alluxio.conf.Configuration.getString(Configuration.java:221)
        at alluxio.DefaultStorageTierAssoc.<init>(DefaultStorageTierAssoc.java:71)
        at alluxio.worker.netty.FileWriteHandler.<init>(FileWriteHandler.java:49)
        at alluxio.worker.netty.PipelineHandler.addBlockHandlerForDora(PipelineHandler.java:86)
        at alluxio.worker.netty.PipelineHandler.initChannel(PipelineHandler.java:73)
```

### Does this PR introduce any user facing changes?

No.
