### PR TITLE
Disable starting proxy/job processes in all/local

### DIFF
--- a/bin/alluxio-monitor-bash.sh
+++ b/bin/alluxio-monitor-bash.sh
@@ -19,8 +19,8 @@ BIN=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
 
 USAGE="Usage: alluxio-monitor-bash.sh [-hL] ACTION [host1,host2,...]
 Where ACTION is one of:
-  all                \tStart monitors for all masters, proxies, and workers nodes.
-  local              \tStart monitors for all process locally.
+  all                \tStart monitors for all master and worker nodes.
+  local              \tStart monitors for local master and worker processes.
   master             \tStart a master monitor on this node.
   masters            \tStart monitors for all masters nodes.
   worker             \tStart a worker monitor on this node.
@@ -271,18 +271,12 @@ main() {
     all)
       prepare_monitor "Starting to monitor ${CYAN}all remote${NC} services."
       run_monitors "master"     "" "${MODE}"
-      run_monitors "job_master" "" "${MODE}"
       run_monitors "worker"     "" "${MODE}"
-      run_monitors "job_worker" "" "${MODE}"
-      run_monitors "proxy"      "" "${MODE}"
       ;;
     local)
       prepare_monitor "Starting to monitor ${CYAN}all local${NC} services."
       run_monitor "master"      "${MODE}"
-      run_monitor "job_master"  "${MODE}"
       run_monitor "worker"      "${MODE}"
-      run_monitor "job_worker"  "${MODE}"
-      run_monitor "proxy"       "${MODE}"
       ;;
     master)
       run_monitor "master" "${MODE}"

--- a/bin/alluxio-start-bash.sh
+++ b/bin/alluxio-start-bash.sh
@@ -16,12 +16,12 @@
 
 USAGE="Usage: alluxio-start-bash.sh [-hNwm] ACTION [MOPT] [-f] [-c cache]
 Where ACTION is one of:
-  all [MOPT] [-c cache]     \tStart all masters, proxies, and workers.
+  all [MOPT] [-c cache]     \tStart all master and worker processes.
   job_master                \tStart the job_master on this node.
   job_masters               \tStart job_masters on master nodes.
   job_worker                \tStart a job_worker on this node.
   job_workers               \tStart job_workers on worker nodes.
-  local [MOPT] [-c cache]   \tStart all processes locally.
+  local [MOPT] [-c cache]   \tStart local master and worker processes.
   master                    \tStart the local master on this node.
   masters                   \tStart masters on master nodes.
   proxy                     \tStart the proxy on this node.
@@ -388,11 +388,8 @@ main() {
   case "${ACTION}" in
     all)
       start_masters "${FORMAT}"
-      start_job_masters
       sleep 2
       start_workers "${MOPT}"
-      start_job_workers
-      start_proxies
       ;;
     local)
       local master_hostname=$(${BIN}/alluxio-bash getConf alluxio.master.hostname)
@@ -421,11 +418,8 @@ main() {
         ${LAUNCHER} ${BIN}/alluxio-bash formatWorker
       fi
       start_master
-      start_job_master
       sleep 2
       start_worker "${MOPT}"
-      start_job_worker
-      start_proxy
       ;;
     job_master)
       start_job_master

--- a/cli/src/alluxio.org/cli/env/process_start.go
+++ b/cli/src/alluxio.org/cli/env/process_start.go
@@ -25,7 +25,7 @@ type StartProcessCommand struct {
 func (c *StartProcessCommand) ToCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   StartProcessName,
-		Short: "Starts a process",
+		Short: "Starts one or more processes",
 	}
 	cmd.PersistentFlags().BoolVarP(&c.SkipKillOnStart, "skip-kill-prev", "N", false, "Avoid killing previous running processes when starting")
 	cmd.PersistentFlags().BoolVarP(&c.AsyncStart, "async", "a", false, "Asynchronously start processes without monitoring for start completion")

--- a/cli/src/alluxio.org/cli/env/process_stop.go
+++ b/cli/src/alluxio.org/cli/env/process_stop.go
@@ -22,7 +22,7 @@ type StopProcessCommand struct {
 func (c *StopProcessCommand) ToCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   StopProcessName,
-		Short: "Stops a process",
+		Short: "Stops one or more processes",
 	}
 	cmd.PersistentFlags().BoolVarP(&c.SoftKill, "soft", "s", false, "Soft kill only, don't forcibly kill the process")
 

--- a/cli/src/alluxio.org/cli/processes/all.go
+++ b/cli/src/alluxio.org/cli/processes/all.go
@@ -25,10 +25,7 @@ var All = &AllProcess{
 	},
 	Processes: []env.Process{
 		Masters,
-		JobMasters,
 		Workers,
-		JobWorkers,
-		Proxies,
 	},
 }
 

--- a/cli/src/alluxio.org/cli/processes/local.go
+++ b/cli/src/alluxio.org/cli/processes/local.go
@@ -25,10 +25,7 @@ var Local = &LocalProcess{
 	},
 	Processes: []env.Process{
 		Master,
-		JobMaster,
 		Worker,
-		JobWorker,
-		Proxy,
 	},
 }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Disable proxy and job services to start by default

### Why are the changes needed?

Proxy (standalone), job services are deprecated in 3.0

### Does this PR introduce any user facing changes?

When launching Alluxio, by default no job service or proxy processes will be started
