### PR TITLE
Add init/format, copyDir subcommands to CLI

### DIFF
--- a/cli/src/alluxio.org/cli/cmd/initiate/copy_dir.go
+++ b/cli/src/alluxio.org/cli/cmd/initiate/copy_dir.go
@@ -1,0 +1,185 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package initiate
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh"
+
+	"alluxio.org/cli/processes"
+	"alluxio.org/log"
+)
+
+var CopyDir = &CopyDirCommand{}
+
+type CopyDirCommand struct{}
+
+func (c *CopyDirCommand) ToCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "copyDir [path]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Copy a path to all master/worker nodes.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// prepare client config, ssh port info
+			config, port, err := processes.PrepareCommand()
+			if err != nil {
+				return stacktrace.Propagate(err, "prepare command failed")
+			}
+
+			// get list of masters or workers, or both
+			hosts, err := processes.GetHostnames([]string{processes.HostGroupMasters, processes.HostGroupWorkers})
+			if err != nil {
+				return stacktrace.Propagate(err, "cannot read host names")
+			}
+
+			myHost, err := os.Hostname()
+			if err != nil {
+				return stacktrace.Propagate(err, "cannot read local host name")
+			}
+
+			absolutePath, err := filepath.Abs(args[0])
+			if err != nil {
+				return stacktrace.Propagate(err, "Invalid path to copy")
+			}
+
+			var wg sync.WaitGroup
+			errs := make(chan error, len(hosts))
+			for _, host := range hosts {
+				if host != myHost {
+					wg.Add(1)
+					go func(host string) {
+						defer wg.Done()
+						err := copyDirectory(absolutePath, host, config, port, errs)
+						errs <- err
+					}(host)
+				}
+			}
+
+			go func() {
+				wg.Wait()
+				close(errs)
+			}()
+
+			var errMsgs []string
+			for err := range errs {
+				errMsgs = append(errMsgs, err.Error())
+			}
+			if len(errMsgs) > 0 {
+				return stacktrace.NewError("At least one error encountered:\n%v", strings.Join(errMsgs, "\n"))
+			}
+			log.Logger.Infof("CopyDir successful on nodes: %s", hosts)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func copyDirectory(path, host string, config *ssh.ClientConfig, port int, errs chan<- error) error {
+	log.Logger.Infof("Path: %s", path)
+	conn, err := ssh.Dial("tcp", host+":"+strconv.Itoa(port), config)
+	if err != nil {
+		return err
+	}
+	defer func(conn *ssh.Client) {
+		if err := conn.Close(); err != nil {
+			log.Logger.Warnf("connection to %s closed, error: %s", host, err)
+		} else {
+			log.Logger.Debugf("connection to %s closed", host)
+		}
+	}(conn)
+
+	session, err := conn.NewSession()
+	if err != nil {
+		return stacktrace.Propagate(err, "cannot create session at %v.", host)
+	}
+	defer func(session *ssh.Session) {
+		if err := session.Close(); err != nil && err != io.EOF {
+			log.Logger.Warnf("session at %s closed, error: %s", host, err)
+		} else {
+			log.Logger.Debugf("session at %s closed", host)
+		}
+	}(session)
+
+	session.Stdout = os.Stdout
+	session.Stderr = os.Stderr
+
+	entries, err := ioutil.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		filePath := filepath.Join(path, entry.Name())
+		if entry.IsDir() {
+			if err := copyDirectory(filePath, host, config, port, errs); err != nil {
+				return err
+			}
+		} else {
+			go func() {
+				err := copyFile(path, session)
+				errs <- err
+			}()
+		}
+	}
+
+	return nil
+}
+
+func copyFile(path string, session *ssh.Session) error {
+	localFile, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func(localFile *os.File) {
+		err := localFile.Close()
+		if err != nil {
+			log.Logger.Warnf("Local file %s closed with error: %v", path, err)
+		} else {
+			log.Logger.Debugf("Local file %s closed.", path)
+		}
+	}(localFile)
+
+	remoteFile, err := session.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	errChan := make(chan error)
+	go func() {
+		defer func(remoteFile io.WriteCloser) {
+			err := remoteFile.Close()
+			if err != nil {
+				log.Logger.Warnf("Remote file %s closed with error: %v", path, err)
+			} else {
+				log.Logger.Debugf("Remote file %s closed.", path)
+			}
+		}(remoteFile)
+		_, err := io.Copy(remoteFile, localFile)
+		errChan <- err
+	}()
+
+	if err := session.Run(fmt.Sprintf("cat > %s", path)); err != nil {
+		return err
+	}
+
+	return <-errChan
+}

