### PR TITLE
[SMALLFIX] Allow FileSystem to have FSContext by inheritance

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -78,7 +78,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
   public static DoraCacheFileSystemFactory sDoraCacheFileSystemFactory
       = new DoraCacheFileSystemFactory();
   private final DoraCacheClient mDoraClient;
-  private final FileSystemContext mFsContext;
+  protected final FileSystemContext mFsContext;
   private final boolean mMetadataCacheEnabled;
   private final boolean mUfsFallbackEnabled;
   private final long mDefaultVirtualBlockSize;


### PR DESCRIPTION
### What changes are proposed in this pull request?

This is a very small change which allows children of `DoraFileSystem` to have a ref to its `FileSystemContext`.
