### PR TITLE
Add a new Run interface in CLI for future use

### DIFF
--- a/cli/src/alluxio.org/cli/env/command.go
+++ b/cli/src/alluxio.org/cli/env/command.go
@@ -13,6 +13,7 @@ package env
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -90,10 +91,14 @@ func (c *BaseJavaCommand) RunJavaClassCmd(args []string) *exec.Cmd {
 }
 
 func (c *BaseJavaCommand) Run(args []string) error {
+	return c.RunWithWriters(args, os.Stdout, os.Stderr)
+}
+
+func (c *BaseJavaCommand) RunWithWriters(args []string, stdout, stderr io.Writer) error {
 	cmd := c.RunJavaClassCmd(args)
 
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	log.Logger.Debugln(cmd.String())
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add a `RunWithWriters` interface apart from `Run` for future use.

### Why are the changes needed?
In the future, we might need to parse the output of java in golang CLI. In this way we can reuse more code.

### Does this PR introduce any user facing changes?
nope
