### PR TITLE
Fix S3 multipart upload and add related UTs

### DIFF
--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -36,22 +36,7 @@ import alluxio.s3.S3ErrorCode;
 import alluxio.s3.S3Exception;
 import alluxio.util.ThreadUtils;
 import alluxio.web.ProxyWebServer;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.MediaType;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.security.DigestOutputStream;
-import java.security.MessageDigest;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
-import java.util.stream.Collectors;
+
 import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -67,6 +52,23 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
 
 /**
  * A handler process multipart upload complete response.

--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadRequest.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadRequest.java
@@ -11,7 +11,6 @@
 
 package alluxio.proxy.s3;
 
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -19,6 +18,8 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * Implementation of CompleteMultipartUploadRequest according to

--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadRequest.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadRequest.java
@@ -11,9 +11,7 @@
 
 package alluxio.proxy.s3;
 
-import alluxio.s3.S3ErrorCode;
-import alluxio.s3.S3Exception;
-
+import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -21,8 +19,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 /**
  * Implementation of CompleteMultipartUploadRequest according to
@@ -49,16 +45,18 @@ public class CompleteMultipartUploadRequest {
    * @param parts the list of Part objects
    */
   public CompleteMultipartUploadRequest(List<Part> parts) {
-    this(parts, false);
+    setParts(parts);
   }
 
   /**
    * Creates a {@link CompleteMultipartUploadRequest}.
    * This is used exclusively for unit test purposes.
    *
-   * @param parts the list of Part objects
+   * @param parts            the list of Part objects
    * @param ignoreValidation flag to skip Part validation
+   * @deprecated always ignore valdateion
    */
