### PR TITLE
Fix bug of classnotfound at Fuse runtime

### DIFF
--- a/dora/integration/jnifuse/fs/pom.xml
+++ b/dora/integration/jnifuse/fs/pom.xml
@@ -36,6 +36,10 @@
       <artifactId>jnr-fuse</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.etcd</groupId>
+      <artifactId>jetcd-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-integration-jnifuse-native</artifactId>
       <version>${project.version}</version>

--- a/dora/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
+++ b/dora/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
@@ -120,12 +120,12 @@ public abstract class AbstractFuseFileSystem implements FuseFileSystem {
   }
 
   private int execMount(String[] arg) {
-
-    AddressResolverOptions addressResolverOptions = new AddressResolverOptions();
+    loadNecessaryClasses();
     return mLibFuse.fuse_main_real(this, arg.length, arg);
   }
 
   private void loadNecessaryClasses() {
+    LOG.info("Loading necessary classes...");
     try {
       String[] classesToLoad = {
           "io.vertx.core.dns.AddressResolverOptions"

--- a/dora/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
+++ b/dora/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
@@ -32,6 +32,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.vertx.core.dns.AddressResolverOptions;
+
 /**
  * Abstract class for other File System to extend and integrate with Fuse.
  */
@@ -118,7 +120,25 @@ public abstract class AbstractFuseFileSystem implements FuseFileSystem {
   }
 
   private int execMount(String[] arg) {
+
+    AddressResolverOptions addressResolverOptions = new AddressResolverOptions();
     return mLibFuse.fuse_main_real(this, arg.length, arg);
+  }
+
+  private void loadNecessaryClasses() {
+    try {
+      String[] classesToLoad = {
+          "io.vertx.core.dns.AddressResolverOptions"
+      };
+      for (String classToLoad : classesToLoad) {
+        Class<io.vertx.core.dns.AddressResolverOptions> cls =
+            (Class<AddressResolverOptions>)
+                ClassLoader.getSystemClassLoader().loadClass(classToLoad);
+        cls.newInstance();
+      }
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

fix the bug where fuse has the bug of "java.lang.NoClassDefFoundError: Could not initialize class io.vertx.core.dns.AddressResolverOptions" after jetcd dependency was introduced

### Why are the changes needed?

classes from native side, if not explicitly loaded, it will spew "NoClassDefFoundError" at runtime when the relevant classes was invoked.

### Does this PR introduce any user facing changes?

No.
