### PR TITLE
Support HDFS UFS trash

### DIFF
--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1218,14 +1218,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
-  public static final PropertyKey UNDERFS_HDFS_TRASH_ENABLE =
-      booleanBuilder(Name.UNDERFS_HDFS_TRASH_ENABLE)
+  public static final PropertyKey UNDERFS_HDFS_TRASH_ENABLED =
+      booleanBuilder(Name.UNDERFS_HDFS_TRASH_ENABLED)
           .setDefaultValue(false)
-          .setDescription("Whether to enable the HDFS trash feature, "
-              + "it is important to note that after enabling this configuration, "
-              + "you need to set the relevant trash configurations (such as 'fs.trash.interval') "
-              + "in 'hdfs-site.xml' and 'core-ste.xml' "
-              + "in order to truly use the HDFS trash functionality.")
+          .setDescription("If enabled, when a user deletes a file that's stored in HDFS via "
+              + "Alluxio, Alluxio will make use of HDFS's trash and try to move it to the trash "
+              + "directory instead of deleting it directly from HDFS. Note that HDFS must be "
+              + "configured to enable the trash functionality (in 'core-site.xml'). If trashing "
+              + "is not enabled in HDFS, Alluxio will delete the file directly, regardless of "
+              + "this configuration.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
@@ -7244,7 +7245,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_HDFS_PREFIXES = "alluxio.underfs.hdfs.prefixes";
     public static final String UNDERFS_OZONE_PREFIXES = "alluxio.underfs.ozone.prefixes";
     public static final String UNDERFS_HDFS_REMOTE = "alluxio.underfs.hdfs.remote";
-    public static final String UNDERFS_HDFS_TRASH_ENABLE = "alluxio.underfs.hdfs.trash.enable";
+    public static final String UNDERFS_HDFS_TRASH_ENABLED = "alluxio.underfs.hdfs.trash.enabled";
     public static final String UNDERFS_IO_THREADS = "alluxio.underfs.io.threads";
     public static final String UNDERFS_LOCAL_SKIP_BROKEN_SYMLINKS =
         "alluxio.underfs.local.skip.broken.symlinks";

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1218,6 +1218,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_HDFS_TRASH_ENABLE =
+      booleanBuilder(Name.UNDERFS_HDFS_TRASH_ENABLE)
+          .setDefaultValue(false)
+          .setDescription("Whether to enable the HDFS trash feature, "
+              + "it is important to note that after enabling this configuration, "
+              + "you need to set the relevant trash configurations (such as 'fs.trash.interval') "
+              + "in 'hdfs-site.xml' and 'core-ste.xml' "
+              + "in order to truly use the HDFS trash functionality.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_IO_THREADS =
       intBuilder(Name.UNDERFS_IO_THREADS)
           .setDefaultSupplier(() -> Math.max(4, 3 * Runtime.getRuntime().availableProcessors()),
@@ -7233,6 +7244,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_HDFS_PREFIXES = "alluxio.underfs.hdfs.prefixes";
     public static final String UNDERFS_OZONE_PREFIXES = "alluxio.underfs.ozone.prefixes";
     public static final String UNDERFS_HDFS_REMOTE = "alluxio.underfs.hdfs.remote";
+    public static final String UNDERFS_HDFS_TRASH_ENABLE = "alluxio.underfs.hdfs.trash.enable";
     public static final String UNDERFS_IO_THREADS = "alluxio.underfs.io.threads";
     public static final String UNDERFS_LOCAL_SKIP_BROKEN_SYMLINKS =
         "alluxio.underfs.local.skip.broken.symlinks";


### PR DESCRIPTION
Original-author: humengyu <hellohumengyu@gmail.com>

### What changes are proposed in this pull request?

Support hdfs trash in hdfs ufs.

### Why are the changes needed?

https://github.com/Alluxio/alluxio/issues/17723

HDFS trash is a very useful feature, and we should support it. It allows users to recover deleted files from the trash after accidental deletion.

## Usage:
add config in `alluxio-site.properties`:
```
alluxio.underfs.hdfs.trash.enable=true
```
add config in hdfs `core-site.xml`:
```
    <property>
        <name>fs.trash.interval</name>
        <value>1440</value>
    </property>
```

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs YES
  2. addition or removal of property keys YES
  3. webui NO
