### PR TITLE
Write to UFS when failed to write to Alluxio Worker

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraFileOutStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraFileOutStream.java
@@ -225,36 +225,45 @@ public class DoraFileOutStream extends FileOutStream {
   }
 
   private void writeInternal(byte[] b, int off, int len) throws IOException {
-    try {
-      Preconditions.checkArgument(b != null, PreconditionMessage.ERR_WRITE_BUFFER_NULL);
-      Preconditions.checkArgument(off >= 0 && len >= 0 && len + off <= b.length,
-          PreconditionMessage.ERR_BUFFER_STATE.toString(), b.length, off, len);
-
-      if (mAlluxioStorageType.isStore() || !mClientWriteToUFSEnabled) {
-        // If client is configured to write data to worker and ask worker to write to UFS,
-        // client must send data over netty.
+    Preconditions.checkArgument(b != null, PreconditionMessage.ERR_WRITE_BUFFER_NULL);
+    Preconditions.checkArgument(off >= 0 && len >= 0 && len + off <= b.length,
+        PreconditionMessage.ERR_BUFFER_STATE.toString(), b.length, off, len);
+    if (!mClientWriteToUFSEnabled) {
+      // If client is configured to write data to worker and ask worker to write to UFS,
+      // client must send data over netty.
+      try {
         mNettyDataWriter.writeChunk(b, off, len);
-
         Metrics.BYTES_WRITTEN_ALLUXIO.inc(len);
-      }
-      if (mUnderStorageType.isSyncPersist()) {
-        if (mUnderStorageOutputStream != null) {
-          mUnderStorageOutputStream.write(b, off, len);
-          Metrics.BYTES_WRITTEN_UFS.inc(len);
+        mBytesWritten += len;
+        return;
+      } catch (IOException e) {
+        Throwable throwable = mNettyDataWriter.getPacketWriteException();
+        if (throwable != null) {
+          e.addSuppressed(throwable);
         }
+        throw e;
       }
-      mBytesWritten += len;
-    } catch (IOException e) {
-      StringBuffer exceptionMsg = new StringBuffer();
-      Throwable throwable = mNettyDataWriter.getPacketWriteException();
-      if (throwable != null) {
-        exceptionMsg.append(throwable.getMessage() + " ");
-      }
-      if (e.getMessage() != null) {
-        exceptionMsg.append(e.getMessage());
-      }
-      throw new IOException(exceptionMsg.toString());
     }
+
+    if (mAlluxioStorageType.isStore()) {
+      try {
+        mNettyDataWriter.writeChunk(b, off, len);
+        Metrics.BYTES_WRITTEN_ALLUXIO.inc(len);
+      } catch (IOException e) {
+        Throwable throwable = mNettyDataWriter.getPacketWriteException();
+        if (throwable != null) {
+          e.addSuppressed(throwable);
+        }
+        LOG.error("Failed to write data to alluxio worker. ", e);
+      }
+    }
+    if (mUnderStorageType.isSyncPersist()) {
+      if (mUnderStorageOutputStream != null) {
+        mUnderStorageOutputStream.write(b, off, len);
+        Metrics.BYTES_WRITTEN_UFS.inc(len);
+      }
+    }
+    mBytesWritten += len;
   }
 
   /**

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraFileOutStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraFileOutStream.java
@@ -254,6 +254,7 @@ public class DoraFileOutStream extends FileOutStream {
         if (throwable != null) {
           e.addSuppressed(throwable);
         }
+        // writing to worker over netty failed. But Alluxio client continues writing to UFS.
         LOG.error("Failed to write data to alluxio worker. ", e);
       }
     }


### PR DESCRIPTION
1. Use `addSuppressed` instead of creating a new exception to throw the original exception.
2. Go ahead to write data to UFS when it encountered exception during the time writing data to Alluxio Worker.
