### PR TITLE
Add metrics for the ages of the pages in page cache store

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -855,6 +855,8 @@ public class LocalCacheManager implements CacheManager {
         dir.scanPages(pageInfo -> {
           if (pageInfo.isPresent() && predicate.test(pageInfo.get())) {
             MetricsSystem.meter(MetricKey.CLIENT_CACHE_PAGES_INVALIDATED.getName()).mark();
+            MetricsSystem.histogram(MetricKey.CLIENT_CACHE_PAGES_AGES.getName())
+                .update(System.currentTimeMillis() - pageInfo.get().getCreatedTimestamp());
             delete(pageInfo.get().getPageId());
           }
         });

--- a/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -2259,6 +2259,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_PAGES_AGES =
+      new Builder("Client.CachePagesAges")
+          .setDescription("The ages of pages in the client cache.")
+          .setMetricType(MetricType.HISTOGRAM)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_PAGES_DISCARDED =
       new Builder("Client.CachePagesDiscarded")
           .setDescription("Total number of pages discarded when restoring the page store.")


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add metrics for the ages of the pages in page cache store

### Why are the changes needed?
To make sure we're not keep the data in cache too long

### Does this PR introduce any user facing changes?

no