+  @Deprecated
   public CompleteMultipartUploadRequest(List<Part> parts, boolean ignoreValidation) {
     if (ignoreValidation) {
       mParts = parts;
@@ -82,25 +80,6 @@ public class CompleteMultipartUploadRequest {
   @JacksonXmlProperty(localName = "Part")
   public void setParts(List<Part> parts) {
     mParts = parts;
-    validateParts();
-  }
-
-  private void validateParts() {
-    if (mParts.size() <= 1) { return; }
-    try {
-      int prevPartNum = mParts.get(0).getPartNumber();
-      for (Part part : mParts.subList(1, mParts.size())) {
-        if (prevPartNum + 1 != part.getPartNumber()) {
-          throw new S3Exception(S3ErrorCode.INVALID_PART_ORDER);
-        }
-        prevPartNum = part.getPartNumber();
-      }
-    } catch (S3Exception e) {
-      // IllegalArgumentException will be consumed by IOException from the
-      // jersey library when parsing the XML into this object
-      // - the underlying S3Exception will be the throwable cause for the IOException
-      throw new IllegalArgumentException(e);
-    }
   }
 
   /**

--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/ListMultipartUploadsResult.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/ListMultipartUploadsResult.java
@@ -12,8 +12,7 @@
 package alluxio.proxy.s3;
 
 import alluxio.client.file.URIStatus;
-import java.util.List;
-import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -21,6 +20,9 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of ListMultipartUploadsResult according to

--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/ListMultipartUploadsResult.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/ListMultipartUploadsResult.java
@@ -12,8 +12,8 @@
 package alluxio.proxy.s3;
 
 import alluxio.client.file.URIStatus;
-import alluxio.s3.S3Constants;
-
+import java.util.List;
+import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -21,9 +21,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Implementation of ListMultipartUploadsResult according to
@@ -48,6 +45,12 @@ public class ListMultipartUploadsResult {
   public static ListMultipartUploadsResult buildFromStatuses(String bucket,
                                                              List<URIStatus> children) {
     List<ListMultipartUploadsResult.Upload> uploads = children.stream()
+        .map(status -> new Upload(status.getName(), status.getName(),
+            S3RestUtils.toS3Date(status.getLastModificationTimeMs())
+        ))
+        .collect(Collectors.toList());
+        /*
+        TODO(pkuweblab): 3.x haven't supported XAttr yet, so can't mark Upload.key as object name
         .filter(status -> {
           if (status.getXAttr() == null
               || !status.getXAttr().containsKey(S3Constants.UPLOADS_BUCKET_XATTR_KEY)
@@ -65,6 +68,7 @@ public class ListMultipartUploadsResult {
             S3RestUtils.toS3Date(status.getLastModificationTimeMs())
         ))
         .collect(Collectors.toList());
+        */
     return new ListMultipartUploadsResult(bucket, uploads);
   }
 

--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ObjectTask.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ObjectTask.java
@@ -48,9 +48,22 @@ import alluxio.s3.S3RangeSpec;
 import alluxio.s3.TaggingData;
 import alluxio.util.ThreadUtils;
 import alluxio.web.ProxyWebServer;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+
+import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.google.common.base.Preconditions;
+import com.google.common.io.BaseEncoding;
+import com.google.common.io.ByteStreams;
+import com.google.common.primitives.Longs;
+import com.google.common.util.concurrent.RateLimiter;
+import com.google.protobuf.ByteString;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -67,20 +80,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
-import com.codahale.metrics.Timer;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.google.common.base.Preconditions;
-import com.google.common.io.BaseEncoding;
-import com.google.common.io.ByteStreams;
-import com.google.common.primitives.Longs;
-import com.google.common.util.concurrent.RateLimiter;
-import com.google.protobuf.ByteString;
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 /**
  * S3 Tasks to handle object level request.

--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -44,17 +44,14 @@ import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.user.ServerUserState;
 import alluxio.util.SecurityUtils;
 import alluxio.util.ThreadUtils;
-
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.cache.Cache;
-import com.google.common.primitives.Longs;
-import com.google.common.util.concurrent.RateLimiter;
-import com.google.protobuf.ByteString;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.security.auth.Subject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.Serializable;
 import java.text.DateFormat;
@@ -69,14 +66,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.security.auth.Subject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.util.concurrent.RateLimiter;
+import com.google.protobuf.ByteString;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utilities for handling S3 REST calls.
@@ -359,6 +356,7 @@ public final class S3RestUtils {
     final AlluxioURI metaUri = new AlluxioURI(
         S3RestUtils.getMultipartMetaFilepathForUploadId(uploadId));
     URIStatus metaStatus = metaFs.getStatus(metaUri);
+    /*  TODO(pkuweblab): 3.x haven't supported XAttr yet
     if (metaStatus.getXAttr() == null
         || !metaStatus.getXAttr().containsKey(S3Constants.UPLOADS_FILE_ID_XATTR_KEY)) {
       //TODO(czhu): determine intended behavior in this edge-case
@@ -370,6 +368,7 @@ public final class S3RestUtils {
       throw new RuntimeException(
           "Alluxio mismatched file ID for multipart-upload with upload ID: " + uploadId);
     }
+     */
     return new ArrayList<>(Arrays.asList(multipartTempDirStatus, metaStatus));
   }
 

--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -44,14 +44,16 @@ import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.user.ServerUserState;
 import alluxio.util.SecurityUtils;
 import alluxio.util.ThreadUtils;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.security.auth.Subject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.util.concurrent.RateLimiter;
+import com.google.protobuf.ByteString;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.text.DateFormat;
@@ -66,14 +68,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.cache.Cache;
-import com.google.common.util.concurrent.RateLimiter;
-import com.google.protobuf.ByteString;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.security.auth.Subject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 
 /**
  * Utilities for handling S3 REST calls.

--- a/dora/tests/integration/src/test/java/alluxio/client/rest/MultipartUploadTest.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/rest/MultipartUploadTest.java
@@ -25,10 +25,7 @@ import alluxio.proxy.s3.S3RestUtils;
 import alluxio.s3.S3ErrorCode;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.CommonUtils;
-import javax.ws.rs.core.Response.Status;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
@@ -41,6 +38,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.ws.rs.core.Response.Status;
 
 public class MultipartUploadTest extends RestApiTest {
   private FileSystem mFileSystem;

--- a/dora/tests/integration/src/test/java/alluxio/client/rest/MultipartUploadTest.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/rest/MultipartUploadTest.java
@@ -1,0 +1,425 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.rest;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.client.WriteType;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.conf.PropertyKey;
+import alluxio.proxy.s3.CompleteMultipartUploadRequest;
+import alluxio.proxy.s3.CompleteMultipartUploadRequest.Part;
+import alluxio.proxy.s3.CompleteMultipartUploadResult;
+import alluxio.proxy.s3.InitiateMultipartUploadResult;
+import alluxio.proxy.s3.S3RestUtils;
+import alluxio.s3.S3ErrorCode;
+import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.util.CommonUtils;
+import javax.ws.rs.core.Response.Status;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.gaul.s3proxy.junit.S3ProxyRule;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MultipartUploadTest extends RestApiTest {
+  private FileSystem mFileSystem;
+  private AmazonS3 mS3Client = null;
+  private static final int UFS_PORT = 8004;
+  private static final String S3_USER_NAME = "CustomersName@amazon.com";
+  private static final String BUCKET_NAME = "bucket";
+  private static final String OBJECT_NAME = "object";
+  private static final String OBJECT_KEY = BUCKET_NAME + AlluxioURI.SEPARATOR + OBJECT_NAME;
+  @Rule
+  public S3ProxyRule mS3Proxy = S3ProxyRule.builder()
+      .withBlobStoreProvider("transient")
+      .withPort(UFS_PORT)
+      .withCredentials("_", "_")
+      .build();
+
+  @Rule
+  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
+      new LocalAlluxioClusterResource.Builder()
+          .setIncludeProxy(true)
+          .setProperty(PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE, "1KB")
+          //Each part must be at least 1 KB in size, except the last part
+          .setProperty(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL,
+              "0s")  //always sync the metadata
+          .setProperty(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.CACHE_THROUGH)
+          .setProperty(PropertyKey.WORKER_BLOCK_STORE_TYPE, "PAGE")
+          .setProperty(PropertyKey.WORKER_PAGE_STORE_PAGE_SIZE, Constants.KB)
+          .setProperty(PropertyKey.UNDERFS_S3_ENDPOINT, "localhost:" + UFS_PORT)
+          .setProperty(PropertyKey.UNDERFS_S3_ENDPOINT_REGION, "us-west-2")
+          .setProperty(PropertyKey.UNDERFS_S3_DISABLE_DNS_BUCKETS, true)
+          .setProperty(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, "s3://" + TEST_BUCKET)
+          .setProperty(PropertyKey.DORA_CLIENT_UFS_ROOT, "s3://" + TEST_BUCKET)
+          .setProperty(PropertyKey.WORKER_HTTP_SERVER_ENABLED, false)
+          .setProperty(PropertyKey.S3A_ACCESS_KEY, mS3Proxy.getAccessKey())
+          .setProperty(PropertyKey.S3A_SECRET_KEY, mS3Proxy.getSecretKey())
+          .setNumWorkers(2)
+          .build();
+
+  @Before
+  public void before() throws Exception {
+    mS3Client = AmazonS3ClientBuilder
+        .standard()
+        .withPathStyleAccessEnabled(true)
+        .withCredentials(
+            new AWSStaticCredentialsProvider(
+                new BasicAWSCredentials(mS3Proxy.getAccessKey(), mS3Proxy.getSecretKey())))
+        .withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration(mS3Proxy.getUri().toString(),
+                Regions.US_WEST_2.getName()))
+        .build();
+    mS3Client.createBucket(TEST_BUCKET);
+    mHostname = mLocalAlluxioClusterResource.get().getHostname();
+    mPort = mLocalAlluxioClusterResource.get().getProxyProcess().getWebLocalPort();
+    mBaseUri = String.format("/api/v1/s3");
+    mFileSystem = mLocalAlluxioClusterResource.get().getClient();
+  }
+
+  @After
+  public void after() {
+    mS3Client = null;
+  }
+
+  /**
+   * Initiate a multipart upload.
+   *
+   * @return the upload id
+   */
+  public String initiateMultipartUpload() throws Exception {
+    // Initiate the multipart upload.
+    createBucketTestCase(BUCKET_NAME);
+    final InitiateMultipartUploadResult result =
+        initiateMultipartUploadTestCase(OBJECT_KEY)
+            .getResponse(InitiateMultipartUploadResult.class);
+    final String uploadId = result.getUploadId();
+    final AlluxioURI tmpDir = new AlluxioURI(
+        AlluxioURI.SEPARATOR + OBJECT_KEY + "_" + uploadId);
+    final URIStatus mpTempDirStatus = mFileSystem.getStatus(tmpDir);
+    final URIStatus mpMetaFileStatus = mFileSystem.getStatus(
+        new AlluxioURI(S3RestUtils.getMultipartMetaFilepathForUploadId(uploadId)));
+
+    Assert.assertEquals(BUCKET_NAME, result.getBucket());
+    Assert.assertEquals(OBJECT_NAME, result.getKey());
+    Assert.assertTrue(mpMetaFileStatus.isCompleted());
+    Assert.assertTrue(mpTempDirStatus.isCompleted());
+    Assert.assertTrue(mpTempDirStatus.getFileInfo().isFolder());
+    return uploadId;
+  }
+
+  /**
+   * Upload parts.
+   *
+   * @param uploadId the upload id
+   * @param objects  the objects to upload
+   * @param parts    the list of part number
+   */
+  public void uploadParts(String uploadId, List<String> objects, List<Integer> parts)
+      throws Exception {
+    // Upload parts
+    for (int partNum : parts) {
+      uploadPartTestCase(OBJECT_KEY, objects.get(partNum - 1).getBytes(), uploadId, partNum)
+          .checkResponseCode(Status.OK.getStatusCode());
+    }
+    for (int partNum : parts) {
+      getTestCase(OBJECT_KEY + "_" + uploadId + AlluxioURI.SEPARATOR + partNum)
+          .checkResponseCode(Status.OK.getStatusCode())
+          .checkResponse(objects.get(partNum - 1).getBytes());
+    }
+  }
+
+  /**
+   * upload parts with non-existent upload id.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void uploadPartWithNonExistentUpload() throws Exception {
+    uploadPartTestCase(OBJECT_KEY, EMPTY_CONTENT, "wrong", 1)
+        .checkResponseCode(Status.NOT_FOUND.getStatusCode())
+        .checkErrorCode(S3ErrorCode.Name.NO_SUCH_UPLOAD);
+    initiateMultipartUpload();
+    uploadPartTestCase(OBJECT_KEY, EMPTY_CONTENT, "wrong", 1)
+        .checkResponseCode(Status.NOT_FOUND.getStatusCode())
+        .checkErrorCode(S3ErrorCode.Name.NO_SUCH_UPLOAD);
+  }
+
+  /**
+   * Complete multipart upload.
+   *
+   * @param uploadId the upload id
+   * @param partList the list of part number
+   * @throws Exception
+   */
+  public void completeMultipartUpload(String uploadId, List<Part> partList) throws Exception {
+    CompleteMultipartUploadResult completeMultipartUploadResult =
+        completeMultipartUploadTestCase(OBJECT_KEY, uploadId,
+            new CompleteMultipartUploadRequest(partList))
+            .checkResponseCode(Status.OK.getStatusCode())
+            .getResponse(CompleteMultipartUploadResult.class);
+
+    // Verify that the response is expected.
+    Assert.assertEquals(BUCKET_NAME, completeMultipartUploadResult.getBucket());
+    Assert.assertEquals(OBJECT_NAME, completeMultipartUploadResult.getKey());
+  }
+
+  /**
+   * Complete multipart upload with 50 objects.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void completeMultipartUpload() throws Exception {
+    final int partsNum = 50;
+    final List<String> objects = new ArrayList<>();
+    final List<Integer> parts = new ArrayList<>();
+    final List<Part> partList = new ArrayList<>();
+    final String uploadId = initiateMultipartUpload();
+    final AlluxioURI tmpDir = new AlluxioURI(
+        AlluxioURI.SEPARATOR + OBJECT_KEY + "_" + uploadId);
+    for (int i = 1; i <= partsNum; i++) {
+      parts.add(i);
+      partList.add(new Part("", i));
+      objects.add(CommonUtils.randomAlphaNumString(Constants.KB));
+    }
+    Collections.shuffle(parts);
+
+    uploadParts(uploadId, objects, parts);
+    // Verify that all parts are uploaded to the temporary directory.
+    Assert.assertEquals(partsNum, mFileSystem.listStatus(tmpDir).size());
+
+    completeMultipartUpload(uploadId, partList);
+    // Verify that the temporary directory is deleted.
+    Assert.assertFalse(mFileSystem.exists(tmpDir));
+    getTestCase(OBJECT_KEY).checkResponse(String.join("", objects).getBytes());
+  }
+
+  /**
+   * Complete multipart upload with an empty part list.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void completeMultipartUploadWithEmptyPart() throws Exception {
+    final List<Part> partList = new ArrayList<>();
+    final String uploadId = initiateMultipartUpload();
+    completeMultipartUploadTestCase(OBJECT_KEY, uploadId,
+        new CompleteMultipartUploadRequest(partList))
+        .checkResponseCode(Status.BAD_REQUEST.getStatusCode())
+        .checkErrorCode(S3ErrorCode.Name.MALFORMED_XML);
+  }
+
+  /**
+   * Complete multipart upload with the subsequence of uploaded parts.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void completeMultipartUploadWithPartialParts() throws Exception {
+    final int partsNum = 3;
+    final List<String> objects = new ArrayList<>();
+    final List<Integer> parts = new ArrayList<>();
+    final List<Part> partList = new ArrayList<>();
+    final String uploadId = initiateMultipartUpload();
+    for (int i = 1; i <= partsNum; i++) {
+      parts.add(i);
+      objects.add(CommonUtils.randomAlphaNumString(Constants.KB));
+    }
+    Collections.shuffle(parts);
+    uploadParts(uploadId, objects, parts);
+    partList.add(new Part("", 1));
+    partList.add(new Part("", 3));
+    completeMultipartUpload(uploadId, partList);
+    getTestCase(OBJECT_KEY).checkResponse(
+        (objects.get(0) + objects.get(2)).getBytes());
+  }
+
+  /**
+   * Complete multipart upload with non-existent part number.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void completeMultipartUploadWithInvalidPart() throws Exception {
+    final int partsNum = 10;
+    final List<String> objects = new ArrayList<>();
+    final List<Integer> parts = new ArrayList<>();
+    final List<Part> partList = new ArrayList<>();
+    final String uploadId = initiateMultipartUpload();
+    final AlluxioURI tmpDir = new AlluxioURI(
+        AlluxioURI.SEPARATOR + OBJECT_KEY + "_" + uploadId);
+    for (int i = 1; i <= partsNum; i++) {
+      parts.add(i);
+      partList.add(new Part("", i));
+      objects.add(CommonUtils.randomAlphaNumString(Constants.KB));
+    }
+    Collections.shuffle(parts);
+    uploadParts(uploadId, objects, parts);
+
+    // Invalid part
+    partList.add(new Part("", partsNum + 1));
+    completeMultipartUploadTestCase(OBJECT_KEY, uploadId,
+        new CompleteMultipartUploadRequest(partList))
+        .checkResponseCode(Status.BAD_REQUEST.getStatusCode())
+        .checkErrorCode(S3ErrorCode.Name.INVALID_PART);
+    // the temporary directory should still exist.
+    Assert.assertTrue(mFileSystem.exists(tmpDir));
+  }
+
+  /**
+   * Complete multipart upload with invalid part order.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void completeMultipartUploadWithInvalidPartOrder() throws Exception {
+    final int partsNum = 10;
+    final List<String> objects = new ArrayList<>();
+    final List<Integer> parts = new ArrayList<>();
+    final List<Part> partList = new ArrayList<>();
+    final String uploadId = initiateMultipartUpload();
+    final AlluxioURI tmpDir = new AlluxioURI(
+        AlluxioURI.SEPARATOR + OBJECT_KEY + "_" + uploadId);
+    for (int i = 1; i <= partsNum; i++) {
+      parts.add(i);
+      objects.add(CommonUtils.randomAlphaNumString(Constants.KB));
+    }
+    Collections.shuffle(parts);
+    uploadParts(uploadId, objects, parts);
+
+    // Invalid part order
+    partList.add(new Part("", 2));
+    partList.add(new Part("", 1));
+
+    completeMultipartUploadTestCase(OBJECT_KEY, uploadId,
+        new CompleteMultipartUploadRequest(partList))
+        .checkResponseCode(Status.BAD_REQUEST.getStatusCode())
+        .checkErrorCode(S3ErrorCode.Name.INVALID_PART_ORDER);
+    // the temporary directory should still exist.
+    Assert.assertTrue(mFileSystem.exists(tmpDir));
+
+    // Invalid part order
+    partList.clear();
+    partList.add(new Part("", 2));
+    partList.add(new Part("", 2));
+
+    completeMultipartUploadTestCase(OBJECT_KEY, uploadId,
+        new CompleteMultipartUploadRequest(partList))
+        .checkResponseCode(Status.BAD_REQUEST.getStatusCode())
+        .checkErrorCode(S3ErrorCode.Name.INVALID_PART_ORDER);
+    // the temporary directory should still exist.
+    Assert.assertTrue(mFileSystem.exists(tmpDir));
+  }
+
+  /**
+   * Complete multipart upload with the part size smaller than the minimum.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void completeMultipartUploadWithTooSmallEntity() throws Exception {
+    final int partsNum = 10;
+    final List<String> objects = new ArrayList<>();
+    final List<Integer> parts = new ArrayList<>();
+    final List<Part> partList = new ArrayList<>();
+    final String uploadId = initiateMultipartUpload();
+    for (int i = 1; i <= partsNum; i++) {
+      parts.add(i);
+      partList.add(new Part("", i));
+      objects.add(CommonUtils.randomAlphaNumString(1));
+    }
+    Collections.shuffle(parts);
+    uploadParts(uploadId, objects, parts);
+
+    completeMultipartUploadTestCase(OBJECT_KEY, uploadId,
+        new CompleteMultipartUploadRequest(partList))
+        .checkResponseCode(Status.BAD_REQUEST.getStatusCode())
+        .checkErrorCode(S3ErrorCode.Name.ENTITY_TOO_SMALL);
+  }
+
+  /**
+   * Complete multipart upload with non-existent upload id.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void completeMultipartUploadWithNonExistentUpload() throws Exception {
+    final String uploadId = "wrong";
+    final List<Part> partList = new ArrayList<>();
+
+    initiateMultipartUpload();
+    completeMultipartUploadTestCase(OBJECT_KEY, uploadId,
+        new CompleteMultipartUploadRequest(partList))
+        .checkResponseCode(Status.NOT_FOUND.getStatusCode())
+        .checkErrorCode(S3ErrorCode.Name.NO_SUCH_UPLOAD);
+  }
+
+  /**
+   * Abort multipart upload.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void abortMultipartUpload() throws Exception {
+    final String uploadId = initiateMultipartUpload();
+    final AlluxioURI tmpDir = new AlluxioURI(
+        AlluxioURI.SEPARATOR + OBJECT_KEY + "_" + uploadId);
+    final List<Part> partList = new ArrayList<>();
+    abortMultipartUploadTestCase(OBJECT_KEY, uploadId)
+        .checkResponseCode(Status.NO_CONTENT.getStatusCode());
+    completeMultipartUploadTestCase(OBJECT_KEY, uploadId,
+        new CompleteMultipartUploadRequest(partList))
+        .checkResponseCode(Status.NOT_FOUND.getStatusCode())
+        .checkErrorCode(S3ErrorCode.Name.NO_SUCH_UPLOAD);
+    Assert.assertFalse(mFileSystem.exists(tmpDir));
+  }
+
+  /**
+   * Abort multipart upload with non-existent upload id.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void abortMultipartUploadWithNonExistentUpload() throws Exception {
+    final String uploadId = initiateMultipartUpload();
+    final AlluxioURI tmpDir = new AlluxioURI(
+        AlluxioURI.SEPARATOR + OBJECT_KEY + "_" + uploadId);
+    abortMultipartUploadTestCase(OBJECT_KEY, "wrong")
+        .checkResponseCode(Status.NOT_FOUND.getStatusCode())
+        .checkErrorCode(S3ErrorCode.Name.NO_SUCH_UPLOAD);
+    // the temporary directory should still exist.
+    Assert.assertTrue(mFileSystem.exists(tmpDir));
+  }
+
+  /**
+   * Get default options with username {@code CustomersName@amazon.com}.
+   *
+   * @return
+   */
+  @Override
+  protected TestCaseOptions getDefaultOptionsWithAuth() {
+    return getDefaultOptionsWithAuth(S3_USER_NAME);
+  }
+}