--- a/cli/src/alluxio.org/cli/cmd/initiate/copy_dir.go
+++ b/cli/src/alluxio.org/cli/cmd/initiate/copy_dir.go
@@ -61,14 +61,8 @@ func (c *CopyDirCommand) ToCommand() *cobra.Command {
 				log.Logger.Infof("RSYNCing directory %s to %s", args[0], host)
 
 				// src path needs to end with a slash, but dst path needs to end without the slash
-				var srcDir, dstDir string
-				if strings.HasSuffix(absolutePath, "/") {
-					srcDir = absolutePath
-					dstDir = strings.TrimRight(absolutePath, "/")
-				} else {
-					srcDir = absolutePath + "/"
-					dstDir = absolutePath
-				}
+				dstDir := strings.TrimRight(absolutePath, "/")
+				srcDir := dstDir + "/"
 
 				cmd := exec.Command("rsync", "-az", srcDir,
 					fmt.Sprintf("%s:%s", host, dstDir))

--- a/cli/src/alluxio.org/cli/cmd/initiate/copy_dir.go
+++ b/cli/src/alluxio.org/cli/cmd/initiate/copy_dir.go
@@ -13,20 +13,16 @@ package initiate
 
 import (
 	"fmt"
-	"io"
-	"io/ioutil"
 	"os"
+	"os/exec"
+	"os/user"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"sync"
-
-	"github.com/palantir/stacktrace"
-	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh"
 
 	"alluxio.org/cli/processes"
 	"alluxio.org/log"
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
 )
 
 var CopyDir = &CopyDirCommand{}
@@ -39,147 +35,67 @@ func (c *CopyDirCommand) ToCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Short: "Copy a path to all master/worker nodes.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// prepare client config, ssh port info
-			config, port, err := processes.PrepareCommand()
-			if err != nil {
-				return stacktrace.Propagate(err, "prepare command failed")
-			}
-
 			// get list of masters or workers, or both
 			hosts, err := processes.GetHostnames([]string{processes.HostGroupMasters, processes.HostGroupWorkers})
 			if err != nil {
 				return stacktrace.Propagate(err, "cannot read host names")
 			}
 
+			// get name of current host, avoid rsync itself
 			myHost, err := os.Hostname()
 			if err != nil {
 				return stacktrace.Propagate(err, "cannot read local host name")
 			}
 
+			// determine the absolute directory to copy
 			absolutePath, err := filepath.Abs(args[0])
 			if err != nil {
-				return stacktrace.Propagate(err, "Invalid path to copy")
+				return stacktrace.Propagate(err, "cannot find absolute path")
 			}
 
-			var wg sync.WaitGroup
-			errs := make(chan error, len(hosts))
+			// hypothesize all hosts use the same username
+			cu, err := user.Current()
+			if err != nil {
+				return stacktrace.Propagate(err, "cannot find current user")
+			}
+
+			var errs []error
 			for _, host := range hosts {
-				if host != myHost {
-					wg.Add(1)
-					go func(host string) {
-						defer wg.Done()
-						err := copyDirectory(absolutePath, host, config, port, errs)
-						errs <- err
-					}(host)
+				if host == myHost {
+					continue
+				}
+				log.Logger.Infof("RSYNCing directory %s to %s", args[0], host)
+
+				// src path needs to end with a slash, but dst path needs to end without the slash
+				var srcDir, dstDir string
+				if strings.HasSuffix(absolutePath, "/") {
+					srcDir = absolutePath
+					dstDir = strings.TrimRight(absolutePath, "/")
+				} else {
+					srcDir = absolutePath + "/"
+					dstDir = absolutePath
+				}
+
+				cmd := exec.Command("rsync", "-az", srcDir,
+					fmt.Sprintf("%s@%s:%s", cu.Username, host, dstDir))
+				log.Logger.Infof("Command: %s", cmd)
+				if err := cmd.Run(); err != nil {
+					log.Logger.Error("Error: %s", err)
+					errs = append(errs, err)
 				}
 			}
 
-			go func() {
-				wg.Wait()
-				close(errs)
-			}()
-
-			var errMsgs []string
-			for err := range errs {
-				errMsgs = append(errMsgs, err.Error())
-			}
-			if len(errMsgs) > 0 {
+			if len(errs) > 0 {
+				var errMsgs []string
+				for _, err := range errs {
+					errMsgs = append(errMsgs, err.Error())
+				}
 				return stacktrace.NewError("At least one error encountered:\n%v", strings.Join(errMsgs, "\n"))
 			}
-			log.Logger.Infof("CopyDir successful on nodes: %s", hosts)
+
+			log.Logger.Infof("Copying path %s successful on nodes: %s", args[0], hosts)
 			return nil
 		},
 	}
 	return cmd
-}
-
-func copyDirectory(path, host string, config *ssh.ClientConfig, port int, errs chan<- error) error {
-	log.Logger.Infof("Path: %s", path)
-	conn, err := ssh.Dial("tcp", host+":"+strconv.Itoa(port), config)
-	if err != nil {
-		return err
-	}
-	defer func(conn *ssh.Client) {
-		if err := conn.Close(); err != nil {
-			log.Logger.Warnf("connection to %s closed, error: %s", host, err)
-		} else {
-			log.Logger.Debugf("connection to %s closed", host)
-		}
-	}(conn)
-
-	session, err := conn.NewSession()
-	if err != nil {
-		return stacktrace.Propagate(err, "cannot create session at %v.", host)
-	}
-	defer func(session *ssh.Session) {
-		if err := session.Close(); err != nil && err != io.EOF {
-			log.Logger.Warnf("session at %s closed, error: %s", host, err)
-		} else {
-			log.Logger.Debugf("session at %s closed", host)
-		}
-	}(session)
-
-	session.Stdout = os.Stdout
-	session.Stderr = os.Stderr
-
-	entries, err := ioutil.ReadDir(path)
-	if err != nil {
-		return err
-	}
-
-	for _, entry := range entries {
-		filePath := filepath.Join(path, entry.Name())
-		if entry.IsDir() {
-			if err := copyDirectory(filePath, host, config, port, errs); err != nil {
-				return err
-			}
-		} else {
-			go func() {
-				err := copyFile(path, session)
-				errs <- err
-			}()
-		}
-	}
-
-	return nil
-}
-
-func copyFile(path string, session *ssh.Session) error {
-	localFile, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer func(localFile *os.File) {
-		err := localFile.Close()
-		if err != nil {
-			log.Logger.Warnf("Local file %s closed with error: %v", path, err)
-		} else {
-			log.Logger.Debugf("Local file %s closed.", path)
-		}
-	}(localFile)
-
-	remoteFile, err := session.StdinPipe()
-	if err != nil {
-		return err
-	}
-
-	errChan := make(chan error)
-	go func() {
-		defer func(remoteFile io.WriteCloser) {
-			err := remoteFile.Close()
-			if err != nil {
-				log.Logger.Warnf("Remote file %s closed with error: %v", path, err)
-			} else {
-				log.Logger.Debugf("Remote file %s closed.", path)
-			}
-		}(remoteFile)
-		_, err := io.Copy(remoteFile, localFile)
-		errChan <- err
-	}()
-
-	if err := session.Run(fmt.Sprintf("cat > %s", path)); err != nil {
-		return err
-	}
-
-	return <-errChan
 }

