### PR TITLE
Add golang cli compilation to github check

### DIFF
--- a/dev/github/run_checks.sh
+++ b/dev/github/run_checks.sh
@@ -29,5 +29,8 @@ JAVA_HOME=/usr/local/openjdk-8
 PATH=$JAVA_HOME/bin:$PATH
 mvn -Duser.home=/home/jenkins -T 4C clean install -DskipTests
 
+# compile go cli
+./build/cli/build-cli.sh
+
 ./dev/scripts/check-docs.sh
 ./dev/scripts/build-artifact.sh ufsVersionCheck


### PR DESCRIPTION
add check to ensure the go code in `cli/` compiles as part of the checks build