--- a/dora/tests/integration/src/test/java/alluxio/client/rest/RestApiTest.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/rest/RestApiTest.java
@@ -15,13 +15,15 @@ import alluxio.Constants;
 import alluxio.proxy.s3.CompleteMultipartUploadRequest;
 import alluxio.s3.S3Constants;
 import alluxio.testutils.BaseIntegrationTest;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.HttpMethod;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
+
 import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.Map;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.BaseEncoding;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.HttpMethod;
 
 public abstract class RestApiTest extends BaseIntegrationTest {
   protected static final Map<String, String> NO_PARAMS = ImmutableMap.of();

--- a/dora/tests/integration/src/test/java/alluxio/client/rest/RestApiTest.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/rest/RestApiTest.java
@@ -12,16 +12,16 @@
 package alluxio.client.rest;
 
 import alluxio.Constants;
+import alluxio.proxy.s3.CompleteMultipartUploadRequest;
 import alluxio.s3.S3Constants;
 import alluxio.testutils.BaseIntegrationTest;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.BaseEncoding;
-
-import java.security.MessageDigest;
-import java.util.Map;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.HttpMethod;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.Map;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
 
 public abstract class RestApiTest extends BaseIntegrationTest {
   protected static final Map<String, String> NO_PARAMS = ImmutableMap.of();
@@ -32,49 +32,79 @@ public abstract class RestApiTest extends BaseIntegrationTest {
   protected int mPort;
   protected String mBaseUri = Constants.REST_API_PREFIX;
 
-  protected TestCase newTestCase(String bucket, Map<String, String> params,
+  protected TestCase runTestCase(String bucket, Map<String, String> params,
                                  String httpMethod, TestCaseOptions options) throws Exception {
-    return new TestCase(mHostname, mPort, mBaseUri, bucket, params, httpMethod,
-        options);
+    return new TestCase(mHostname, mPort, mBaseUri, bucket, params, httpMethod, options).run();
   }
 
   protected TestCase createBucketTestCase(String bucket) throws Exception {
-    return newTestCase(bucket, NO_PARAMS, HttpMethod.PUT, getDefaultOptionsWithAuth());
+    return runTestCase(bucket, NO_PARAMS, HttpMethod.PUT, getDefaultOptionsWithAuth());
   }
 
-  protected TestCase createObjectTestCase(String bucket, byte[] object) throws Exception {
-    return newTestCase(bucket, NO_PARAMS, HttpMethod.PUT, getDefaultOptionsWithAuth()
+  protected TestCase createObjectTestCase(String uri, byte[] object) throws Exception {
+    return runTestCase(uri, NO_PARAMS, HttpMethod.PUT, getDefaultOptionsWithAuth()
         .setBody(object)
         .setMD5(computeObjectChecksum(object)));
   }
 
-  protected TestCase createObjectTestCase(String bucket, TestCaseOptions options)
+  protected TestCase createObjectTestCase(String uri, TestCaseOptions options)
       throws Exception {
-    return newTestCase(bucket, NO_PARAMS, HttpMethod.PUT, options);
+    return runTestCase(uri, NO_PARAMS, HttpMethod.PUT, options);
   }
 
-  protected TestCase copyObjectTestCase(String sourcePath, String targetPath) throws Exception {
-    return newTestCase(targetPath, NO_PARAMS, HttpMethod.PUT, getDefaultOptionsWithAuth()
+  protected TestCase copyObjectTestCase(String sourceUri, String targetUri) throws Exception {
+    return runTestCase(targetUri, NO_PARAMS, HttpMethod.PUT, getDefaultOptionsWithAuth()
         .addHeader(S3Constants.S3_METADATA_DIRECTIVE_HEADER,
             S3Constants.Directive.REPLACE.name())
-        .addHeader(S3Constants.S3_COPY_SOURCE_HEADER, sourcePath));
+        .addHeader(S3Constants.S3_COPY_SOURCE_HEADER, sourceUri));
   }
 
   protected TestCase deleteTestCase(String uri) throws Exception {
-    return newTestCase(uri, NO_PARAMS, HttpMethod.DELETE, getDefaultOptionsWithAuth());
+    return runTestCase(uri, NO_PARAMS, HttpMethod.DELETE, getDefaultOptionsWithAuth());
   }
 
   protected TestCase headTestCase(String uri) throws Exception {
-    return newTestCase(uri, NO_PARAMS, HttpMethod.HEAD, getDefaultOptionsWithAuth());
+    return runTestCase(uri, NO_PARAMS, HttpMethod.HEAD, getDefaultOptionsWithAuth());
   }
 
   protected TestCase getTestCase(String uri) throws Exception {
-    return newTestCase(uri, NO_PARAMS, HttpMethod.GET, getDefaultOptionsWithAuth());
+    return runTestCase(uri, NO_PARAMS, HttpMethod.GET, getDefaultOptionsWithAuth());
   }
 
   protected TestCase listTestCase(String uri, Map<String, String> params) throws Exception {
-    return newTestCase(uri, params, HttpMethod.GET,
+    return runTestCase(uri, params, HttpMethod.GET,
         getDefaultOptionsWithAuth().setContentType(TestCaseOptions.XML_CONTENT_TYPE));
+  }
+
+  protected TestCase initiateMultipartUploadTestCase(String uri) throws Exception {
+    return runTestCase(
+        uri, ImmutableMap.of("uploads", ""), HttpMethod.POST,
+        getDefaultOptionsWithAuth());
+  }
+
+  protected TestCase completeMultipartUploadTestCase(
+      String objectUri, String uploadId, CompleteMultipartUploadRequest request) throws Exception {
+    return runTestCase(
+        objectUri, ImmutableMap.of("uploadId", uploadId), HttpMethod.POST,
+        getDefaultOptionsWithAuth()
+            .setBody(request)
+            .setContentType(TestCaseOptions.XML_CONTENT_TYPE));
+  }
+
+  protected TestCase abortMultipartUploadTestCase(String uri, String uploadId) throws Exception {
+    return runTestCase(
+        uri, ImmutableMap.of("uploadId", uploadId), HttpMethod.DELETE,
+        getDefaultOptionsWithAuth());
+  }
+
+  protected TestCase uploadPartTestCase(String uri, byte[] object, String uploadId,
+                                        Integer partNumber) throws Exception {
+    Map<String, String> params = new HashMap<>();
+    params.put("uploadId", uploadId);
+    params.put("partNumber", partNumber.toString());
+    return runTestCase(uri, params, HttpMethod.PUT, getDefaultOptionsWithAuth()
+        .setBody(object)
+        .setMD5(computeObjectChecksum(object)));
   }
 
   protected TestCaseOptions getDefaultOptionsWithAuth(@NotNull String user) {

--- a/dora/tests/integration/src/test/java/alluxio/client/rest/TestCase.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/rest/TestCase.java
@@ -13,9 +13,14 @@ package alluxio.client.rest;
 
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.s3.S3Error;
-import javax.annotation.concurrent.NotThreadSafe;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.core.Response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.google.common.base.Joiner;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -25,12 +30,9 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.google.common.base.Joiner;
-import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.core.Response;
 
 /**
  * Represents a REST API test case.

--- a/dora/tests/integration/src/test/java/alluxio/client/rest/TestCase.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/rest/TestCase.java
@@ -13,14 +13,9 @@ package alluxio.client.rest;
 
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.s3.S3Error;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.google.common.base.Joiner;
-import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.core.Response;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -30,9 +25,12 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.annotation.concurrent.NotThreadSafe;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.core.Response;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.google.common.base.Joiner;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
 
 /**
  * Represents a REST API test case.
@@ -52,7 +50,7 @@ public final class TestCase {
   private final Map<String, String> mParameters;
   private final String mMethod;
   private final TestCaseOptions mOptions;
-  private final HttpURLConnection mConnection;
+  private HttpURLConnection mConnection;
 
   /**
    * Creates a new instance of {@link TestCase}.
@@ -76,7 +74,6 @@ public final class TestCase {
     mParameters = parameters;
     mMethod = method;
     mOptions = options;
-    mConnection =  execute();
   }
 
   /**
@@ -130,8 +127,62 @@ public final class TestCase {
   }
 
   /**
-   * Runs the test case and returns the {@link HttpURLConnection}.
+   * @return the specified-type instance from the InputStream of HttpURLConnection
    */
+  public <T> T getResponse(Class<T> valueType) throws Exception {
+    return XML_MAPPER.readValue(getResponse(), valueType);
+  }
+
+  /**
+   * Runs the test case and returns the {@link TestCase}.
+   */
+  public TestCase run() throws Exception {
+    mConnection = (HttpURLConnection) createURL().openConnection();
+    mConnection.setRequestMethod(mMethod);
+    for (Map.Entry<String, String> entry : mOptions.getHeaders().entrySet()) {
+      mConnection.setRequestProperty(entry.getKey(), entry.getValue());
+    }
+    if (mOptions.getBody() != null) {
+      mConnection.setDoOutput(true);
+      switch (mOptions.getContentType()) {
+        case TestCaseOptions.XML_CONTENT_TYPE: // encode as XML string
+          try (OutputStream os = mConnection.getOutputStream()) {
+            os.write(XML_MAPPER.writeValueAsBytes(mOptions.getBody()));
+          }
+          break;
+        case TestCaseOptions.JSON_CONTENT_TYPE: // encode as JSON string
+          try (OutputStream os = mConnection.getOutputStream()) {
+            os.write(JSON_MAPPER.writeValueAsBytes(mOptions.getBody()));
+          }
+          break;
+        case TestCaseOptions.OCTET_STREAM_CONTENT_TYPE: // encode as-is
+          try (OutputStream os = mConnection.getOutputStream()) {
+            os.write((byte[]) mOptions.getBody());
+          }
+          break;
+        case TestCaseOptions.TEXT_PLAIN_CONTENT_TYPE: // encode string using the charset
+          try (OutputStream os = mConnection.getOutputStream()) {
+            os.write(((String) mOptions.getBody()).getBytes(mOptions.getCharset()));
+          }
+          break;
+        default:
+          throw new InvalidArgumentException(String.format(
+              "No mapper available for content type %s in TestCaseOptions!",
+              mOptions.getContentType()));
+      }
+    }
+
+    mConnection.connect();
+    mConnection.getResponseCode();
+    return this;
+  }
+
+  /**
+   * Runs the test case and returns the {@link HttpURLConnection}.
+   *
+   * @deprecated use run() instead.
+   */
+  @Deprecated
   public HttpURLConnection execute() throws Exception {
     HttpURLConnection connection = (HttpURLConnection) createURL().openConnection();
     connection.setRequestMethod(mMethod);


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. fix bugs in `alluxio.proxy.s3.S3ObjectTask.CompleteMultipartUploadTask#validateParts`
2. `CompleteMultipartUpload` executes the specified parts  with the specified upload ID rather than all parts. 
3. add `initiate / complete / abort MPU and upload part` unit tests.
4. remove `XAttr`
5. show all upload-parts to user while listing parts

### Why are the changes needed?


there are problems in validateParts() of complete MPU

1. can’t recognize S3 Error: MalformedXML
3. throw unexpected error: InvalidPartOrder

we need to fix validateParts() of complete MPU to keep s3 proxy behaviors as consistent with aws as possible.


### Does this PR introduce any user facing changes?

- can't get the bucket name and object name of the part while executing  ListMultipartUploads

- now complete MPU's response is like

|part list|response(before)|response(now)|
|-|-|-|
|  [] |   500  |MalformedXML|
|[1,3]|   InvalidPartOrder  | 200 |
|[2,1]|   InvalidPartOrder  |InvalidPartOrder|
|[3,3]|   InvalidPartOrder  |InvalidPartOrder|