### PR TITLE
Remove unused class

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/netty/FileWriteHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/netty/FileWriteHandler.java
@@ -45,10 +45,6 @@ public class FileWriteHandler extends AbstractWriteHandler<BlockWriteRequestCont
 
   /** The Block Worker which handles blocks stored in the Alluxio storage of the worker. */
   private final DoraWorker mWorker;
-  /** An object storing the mapping of tier aliases to ordinals. */
-  private final StorageTierAssoc mStorageTierAssoc = new DefaultStorageTierAssoc(
-      PropertyKey.WORKER_TIERED_STORE_LEVELS,
-      PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS);
 
   /**
    * Creates an instance of {@link FileWriteHandler}.


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove unused class which causing problem.
```
2023-08-15 21:40:36,663 WARN  ChannelInitializer - Failed to initialize a channel. Closing: [id: 0xa460dfda, L:/172.31.93.123:29997 - R:/172.31.80.106:34390]
java.lang.RuntimeException: No value set for configuration key alluxio.worker.tieredstore.level0.alias
	at alluxio.conf.InstancedConfiguration.get(InstancedConfiguration.java:108)
	at alluxio.conf.InstancedConfiguration.get(InstancedConfiguration.java:100)
	at alluxio.conf.InstancedConfiguration.getString(InstancedConfiguration.java:259)
	at alluxio.conf.Configuration.getString(Configuration.java:221)
	at alluxio.DefaultStorageTierAssoc.<init>(DefaultStorageTierAssoc.java:71)
	at alluxio.worker.netty.FileWriteHandler.<init>(FileWriteHandler.java:49)
	at alluxio.emon.worker.netty.FileWriteHandlerEE.<init>(FileWriteHandlerEE.java:42)
	at alluxio.emon.worker.netty.PipelineHandlerEE.addBlockHandlerForDora(PipelineHandlerEE.java:113)
	at alluxio.emon.worker.netty.PipelineHandlerEE.initChannel(PipelineHandlerEE.java:100)
	at io.netty.channel.ChannelInitializer.initChannel(ChannelInitializer.java:129)
	at io.netty.channel.ChannelInitializer.handlerAdded(ChannelInitializer.java:112)
	at io.netty.channel.AbstractChannelHandlerContext.callHandlerAdded(AbstractChannelHandlerContext.java:1114)
	at io.netty.channel.DefaultChannelPipeline.callHandlerAdded0(DefaultChannelPipeline.java:609)
	at io.netty.channel.DefaultChannelPipeline.access$100(DefaultChannelPipeline.java:46)
	at io.netty.channel.DefaultChannelPipeline$PendingHandlerAddedTask.execute(DefaultChannelPipeline.java:1463)
	at io.netty.channel.DefaultChannelPipeline.callHandlerAddedForAllHandlers(DefaultChannelPipeline.java:1115)
	at io.netty.channel.DefaultChannelPipeline.invokeHandlerAddedIfNeeded(DefaultChannelPipeline.java:650)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:514)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:429)
	at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:486)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
### Why are the changes needed?

fix bug

### Does this PR introduce any user facing changes?
na
