### PR TITLE
Add domain socket max path length check

### DIFF
--- a/dora/core/common/src/main/java/alluxio/util/OSUtils.java
+++ b/dora/core/common/src/main/java/alluxio/util/OSUtils.java
@@ -28,6 +28,9 @@ public final class OSUtils {
   public static final String JAVA_VENDOR_NAME = System.getProperty("java.vendor");
   /** Indicates the current java vendor is IBM java or not. */
   public static final boolean IBM_JAVA = JAVA_VENDOR_NAME.contains("IBM");
+  /** The maximum path length supported by a domain socket on unix varies depending on the
+   * operating system. The conservative limit is returned here */
+  public static final int UNIX_SOCKET_MAX_PATH_LENGTH = 100;
 
   /**
    * @return true if current processor is 64 bit
@@ -62,6 +65,13 @@ public final class OSUtils {
    */
   public static boolean isAIX() {
     return OSUtils.OS_NAME.equals("AIX");
+  }
+
+  /***
+   * @return the maximum path length supported by a domain socket on unix
+   */
+  public static int getDomainSocketMaxPathLength() {
+    return OSUtils.UNIX_SOCKET_MAX_PATH_LENGTH;
   }
 
   private OSUtils() {} // prevent instantiation

--- a/dora/core/server/worker/src/main/java/alluxio/worker/DataServerFactory.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/DataServerFactory.java
@@ -18,12 +18,14 @@ import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.BlockWorkerGrpc;
 import alluxio.underfs.UfsManager;
+import alluxio.util.OSUtils;
 import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.worker.dora.DoraWorker;
 import alluxio.worker.grpc.DoraWorkerClientServiceHandler;
 import alluxio.worker.grpc.GrpcDataServer;
 
+import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import io.netty.channel.unix.DomainSocketAddress;
 import org.slf4j.Logger;
@@ -81,6 +83,9 @@ public class DataServerFactory {
       domainSocketPath =
           PathUtils.concatPath(domainSocketPath, UUID.randomUUID().toString());
     }
+    Preconditions.checkState(domainSocketPath.length() < OSUtils.getDomainSocketMaxPathLength(),
+        "The longest domain socket path possible on this host is %d bytes.",
+        OSUtils.getDomainSocketMaxPathLength());
     LOG.info("Domain socket data server is enabled at {}.", domainSocketPath);
     BlockWorkerGrpc.BlockWorkerImplBase blockWorkerService;
     if (worker instanceof DoraWorker) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Short circuit read the alluxio.worker.data.server.domain.socket.address more than 108 throw NoSuchFileException address configuration if the path，especially alluxio.worker.data.server.domain.socket.as.uuid set true
- On unix systems, the length of a domain socket path is limited to 108 ，however, this limitation is not checked in alluxio, resulting in only half of the uuid being created，such as


> domainSocketPath is /xxx/xxx/xxx/xxx/alluxio_socket/65f21a84-a4b5-408e-8066-8d8c4c171cd5

> What's actually generated is  /xxx/xxx/xxx/xxx/alluxio_socket/65f21a84-a4b5-408e-8066-8d8c4c


### Why are the changes needed?

1. Add domainSocketPath length checks instead of throwing NoSuchFileException
