### PR TITLE
[SMALLFIX] Fix DataPercentageinAlluxio always shows 0%

### DIFF
--- a/dora/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -48,7 +48,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @PublicApi
 public final class LsCommand extends AbstractFileSystemCommand {
   public static final String IN_ALLUXIO_STATE_DIR = "DIR";
-  public static final String IN_ALLUXIO_STATE_FILE_FORMAT = "%d%%";
+  public static final String IN_ALLUXIO_STATE_FILE = "FILE";
   // Permission: drwxrwxrwx+
   public static final String LS_FORMAT_PERMISSION = "%-12s";
   public static final String LS_FORMAT_FILE_SIZE = "%15s";
@@ -170,7 +170,6 @@ public final class LsCommand extends AbstractFileSystemCommand {
    * @param groupName group name
    * @param size size of the file in bytes
    * @param timestamp the epoch time in ms
-   * @param inAlluxioPercentage whether the file is in Alluxio
    * @param persistenceState the persistence state of the file
    * @param path path of the file or folder
    * @param dateFormatPattern the format to follow when printing dates
@@ -178,7 +177,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
    */
   public static String formatLsString(boolean hSize, boolean acl, boolean isFolder, String
       permission,
-      String userName, String groupName, long size, long timestamp, int inAlluxioPercentage,
+      String userName, String groupName, long size, long timestamp,
       String persistenceState, String path, String dateFormatPattern) {
     String inAlluxioState;
     String sizeStr;
@@ -186,7 +185,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
       inAlluxioState = IN_ALLUXIO_STATE_DIR;
       sizeStr = String.valueOf(size);
     } else {
-      inAlluxioState = String.format(IN_ALLUXIO_STATE_FILE_FORMAT, inAlluxioPercentage);
+      inAlluxioState = IN_ALLUXIO_STATE_FILE;
       sizeStr = hSize ? FormatUtils.getSizeFromBytes(size) : String.valueOf(size);
     }
 
@@ -216,8 +215,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
         status.isFolder(),
         FormatUtils.formatMode((short) status.getMode(), status.isFolder(), hasExtended),
         status.getOwner(), status.getGroup(), status.getLength(),
-        timestamp, status.getInAlluxioPercentage(),
-        status.getPersistenceState(), status.getPath(),
+        timestamp, status.getPersistenceState(), status.getPath(),
         mFsContext.getClusterConf().getString(
             PropertyKey.USER_DATE_FORMAT_PATTERN)));
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?
The LsCommand displays DataInAlluxioPercentage, but it always shows 0% which is misleading.
This change changes the DataInAlluxioPercentage column to a fix string FILE in the Lscommand.
### Why are the changes needed?

Please clarify why the changes are needed. For instance,
As mentioned above, it fixes the bug that LsCommand always shows 0% for DataInAlluxio.

### Does this PR introduce any user facing changes?
Yes, it will change the display of LsCommand.

It will change the output of LsCommand for files but not directories. For files, it will be the follow format

```
./alluxio fs ls /file_path
          FileSize     PeristenceState    Timestamp    FILE     FilePath 
```

Please list the user-facing changes introduced by your change, including
 It changes the percentage of data in Alluxio to a fix string FILE as shown above.
