### PR TITLE
Build all golang cli executables for tarball dry run

### DIFF
--- a/dev/github/run_checks.sh
+++ b/dev/github/run_checks.sh
@@ -34,3 +34,4 @@ mvn -Duser.home=/home/jenkins -T 4C clean install -DskipTests
 
 ./dev/scripts/check-docs.sh
 ./dev/scripts/build-artifact.sh ufsVersionCheck
+./dev/scripts/build-artifact.sh tarball --dryRun

--- a/dev/scripts/src/alluxio.org/build/cmd/build.go
+++ b/dev/scripts/src/alluxio.org/build/cmd/build.go
@@ -96,6 +96,10 @@ func buildTarball(opts *buildOpts) error {
 				return stacktrace.Propagate(err, "error creating libexec/version.sh")
 			}
 		}
+		// need to build all golang cli
+		if err := command.New("./build/cli/build-cli.sh -a").WithDir(repoBuildDir).Run(); err != nil {
+			return stacktrace.Propagate(err, "error building golang cli")
+		}
 		// mock creation of client, assembly, and lib jars
 		var mockFiles []string
 		if opts.tarball.ClientJarName != "" {


### PR DESCRIPTION
### What changes are proposed in this pull request?
running `build/cli/build-cli.sh -a` from tarball dry runs

### Why are the changes needed?
needed to fix dry runs

### Does this PR introduce any user facing changes?
no
