### PR TITLE
Check env preconditions before building go cli

### DIFF
--- a/build/cli/build-cli.sh
+++ b/build/cli/build-cli.sh
@@ -12,7 +12,7 @@
 
 set -eu
 
-CLI_DIR=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
+CWD=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
 
 # tuple of GOOS, GOARCH, and combined uname value for binary name
 OS_ARCH_TUPLES=(
@@ -41,10 +41,22 @@ main() {
     esac
   done
 
-  cliBinDir="${CLI_DIR}/../../cli/src/alluxio.org/cli/bin"
+  # check go and its version
+  if ! command -v go > /dev/null; then
+    echo "Could not run the command 'go'. Please check that it is installed and accessible from \$PATH"
+    exit 1
+  fi
+  go_version=$(go version)
+  if [[ ! ${go_version} =~ ^go\ version\ go1\.(18|19|[2-9][0-9]) ]]; then
+    echo "Go version must be 1.18 or later, but got ${go_version}"
+    exit 1
+  fi
+
+  cliBinDir="${CWD}/../../cli/src/alluxio.org/cli/bin"
   mkdir -p "${cliBinDir}"
 
-  cd "${CLI_DIR}/../../cli/src/alluxio.org/"
+  cd "${CWD}/../../cli/src/alluxio.org/"
+  go mod tidy
 
   if [[ ${build_all} == "false" ]]; then
     GO111MODULE=on go build -o "${cliBinDir}/alluxioCli-$(uname)-$(uname -m)" "${MAIN_PATH}"

--- a/docs/en/contributor/Building-Alluxio-From-Source.md
+++ b/docs/en/contributor/Building-Alluxio-From-Source.md
@@ -8,11 +8,12 @@ This guide describes how to clone the Alluxio repository, compile the source cod
 
 ## Required Software
 
-- [Java 11](https://www.oracle.com/java/technologies/downloads/#java11)
+- [Java 8](https://www.oracle.com/java/technologies/downloads/#java8)
 - [Maven 3.8.6 or later](http://maven.apache.org/download.cgi)
+- [Golang 1.18.1 or later](https://go.dev/doc/install)
 - [Git](https://git-scm.org/downloads)
 
-Alternatively, we have published a docker image [alluxio/alluxio-maven](https://hub.docker.com/r/alluxio/alluxio-maven) with Java, Maven, and Git pre-installed to help build Alluxio source code.
+Alternatively, we have published a docker image [alluxio/alluxio-maven](https://hub.docker.com/r/alluxio/alluxio-maven) with Java, Maven, Golang, and Git pre-installed to help build Alluxio source code.
 
 ## Checkout Source Code
 
@@ -79,7 +80,7 @@ Subsequent builds, however, will be much faster.
 Once Alluxio is built, you can start it with:
 
 ```shell
-$ ./bin/alluxio-start.sh local SudoMount
+$ ./bin/alluxio process start local
 ```
 
 To verify that Alluxio is running, you can visit [`http://localhost:19999`](http://localhost:19999) or
@@ -89,7 +90,7 @@ It may take a few seconds for the web server to start.
 You can run a test command to verify that data can be read and written to Alluxio:
 
 ```shell
-$ ./bin/alluxio runTests
+$ ./bin/alluxio exec basicIOTest
 ```
 
 You should be able to see the result `Passed the test!`
@@ -97,7 +98,7 @@ You should be able to see the result `Passed the test!`
 Stop the local Alluxio system by using:
 
 ```shell
-$ ./bin/alluxio-stop.sh local
+$ ./bin/alluxio process stop local
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
in the golang cli build script, check that
- `go` is accessible
- go version is 1.18+
- run `go mod tidy` which should be a no-op command normally, but if it's the first time building, it will download some native packages

also update the compile requirements in docs