--- a/cli/src/alluxio.org/cli/cmd/initiate/copy_dir.go
+++ b/cli/src/alluxio.org/cli/cmd/initiate/copy_dir.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -53,12 +52,6 @@ func (c *CopyDirCommand) ToCommand() *cobra.Command {
 				return stacktrace.Propagate(err, "cannot find absolute path")
 			}
 
-			// hypothesize all hosts use the same username
-			cu, err := user.Current()
-			if err != nil {
-				return stacktrace.Propagate(err, "cannot find current user")
-			}
-
 			var errs []error
 			for _, host := range hosts {
 				if host == myHost {
@@ -77,7 +70,7 @@ func (c *CopyDirCommand) ToCommand() *cobra.Command {
 				}
 
 				cmd := exec.Command("rsync", "-az", srcDir,
-					fmt.Sprintf("%s@%s:%s", cu.Username, host, dstDir))
+					fmt.Sprintf("%s:%s", host, dstDir))
 				log.Logger.Infof("Command: %s", cmd)
 				if err := cmd.Run(); err != nil {
 					log.Logger.Error("Error: %s", err)

--- a/cli/src/alluxio.org/cli/cmd/initiate/copy_dir.go
+++ b/cli/src/alluxio.org/cli/cmd/initiate/copy_dir.go
@@ -18,10 +18,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"alluxio.org/cli/processes"
-	"alluxio.org/log"
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/processes"
+	"alluxio.org/log"
 )
 
 var CopyDir = &CopyDirCommand{}

--- a/cli/src/alluxio.org/cli/cmd/initiate/format.go
+++ b/cli/src/alluxio.org/cli/cmd/initiate/format.go
@@ -1,0 +1,78 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package initiate
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/palantir/stacktrace"
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/cmd/names"
+	"alluxio.org/cli/env"
+	"alluxio.org/cli/processes"
+	"alluxio.org/log"
+)
+
+var Format = &FormatCommand{}
+
+type FormatCommand struct {
+	localFileSystem bool
+}
+
+func (c *FormatCommand) ToCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "format",
+		Args:  cobra.NoArgs,
+		Short: "Format Alluxio master and all workers",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if c.localFileSystem {
+				// check if alluxio.master.mount.table.root.ufs set
+				if env.Env.EnvVar.GetString(env.ConfAlluxioMasterMountTableRootUfs.EnvVar) != "" {
+					return nil
+				}
+			}
+
+			cliPath := filepath.Join(env.Env.EnvVar.GetString(env.ConfAlluxioHome.EnvVar), names.BinAlluxio)
+
+			//run cache format on workers
+			workerArgs := []string{"cache", "format"}
+			if err := processes.RunSshCommand(
+				strings.Join(append([]string{cliPath}, workerArgs...), " "),
+				processes.HostGroupWorkers); err != nil {
+				return stacktrace.Propagate(err, "error formatting workers")
+			}
+
+			// run journal format on masters
+			journalArgs := []string{"journal", "format"}
+			if env.Env.EnvVar.GetString(env.ConfAlluxioMasterJournalType.EnvVar) == "EMBEDDED" {
+				if err := processes.RunSshCommand(
+					strings.Join(append([]string{cliPath}, journalArgs...), " "),
+					processes.HostGroupWorkers); err != nil {
+					return stacktrace.Propagate(err, "error formatting masters")
+				}
+			} else {
+				if err := exec.Command(cliPath, journalArgs...).Run(); err != nil {
+					return stacktrace.Propagate(err, "error formatting master")
+				}
+			}
+			log.Logger.Infof("Format successful on master and workers.")
+
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&c.localFileSystem, "localFileSystem", "s", false,
+		"if -s specified, only format if underfs is local and doesn't already exist")
+	return cmd
+}

