### PR TITLE
Change the interface of etcd-related class

### DIFF
--- a/dora/core/common/src/main/java/alluxio/membership/AlluxioEtcdClient.java
+++ b/dora/core/common/src/main/java/alluxio/membership/AlluxioEtcdClient.java
@@ -78,6 +78,7 @@ public class AlluxioEtcdClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(AlluxioEtcdClient.class);
   private static final Lock INSTANCE_LOCK = new ReentrantLock();
+  public static final String BASE_PATH = "/ServiceDiscovery";
   public static final long DEFAULT_LEASE_TTL_IN_SEC = 2L;
   public static final long DEFAULT_TIMEOUT_IN_SEC = 2L;
   public static final int RETRY_TIMES = 3;
@@ -102,7 +103,8 @@ public class AlluxioEtcdClient {
     String clusterName = conf.getString(PropertyKey.ALLUXIO_CLUSTER_NAME);
     List<String> endpointsList = conf.getList(PropertyKey.ETCD_ENDPOINTS);
     mEndpoints = endpointsList.toArray(new String[0]);
-    mServiceDiscovery = new ServiceDiscoveryRecipe(this, clusterName);
+    mServiceDiscovery = new ServiceDiscoveryRecipe(this,
+        String.format("%s%s%s", BASE_PATH, MembershipManager.PATH_SEPARATOR, clusterName));
     // TODO(lucy) add more options as needed for io.etcd.jetcd.ClientBuilder
     // to control underneath grpc parameters.
     mClient = Client.builder().endpoints(mEndpoints)

--- a/dora/core/common/src/main/java/alluxio/membership/WorkerServiceEntity.java
+++ b/dora/core/common/src/main/java/alluxio/membership/WorkerServiceEntity.java
@@ -19,8 +19,11 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonSyntaxException;
+import com.google.gson.InstanceCreator;
 import com.google.gson.annotations.Expose;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
 
 /**
  * Entity class including all the information to register to Etcd
@@ -46,6 +49,11 @@ public class WorkerServiceEntity extends DefaultServiceEntity {
   @Expose
   @com.google.gson.annotations.SerializedName("GenerationNumber")
   int mGenerationNum = -1;
+
+  /**
+   * CTOR for WorkerServiceEntity.
+   */
+  public WorkerServiceEntity() {}
 
   /**
    * CTOR  for WorkerServiceEntity with given WorkerNetAddress.
@@ -92,16 +100,14 @@ public class WorkerServiceEntity extends DefaultServiceEntity {
     return Objects.hashCode(mAddress, mServiceEntityName);
   }
 
-  /**
-   * Convert from a json string to a WorkerServiceEntity object.
-   * @param jsonStr
-   * @return WorkerServiceEntity
-   * @throws JsonSyntaxException
-   */
-  public static WorkerServiceEntity fromJson(String jsonStr) throws JsonSyntaxException {
+  @Override
+  public void deserialize(byte[] buf) {
+    WorkerServiceEntity obj = this;
+    InstanceCreator<DefaultServiceEntity> creator = type -> obj;
     Gson gson = new GsonBuilder()
         .excludeFieldsWithoutExposeAnnotation()
+        .registerTypeAdapter(WorkerServiceEntity.class, creator)
         .create();
-    return gson.fromJson(jsonStr, WorkerServiceEntity.class);
+    gson.fromJson(new InputStreamReader(new ByteArrayInputStream(buf)), WorkerServiceEntity.class);
   }
 }

--- a/dora/core/common/src/test/java/alluxio/membership/ServiceEntityTest.java
+++ b/dora/core/common/src/test/java/alluxio/membership/ServiceEntityTest.java
@@ -24,8 +24,9 @@ public final class ServiceEntityTest {
         .setHost("worker1").setContainerHost("containerhostname1")
         .setRpcPort(1000).setDataPort(1001).setWebPort(1011)
         .setDomainSocketPath("/var/lib/domain.sock"));
-    String str = DefaultServiceEntity.toJson(entity);
-    DefaultServiceEntity deserialized = WorkerServiceEntity.fromJson(str);
+    byte[] jsonBytes = entity.serialize();
+    DefaultServiceEntity deserialized = new WorkerServiceEntity();
+    deserialized.deserialize(jsonBytes);
     Assert.assertEquals(deserialized, entity);
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?
- Change the serialize/deserialize interface for future use(#17959)
- Expose the TTL and timeout of the lease used in `ServiceDiscoveryRecipe`
- Expose the path prefix of the `ServiceDiscoveryRecipe` for future use

### Why are the changes needed?
etcd will be used in the near future for more areas than worker service discovery. so expose more information for future use.

### Does this PR introduce any user facing changes?
nope
