### PR TITLE
Reduce CPU overhead by replacing while loop with await

### DIFF
--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4225,7 +4225,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.WORKER)
           .setDefaultValue(ChannelType.NIO)
           .build();
-
+  public static final PropertyKey WORKER_NETWORK_PACKET_SENDING_TIMEOUT =
+      durationBuilder(Name.WORKER_NETWORK_PACKET_SENDING_TIMEOUT)
+          .setDefaultValue("5min")
+          .setDescription("Maximum amount of time to wait until all the packets on worker have "
+              + "been sent to client successfully.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_FILE_TRANSFER_TYPE =
       enumBuilder(Name.WORKER_NETWORK_NETTY_FILE_TRANSFER_TYPE, FileTransferType.class)
           .setDefaultValue("TRANSFER")
@@ -7900,6 +7907,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String WORKER_NETWORK_NETTY_CHANNEL =
         "alluxio.worker.network.netty.channel";
 
+    public static final String WORKER_NETWORK_PACKET_SENDING_TIMEOUT =
+        "alluxio.worker.network.packet.sending.timeout";
     public static final String WORKER_NETWORK_NETTY_FILE_TRANSFER_TYPE =
         "alluxio.worker.network.netty.file.transfer";
     public static final String USER_NETWORK_NETTY_WRITER_CLOSE_TIMEOUT_MS =

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4232,6 +4232,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "been sent to client successfully.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
+          .setIsHidden(true)
           .build();
   public static final PropertyKey WORKER_NETWORK_NETTY_FILE_TRANSFER_TYPE =
       enumBuilder(Name.WORKER_NETWORK_NETTY_FILE_TRANSFER_TYPE, FileTransferType.class)

--- a/dora/core/server/worker/src/main/java/alluxio/worker/netty/PacketReadTaskStateMachine.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/netty/PacketReadTaskStateMachine.java
@@ -68,7 +68,7 @@ public class PacketReadTaskStateMachine<T extends ReadRequestContext<?>> {
   private final BlockingQueue<String> mWaitForTerminatedSignalQueue =
       new ArrayBlockingQueue<>(1);
 
-  private boolean mAllDataRead = false;
+  private volatile boolean mAllDataRead = false;
 
   private final TriggerEventsWithParam mTriggerEventsWithParam;
 

--- a/dora/core/server/worker/src/main/java/alluxio/worker/netty/PacketReadTaskStateMachine.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/netty/PacketReadTaskStateMachine.java
@@ -296,7 +296,7 @@ public class PacketReadTaskStateMachine<T extends ReadRequestContext<?>> {
 
   private void onTerminatedNormally() {
     try {
-      mWaitForTerminatedSignalQueue.poll(mPacketSendingTimeout, TimeUnit.MILLISECONDS);
+      String msg = mWaitForTerminatedSignalQueue.poll(mPacketSendingTimeout, TimeUnit.MILLISECONDS);
       completeRequest(mContext);
       fireNext(TriggerEvent.END);
     } catch (IOException e) {

--- a/dora/core/server/worker/src/main/java/alluxio/worker/netty/PacketReadTaskStateMachine.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/netty/PacketReadTaskStateMachine.java
@@ -41,7 +41,6 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  *  State machine of Netty Server in Alluxio Worker.
@@ -75,7 +74,7 @@ public class PacketReadTaskStateMachine<T extends ReadRequestContext<?>> {
    */
   private volatile boolean mAllDataReadOnWorker = false;
 
-  /** This flag is set when the read request is cancelled */
+  /** This flag is set when the read request is cancelled. */
   private volatile boolean mTaskCancelled = false;
   private final TriggerEventsWithParam mTriggerEventsWithParam;
 


### PR DESCRIPTION
Reduce CPU overhead by replacing while loop with await. The previous version waits for finishing sending data by using a **while loop**. In that way, cpu overhead would be pretty high. Thus, instead of waiting for finishing sending data with a **while loop**, we use a **BlockingQueue** to notice it when all data have been sent out successfully.