--- a/cli/src/alluxio.org/cli/cmd/initiate/initiate.go
+++ b/cli/src/alluxio.org/cli/cmd/initiate/initiate.go
@@ -22,7 +22,7 @@ var Service = &env.Service{
 		ClearMetrics,
 		ClearOSCache,
 		// CopyDir,
-		// Format,
+		Format,
 		Validate,
 	},
 }

--- a/cli/src/alluxio.org/cli/cmd/initiate/initiate.go
+++ b/cli/src/alluxio.org/cli/cmd/initiate/initiate.go
@@ -21,7 +21,7 @@ var Service = &env.Service{
 	Commands: []env.Command{
 		ClearMetrics,
 		ClearOSCache,
-		// CopyDir,
+		CopyDir,
 		Format,
 		Validate,
 	},

--- a/cli/src/alluxio.org/cli/env/env.go
+++ b/cli/src/alluxio.org/cli/env/env.go
@@ -159,7 +159,8 @@ func InitAlluxioEnv(rootPath string, jarEnvVars map[string]string, appendClasspa
 	for _, c := range []*AlluxioConfigEnvVar{
 		confAlluxioRamFolder,
 		confAlluxioMasterHostname,
-		confAlluxioMasterMountTableRootUfs,
+		ConfAlluxioMasterMountTableRootUfs,
+		ConfAlluxioMasterJournalType,
 		confAlluxioWorkerRamdiskSize,
 	} {
 		alluxioJavaOpts += c.ToJavaOpt(envVar, false) // optional user provided java opts

--- a/cli/src/alluxio.org/cli/env/env_vars.go
+++ b/cli/src/alluxio.org/cli/env/env_vars.go
@@ -104,9 +104,13 @@ var (
 		configKey: "alluxio.master.hostname",
 		EnvVar:    "ALLUXIO_MASTER_HOSTNAME",
 	}
-	confAlluxioMasterMountTableRootUfs = &AlluxioConfigEnvVar{
+	ConfAlluxioMasterMountTableRootUfs = &AlluxioConfigEnvVar{
 		configKey: "alluxio.master.mount.table.root.ufs",
 		EnvVar:    "ALLUXIO_MASTER_MOUNT_TABLE_ROOT_UFS",
+	}
+	ConfAlluxioMasterJournalType = &AlluxioConfigEnvVar{
+		configKey: "alluxio.master.journal.type",
+		EnvVar:    "ALLUXIO_MASTER_JOURNAL_TYPE",
 	}
 	confAlluxioWorkerRamdiskSize = &AlluxioConfigEnvVar{
 		configKey: "alluxio.worker.ramdisk.size",

--- a/cli/src/alluxio.org/cli/processes/common.go
+++ b/cli/src/alluxio.org/cli/processes/common.go
@@ -47,16 +47,16 @@ func NewHostnamesFile(name string) *HostnamesFile {
 }
 
 // RunSshCommand parses hostnames from the hosts files such as `conf/masters` and `conf/workers`
-// For each hostname, create a SSH client and run the given command
+// For each hostname, create an SSH client and run the given command
 func RunSshCommand(command string, hostGroups ...string) error {
 	// prepare client config, ssh port info
-	config, port, err := prepareCommand()
+	config, port, err := PrepareCommand()
 	if err != nil {
 		return stacktrace.Propagate(err, "prepare command failed")
 	}
 
 	// get list of masters or workers, or both
-	hosts, err := getHostnames(hostGroups)
+	hosts, err := GetHostnames(hostGroups)
 	if err != nil {
 		return stacktrace.Propagate(err, "cannot read host names")
 	}
@@ -126,7 +126,7 @@ func RunSshCommand(command string, hostGroups ...string) error {
 	return nil
 }
 
-func prepareCommand() (*ssh.ClientConfig, int, error) {
+func PrepareCommand() (*ssh.ClientConfig, int, error) {
 	// get the current user
 	cu, err := user.Current()
 	if err != nil {
@@ -189,7 +189,7 @@ const (
 	HostGroupWorkers = "workers"
 )
 
-func getHostnames(hostGroups []string) ([]string, error) {
+func GetHostnames(hostGroups []string) ([]string, error) {
 	var hosts []string
 	for _, hostGroup := range hostGroups {
 		switch hostGroup {

--- a/cli/src/alluxio.org/cli/processes/common.go
+++ b/cli/src/alluxio.org/cli/processes/common.go
@@ -50,7 +50,7 @@ func NewHostnamesFile(name string) *HostnamesFile {
 // For each hostname, create an SSH client and run the given command
 func RunSshCommand(command string, hostGroups ...string) error {
 	// prepare client config, ssh port info
-	config, port, err := PrepareCommand()
+	config, port, err := prepareCommand()
 	if err != nil {
 		return stacktrace.Propagate(err, "prepare command failed")
 	}
@@ -126,7 +126,7 @@ func RunSshCommand(command string, hostGroups ...string) error {
 	return nil
 }
 
-func PrepareCommand() (*ssh.ClientConfig, int, error) {
+func prepareCommand() (*ssh.ClientConfig, int, error) {
 	// get the current user
 	cu, err := user.Current()
 	if err != nil {

--- a/cli/src/alluxio.org/cli/processes/common.go
+++ b/cli/src/alluxio.org/cli/processes/common.go
@@ -46,9 +46,9 @@ func NewHostnamesFile(name string) *HostnamesFile {
 	}
 }
 
-// runSshCommand parses hostnames from the hosts files such as `conf/masters` and `conf/workers`
+// RunSshCommand parses hostnames from the hosts files such as `conf/masters` and `conf/workers`
 // For each hostname, create a SSH client and run the given command
-func runSshCommand(command string, hostGroups ...string) error {
+func RunSshCommand(command string, hostGroups ...string) error {
 	// prepare client config, ssh port info
 	config, port, err := prepareCommand()
 	if err != nil {

--- a/cli/src/alluxio.org/cli/processes/multi.go
+++ b/cli/src/alluxio.org/cli/processes/multi.go
@@ -82,7 +82,7 @@ func (p *MultiProcess) StopCmd(cmd *cobra.Command) *cobra.Command {
 }
 
 func (p *MultiProcess) Start(cmd *env.StartProcessCommand) error {
-	return runSshCommand(
+	return RunSshCommand(
 		addStartFlags(cmd,
 			process.Service.Name,
 			env.StartProcessName,
@@ -91,7 +91,7 @@ func (p *MultiProcess) Start(cmd *env.StartProcessCommand) error {
 }
 
 func (p *MultiProcess) Stop(cmd *env.StopProcessCommand) error {
-	return runSshCommand(
+	return RunSshCommand(
 		addStopFlags(cmd,
 			process.Service.Name,
 			env.StopProcessName,


### PR DESCRIPTION
Additional `init` commands to golang CLI as part of https://github.com/Alluxio/alluxio/issues/17522

`bin/alluxio-bash format` -> `bin/alluxio init format`
`bin/alluxio-bash copyDir` -> `bin/alluxio init copyDir`