### PR TITLE
Use getStatus function in lsCommand in order to show the percentage

### DIFF
--- a/dora/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -285,7 +285,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
       return;
     }
 
-    List<URIStatus> statusList = mFileSystem.listStatus(path, optionsBuilder.build());
+    List<URIStatus> statusList = mFileSystem.getStatus(path, optionsBuilder.build());
     List<URIStatus> sorted = sortByFieldAndOrder(statusList, sortField, reverse);
     for (URIStatus status : sorted) {
       printLsString(status, hSize, timestampFunction, pinnedOnly, status.isPinned());


### PR DESCRIPTION
### What changes are proposed in this pull request?
Currently, the fs ls command shows 0% data in Alluxio even if the data actually is in Alluxio.
This change switch listStatus to getStatus which has PercentageInAlluxio.

### Why are the changes needed?
Fix the issue of 0% data in Alluxio.
 

### Does this PR introduce any user facing changes?
Yes, it will change the command line output which fixes the incorrect percentage of data in Alluxio.
 
