### PR TITLE
Delete metadata that has been deleted in UFS when the client cancels.

### DIFF
--- a/dora/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2223,7 +2223,10 @@ public class DefaultFileSystemMaster extends CoreMaster
       // We go through each inode, removing it from its parent set and from mDelInodes. If it's a
       // file, we deal with the checkpoints and blocks as well.
       for (int i = inodesToDelete.size() - 1; i >= 0; i--) {
-        rpcContext.throwIfCancelled();
+        if (rpcContext.isCancelled()) {
+          inodesToDelete.set(i, null);
+          continue;
+        }
         Pair<AlluxioURI, LockedInodePath> inodePairToDelete = inodesToDelete.get(i);
         AlluxioURI alluxioUriToDelete = inodePairToDelete.getFirst();
         Inode inodeToDelete = inodePairToDelete.getSecond().getInode();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Delete metadata that has been deleted in UFS when the client cancels.
fix #18001 

### Why are the changes needed?

The metadata and UFS are inconsistent，when the client delete the directory and cancels .

