### PR TITLE
[WIP] Add throughput distribution and coarse datapoints for StressWorkerBench

### DIFF
--- a/dora/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
+++ b/dora/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
@@ -127,8 +127,10 @@ public final class StressBenchDefinition
       RunTaskContext runTaskContext) throws Exception {
     List<String> command = new ArrayList<>(3 + config.getArgs().size());
     command.add(Configuration.get(PropertyKey.HOME) + "/bin/alluxio");
-    command.add("runClass");
+    command.add("exec");
+    command.add("class");
     command.add(config.getClassName());
+    command.add("--");
 
     // the cluster will run distributed tasks
     command.add(BaseParameters.DISTRIBUTED_FLAG);

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
@@ -1,0 +1,53 @@
+package alluxio.stress.worker;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.List;
+
+@JsonDeserialize(using = WorkerBenchCoarseDataPointDeserializer.class)
+public class WorkerBenchCoarseDataPoint {
+    // properties: workerId, threadId, sliceId, records
+    @JsonProperty("wid")
+    private Long mWid;
+    @JsonProperty("tid")
+    private Long mTid;
+    @JsonProperty("data")
+    private List<List<WorkerBenchDataPoint>> mData;
+
+    // constructor
+    public WorkerBenchCoarseDataPoint(Long workerID, Long threadID, List<List<WorkerBenchDataPoint>> data) {
+        mWid = workerID;
+        mTid = threadID;
+        mData = data;
+    }
+
+    // getter & setters
+    public Long getWid() {
+        return mWid;
+    }
+
+    public void setWid(Long wid) {
+        mWid = wid;
+    }
+
+    public Long getTid() {
+        return mTid;
+    }
+
+    public void setTid(Long tid) {
+        mTid = tid;
+    }
+
+    public List<List<WorkerBenchDataPoint>> getData() {
+        return mData;
+    }
+
+    public void setData(List<List<WorkerBenchDataPoint>> data) {
+        mData = data;
+    }
+
+    public void addDataPoints(List<WorkerBenchDataPoint> data) {
+        mData.add(data);
+    }
+}

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
@@ -3,6 +3,7 @@ package alluxio.stress.worker;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @JsonDeserialize(using = WorkerBenchCoarseDataPointDeserializer.class)
@@ -14,12 +15,16 @@ public class WorkerBenchCoarseDataPoint {
     private Long mTid;
     @JsonProperty("data")
     private List<List<WorkerBenchDataPoint>> mData;
+    @JsonProperty("throughput")
+    private List<Long> mThroughput;
 
     // constructor
-    public WorkerBenchCoarseDataPoint(Long workerID, Long threadID, List<List<WorkerBenchDataPoint>> data) {
+    public WorkerBenchCoarseDataPoint(Long workerID, Long threadID, List<List<WorkerBenchDataPoint>> data,
+                                      List<Long> throughput) {
         mWid = workerID;
         mTid = threadID;
         mData = data;
+        mThroughput = throughput;
     }
 
     // getter & setters
@@ -49,5 +54,17 @@ public class WorkerBenchCoarseDataPoint {
 
     public void addDataPoints(List<WorkerBenchDataPoint> data) {
         mData.add(data);
+    }
+
+    public List<Long> getThroughput() {
+        return mThroughput;
+    }
+
+    public void setThroughput(List<Long> throughput) {
+        mThroughput = throughput;
+    }
+
+    public void clearThroughput() {
+        mThroughput.clear();
     }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
@@ -1,0 +1,38 @@
+package alluxio.stress.worker;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A deserializer converting {@link WorkerBenchCoarseDataPoint} from JSON.
+ */
+public class WorkerBenchCoarseDataPointDeserializer extends JsonDeserializer<WorkerBenchCoarseDataPoint> {
+    @Override
+    public WorkerBenchCoarseDataPoint deserialize(JsonParser parser, DeserializationContext ctx)
+            throws IOException {
+        ObjectMapper mapper = (ObjectMapper) parser.getCodec();
+        JsonNode node = parser.getCodec().readTree(parser);
+        Long wId = node.get("wid").asLong();
+        Long tId = node.get("tid").asLong();
+        List<List<WorkerBenchDataPoint>> data = new ArrayList<>();
+        JsonNode dataNode = node.get("data");
+        if (dataNode != null) {
+            for (JsonNode listNode: dataNode){
+                List<WorkerBenchDataPoint> dataPoints = new ArrayList<>();
+                for (JsonNode subListNode: listNode) {
+                    WorkerBenchDataPoint dataPoint = mapper.treeToValue(subListNode, WorkerBenchDataPoint.class);
+                    dataPoints.add(dataPoint);
+                }
+                data.add(dataPoints);
+            }
+        }
+        return new WorkerBenchCoarseDataPoint(wId, tId, data);
+    }
+}

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
@@ -21,6 +21,13 @@ public class WorkerBenchCoarseDataPointDeserializer extends JsonDeserializer<Wor
         JsonNode node = parser.getCodec().readTree(parser);
         Long wId = node.get("wid").asLong();
         Long tId = node.get("tid").asLong();
+        List<Long> tpList = new ArrayList<>();
+        JsonNode tpNode = node.get("throughput");
+        if (tpNode != null) {
+            for (JsonNode throughput : tpNode){
+                tpList.add(throughput.asLong());
+            }
+        }
         List<List<WorkerBenchDataPoint>> data = new ArrayList<>();
         JsonNode dataNode = node.get("data");
         if (dataNode != null) {
@@ -33,6 +40,6 @@ public class WorkerBenchCoarseDataPointDeserializer extends JsonDeserializer<Wor
                 data.add(dataPoints);
             }
         }
-        return new WorkerBenchCoarseDataPoint(wId, tId, data);
+        return new WorkerBenchCoarseDataPoint(wId, tId, data, tpList);
     }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
@@ -14,7 +14,6 @@ package alluxio.stress.worker;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.base.MoreObjects;
 
 /**
  * One data point captures the information we collect from one I/O operation to a worker.
@@ -22,53 +21,23 @@ import com.google.common.base.MoreObjects;
  */
 @JsonDeserialize(using = WorkerBenchDataPointDeserializer.class)
 public class WorkerBenchDataPoint {
-  @JsonProperty("workerID")
-  public String mWorkerID;
-  @JsonProperty("threadID")
-  public String mThreadID;
-
   @JsonProperty("duration")
   public long mDuration;
   @JsonProperty("startMs")
   public long mStartMs;
   @JsonProperty("ioBytes")
   public long mIOBytes;
-  @JsonProperty("inThroughput")
-  public long mInThroughput;
 
   /**
-   * @param workerID the worker this I/O operation reads
-   * @param threadID the thread performing the I/O
    * @param startMs start timestamp of the I/O
    * @param duration duration of the file read operation
    * @param ioBytes bytes read
    */
   @JsonCreator
-  public WorkerBenchDataPoint(@JsonProperty("workerID") String workerID,
-                              @JsonProperty("threadID") String threadID,
-                              @JsonProperty("startMs") long startMs,
-                              @JsonProperty("duration") long duration,
-                              @JsonProperty("ioBytes") long ioBytes) {
-    mWorkerID = workerID;
-    mThreadID = threadID;
+  public WorkerBenchDataPoint(long startMs, long duration, long ioBytes) {
     mStartMs = startMs;
     mDuration = duration;
     mIOBytes = ioBytes;
-    mInThroughput = ioBytes / duration;
-  }
-
-  /**
-   * @return worker ID
-   */
-  public String getWorkerID() {
-    return mWorkerID;
-  }
-
-  /**
-   * @return thread ID
-   */
-  public String getThreadID() {
-    return mThreadID;
   }
 
   /**
@@ -93,27 +62,6 @@ public class WorkerBenchDataPoint {
   }
 
   /**
-   * @return instant throughput
-   */
-  public long getInThroughput() {
-    return mInThroughput;
-  }
-
-  /**
-   * @param workerID worker ID
-   */
-  public void setWorkerID(String workerID) {
-    mWorkerID = workerID;
-  }
-
-  /**
-   * @param threadID the thread ID
-   */
-  public void setThreadID(String threadID) {
-    mThreadID = threadID;
-  }
-
-  /**
    * @param duration duration in ms
    */
   public void setDuration(long duration) {
@@ -132,21 +80,5 @@ public class WorkerBenchDataPoint {
    */
   public void setIOBytes(long ioBytes) {
     mIOBytes = ioBytes;
-  }
-
-  /**
-   * @param inThroughput instant throughput
-   */
-  public void setInThroughput(long inThroughput) {
-    mInThroughput = inThroughput;
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-            .add("threadID", mWorkerID + "-" + mThreadID)
-            .add("startMs", mStartMs)
-            .add("inThroughput", mInThroughput)
-            .toString();
   }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
@@ -25,14 +25,16 @@ public class WorkerBenchDataPoint {
   @JsonProperty("workerID")
   public String mWorkerID;
   @JsonProperty("threadID")
-  public long mThreadID;
+  public String mThreadID;
 
   @JsonProperty("duration")
   public long mDuration;
-  @JsonProperty("start")
+  @JsonProperty("startMs")
   public long mStartMs;
   @JsonProperty("ioBytes")
   public long mIOBytes;
+  @JsonProperty("inThroughput")
+  public long mInThroughput;
 
   /**
    * @param workerID the worker this I/O operation reads
@@ -43,8 +45,8 @@ public class WorkerBenchDataPoint {
    */
   @JsonCreator
   public WorkerBenchDataPoint(@JsonProperty("workerID") String workerID,
-                              @JsonProperty("threadID") long threadID,
-                              @JsonProperty("start") long startMs,
+                              @JsonProperty("threadID") String threadID,
+                              @JsonProperty("startMs") long startMs,
                               @JsonProperty("duration") long duration,
                               @JsonProperty("ioBytes") long ioBytes) {
     mWorkerID = workerID;
@@ -52,6 +54,7 @@ public class WorkerBenchDataPoint {
     mStartMs = startMs;
     mDuration = duration;
     mIOBytes = ioBytes;
+    mInThroughput = ioBytes / duration;
   }
 
   /**
@@ -64,7 +67,7 @@ public class WorkerBenchDataPoint {
   /**
    * @return thread ID
    */
-  public long getThreadID() {
+  public String getThreadID() {
     return mThreadID;
   }
 
@@ -90,6 +93,13 @@ public class WorkerBenchDataPoint {
   }
 
   /**
+   * @return instant throughput
+   */
+  public long getInThroughput() {
+    return mInThroughput;
+  }
+
+  /**
    * @param workerID worker ID
    */
   public void setWorkerID(String workerID) {
@@ -99,7 +109,7 @@ public class WorkerBenchDataPoint {
   /**
    * @param threadID the thread ID
    */
-  public void setThreadID(long threadID) {
+  public void setThreadID(String threadID) {
     mThreadID = threadID;
   }
 
@@ -124,12 +134,19 @@ public class WorkerBenchDataPoint {
     mIOBytes = ioBytes;
   }
 
+  /**
+   * @param inThroughput instant throughput
+   */
+  public void setInThroughput(long inThroughput) {
+    mInThroughput = inThroughput;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-            .add("threadID", mThreadID)
-            .add("ioBytes", mIOBytes)
-            .add("duration", mDuration)
+            .add("threadID", mWorkerID + "-" + mThreadID)
+            .add("startMs", mStartMs)
+            .add("inThroughput", mInThroughput)
             .toString();
   }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
@@ -25,7 +25,7 @@ public class WorkerBenchDataPoint {
   public long mDuration;
   @JsonProperty("startMs")
   public long mStartMs;
-  @JsonProperty("ioBytes")
+  @JsonProperty("iobytes")
   public long mIOBytes;
 
   /**

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
@@ -27,7 +27,7 @@ public class WorkerBenchDataPointDeserializer extends JsonDeserializer<WorkerBen
           throws IOException {
     JsonNode node = parser.getCodec().readTree(parser);
     return new WorkerBenchDataPoint(
-            node.get("startMs").asLong(), node.get("duration").asLong(), node.get("ioBytes").asLong()
+            node.get("startMs").asLong(), node.get("duration").asLong(), node.get("iobytes").asLong()
     );
   }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
@@ -27,7 +27,7 @@ public class WorkerBenchDataPointDeserializer extends JsonDeserializer<WorkerBen
           throws IOException {
     JsonNode node = parser.getCodec().readTree(parser);
     return new WorkerBenchDataPoint(
-            node.get("workerID").asText(), node.get("threadID").asLong(),
+            node.get("workerID").asText(), node.get("threadID").asText(),
             node.get("startMs").asLong(), node.get("duration").asLong(),
             node.get("ioBytes").asLong()
     );

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
@@ -27,9 +27,7 @@ public class WorkerBenchDataPointDeserializer extends JsonDeserializer<WorkerBen
           throws IOException {
     JsonNode node = parser.getCodec().readTree(parser);
     return new WorkerBenchDataPoint(
-            node.get("workerID").asText(), node.get("threadID").asText(),
-            node.get("startMs").asLong(), node.get("duration").asLong(),
-            node.get("ioBytes").asLong()
+            node.get("startMs").asLong(), node.get("duration").asLong(), node.get("ioBytes").asLong()
     );
   }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
@@ -87,6 +87,10 @@ public final class WorkerBenchParameters extends FileSystemParameters {
       description = "If true, skip the data file creation")
   public boolean mSkipCreation = false;
 
+  @Parameter(names = {"--slice-length"},
+      description = "The granularity of coarse data point slices")
+  public String mSliceLength = "10s";
+
   @DynamicParameter(names = "--conf", description = "HDFS client configuration. Can be repeated.")
   public Map<String, String> mConf = new HashMap<>();
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
@@ -14,15 +14,12 @@ package alluxio.stress.worker;
 import alluxio.Constants;
 import alluxio.collections.Pair;
 import alluxio.stress.Parameters;
-import alluxio.stress.StressConstants;
 import alluxio.stress.Summary;
 import alluxio.stress.common.GeneralBenchSummary;
 import alluxio.stress.graph.Graph;
 import alluxio.stress.graph.LineGraph;
-import alluxio.util.FormatUtils;
 
 import com.google.common.base.Splitter;
-import org.HdrHistogram.Histogram;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -65,15 +62,17 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
     mNodeResults = nodes;
     mThroughput = getIOMBps();
 
-    mThroughputPercentiles = new ArrayList<>();
-    Histogram throughputHistogram = new Histogram(
-            FormatUtils.parseSpaceSize(mParameters.mFileSize),
-            StressConstants.TIME_HISTOGRAM_PRECISION);
-    mergedTaskResults.getDataPoints().forEach(stat ->
-            throughputHistogram.recordValue(stat.getInThroughput()));
-    for (int i = 0; i <= 100; i++) {
-      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
-    }
+// TODO: implement percentile calculation for coarse data points
+
+//  mThroughputPercentiles = new ArrayList<>();
+//    Histogram throughputHistogram = new Histogram(
+//            FormatUtils.parseSpaceSize(mParameters.mFileSize),
+//            StressConstants.TIME_HISTOGRAM_PRECISION);
+//    mergedTaskResults.getDataPoints().forEach(stat ->
+//            throughputHistogram.recordValue(stat.getInThroughput()));
+//    for (int i = 0; i <= 100; i++) {
+//      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
+//    }
   }
 
   /**

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
@@ -40,6 +40,7 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
   private long mEndTimeMs;
   private long mIOBytes;
   private List<Long> mDurationPercentiles;
+  private List<Long> mThroughputPercentiles;
 
   /**
    * Creates an instance.
@@ -48,6 +49,7 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
   public WorkerBenchSummary() {
     mNodeResults = new HashMap<>();
     mDurationPercentiles = new ArrayList<>();
+    mThroughputPercentiles = new ArrayList<>();
   }
 
   /**
@@ -74,6 +76,16 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
         durationHistogram.recordValue(stat.getDuration()));
     for (int i = 0; i <= 100; i++) {
       mDurationPercentiles.add(durationHistogram.getValueAtPercentile(i));
+    }
+
+    mThroughputPercentiles = new ArrayList<>();
+    Histogram throughputHistogram = new Histogram(
+            FormatUtils.parseSpaceSize(mParameters.mFileSize),
+            StressConstants.TIME_HISTOGRAM_PRECISION);
+    mergedTaskResults.getDataPoints().forEach(stat ->
+            throughputHistogram.recordValue(stat.getInThroughput()));
+    for (int i = 0; i <= 100; i++) {
+      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
     }
   }
 
@@ -159,6 +171,20 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
    */
   public void setDurationPercentiles(List<Long> percentiles) {
     mDurationPercentiles = percentiles;
+  }
+
+  /**
+   * @return 0~100 percentiles of recorded durations
+   */
+  public List<Long> getThroughputPercentiles() {
+    return mThroughputPercentiles;
+  }
+
+  /**
+   * @param percentiles a list of  calculated percentiles from recorded durations
+   */
+  public void setThroughputPercentiles(List<Long> percentiles) {
+    mThroughputPercentiles = percentiles;
   }
 
   @Override

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
@@ -14,17 +14,18 @@ package alluxio.stress.worker;
 import alluxio.Constants;
 import alluxio.collections.Pair;
 import alluxio.stress.Parameters;
+import alluxio.stress.StressConstants;
 import alluxio.stress.Summary;
+import alluxio.stress.TaskResult;
 import alluxio.stress.common.GeneralBenchSummary;
 import alluxio.stress.graph.Graph;
 import alluxio.stress.graph.LineGraph;
 
+import alluxio.util.FormatUtils;
 import com.google.common.base.Splitter;
+import org.HdrHistogram.Histogram;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -62,17 +63,15 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
     mNodeResults = nodes;
     mThroughput = getIOMBps();
 
-// TODO: implement percentile calculation for coarse data points
-
-//  mThroughputPercentiles = new ArrayList<>();
-//    Histogram throughputHistogram = new Histogram(
-//            FormatUtils.parseSpaceSize(mParameters.mFileSize),
-//            StressConstants.TIME_HISTOGRAM_PRECISION);
-//    mergedTaskResults.getDataPoints().forEach(stat ->
-//            throughputHistogram.recordValue(stat.getInThroughput()));
-//    for (int i = 0; i <= 100; i++) {
-//      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
-//    }
+    mThroughputPercentiles = new ArrayList<>();
+    Histogram throughputHistogram = new Histogram(
+        FormatUtils.parseSpaceSize(mParameters.mFileSize),
+        StressConstants.TIME_HISTOGRAM_PRECISION);
+    mergedTaskResults.getAllThroughput().forEach(throughputHistogram::recordValue);
+    for (int i = 0; i <= 100; i++) {
+      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
+    }
+    // mergedTaskResults.clearAllThroughput();
   }
 
   /**

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
@@ -39,7 +39,6 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
   private long mDurationMs;
   private long mEndTimeMs;
   private long mIOBytes;
-  private List<Long> mDurationPercentiles;
   private List<Long> mThroughputPercentiles;
 
   /**
@@ -48,7 +47,6 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
    */
   public WorkerBenchSummary() {
     mNodeResults = new HashMap<>();
-    mDurationPercentiles = new ArrayList<>();
     mThroughputPercentiles = new ArrayList<>();
   }
 
@@ -66,17 +64,6 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
     mParameters = mergedTaskResults.getParameters();
     mNodeResults = nodes;
     mThroughput = getIOMBps();
-
-    mDurationPercentiles = new ArrayList<>();
-    Histogram durationHistogram = new Histogram(
-        FormatUtils.parseTimeSize(mParameters.mDuration)
-            + FormatUtils.parseTimeSize(mParameters.mWarmup),
-        StressConstants.TIME_HISTOGRAM_PRECISION);
-    mergedTaskResults.getDataPoints().forEach(stat ->
-        durationHistogram.recordValue(stat.getDuration()));
-    for (int i = 0; i <= 100; i++) {
-      mDurationPercentiles.add(durationHistogram.getValueAtPercentile(i));
-    }
 
     mThroughputPercentiles = new ArrayList<>();
     Histogram throughputHistogram = new Histogram(
@@ -162,20 +149,6 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
   /**
    * @return 0~100 percentiles of recorded durations
    */
-  public List<Long> getDurationPercentiles() {
-    return mDurationPercentiles;
-  }
-
-  /**
-   * @param percentiles a list of  calculated percentiles from recorded durations
-   */
-  public void setDurationPercentiles(List<Long> percentiles) {
-    mDurationPercentiles = percentiles;
-  }
-
-  /**
-   * @return 0~100 percentiles of recorded durations
-   */
   public List<Long> getThroughputPercentiles() {
     return mThroughputPercentiles;
   }
@@ -211,7 +184,7 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
       Pair<List<String>, List<String>> fieldNames = Parameters.partitionFieldNames(
           summaries.stream().map(x -> x.mParameters).collect(Collectors.toList()));
 
-      // Split up common description into 100 character chunks, for the sub title
+      // Split up common description into 100 character chunks, for the subtitle
       List<String> subTitle = new ArrayList<>(Splitter.fixedLength(100).splitToList(
           summaries.get(0).mParameters.getDescription(fieldNames.getFirst())));
 

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
@@ -39,8 +39,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
   private long mEndMs;
   private long mIOBytes;
   private List<String> mErrors;
-  private List<WorkerBenchDataPoint> mDataPoints;
-  private List<Long> mDurationPercentiles;
+  private final List<WorkerBenchDataPoint> mDataPoints;
   private List<Long> mThroughputPercentiles;
 
   /**
@@ -50,7 +49,6 @@ public final class WorkerBenchTaskResult implements TaskResult {
     // Default constructor required for json deserialization
     mErrors = new ArrayList<>();
     mDataPoints = new ArrayList<>();
-    mDurationPercentiles = new ArrayList<>();
     mThroughputPercentiles = new ArrayList<>();
   }
 
@@ -174,20 +172,6 @@ public final class WorkerBenchTaskResult implements TaskResult {
   /**
    * @return 100 percentiles for durations of all I/O operations
    */
-  public List<Long> getDurationPercentiles() {
-    return mDurationPercentiles;
-  }
-
-  /**
-   * @param percentiles 100 percentiles for durations of all I/O operations
-   */
-  public void setDurationPercentiles(List<Long> percentiles) {
-    mDurationPercentiles = percentiles;
-  }
-
-  /**
-   * @return 100 percentiles for durations of all I/O operations
-   */
   public List<Long> getThroughputPercentiles() {
     return mThroughputPercentiles;
   }
@@ -203,14 +187,6 @@ public final class WorkerBenchTaskResult implements TaskResult {
    * From the collected operation data, calculates 100 percentiles.
    */
   public void calculatePercentiles() {
-    Histogram durationHistogram = new Histogram(
-        FormatUtils.parseTimeSize(mParameters.mDuration),
-        StressConstants.TIME_HISTOGRAM_PRECISION);
-    mDataPoints.forEach(stat -> durationHistogram.recordValue(stat.getDuration()));
-    for (int i = 0; i <= 100; i++) {
-      mDurationPercentiles.add(durationHistogram.getValueAtPercentile(i));
-    }
-
     Histogram throughputHistogram = new Histogram(
             FormatUtils.parseSpaceSize(mParameters.mFileSize),
             StressConstants.TIME_HISTOGRAM_PRECISION);

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
@@ -41,6 +41,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
   private List<String> mErrors;
   private List<WorkerBenchDataPoint> mDataPoints;
   private List<Long> mDurationPercentiles;
+  private List<Long> mThroughputPercentiles;
 
   /**
    * Creates an instance.
@@ -50,6 +51,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
     mErrors = new ArrayList<>();
     mDataPoints = new ArrayList<>();
     mDurationPercentiles = new ArrayList<>();
+    mThroughputPercentiles = new ArrayList<>();
   }
 
   /**
@@ -184,6 +186,20 @@ public final class WorkerBenchTaskResult implements TaskResult {
   }
 
   /**
+   * @return 100 percentiles for durations of all I/O operations
+   */
+  public List<Long> getThroughputPercentiles() {
+    return mThroughputPercentiles;
+  }
+
+  /**
+   * @param percentiles 100 percentiles for durations of all I/O operations
+   */
+  public void setThroughputPercentiles(List<Long> percentiles) {
+    mThroughputPercentiles = percentiles;
+  }
+
+  /**
    * From the collected operation data, calculates 100 percentiles.
    */
   public void calculatePercentiles() {
@@ -193,6 +209,14 @@ public final class WorkerBenchTaskResult implements TaskResult {
     mDataPoints.forEach(stat -> durationHistogram.recordValue(stat.getDuration()));
     for (int i = 0; i <= 100; i++) {
       mDurationPercentiles.add(durationHistogram.getValueAtPercentile(i));
+    }
+
+    Histogram throughputHistogram = new Histogram(
+            FormatUtils.parseSpaceSize(mParameters.mFileSize),
+            StressConstants.TIME_HISTOGRAM_PRECISION);
+    mDataPoints.forEach(stat -> throughputHistogram.recordValue(stat.getInThroughput()));
+    for (int i = 0; i <= 100; i++) {
+      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
     }
   }
 

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
@@ -12,11 +12,8 @@
 package alluxio.stress.worker;
 
 import alluxio.stress.BaseParameters;
-import alluxio.stress.StressConstants;
 import alluxio.stress.TaskResult;
-import alluxio.util.FormatUtils;
 
-import org.HdrHistogram.Histogram;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +36,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
   private long mEndMs;
   private long mIOBytes;
   private List<String> mErrors;
-  private final List<WorkerBenchDataPoint> mDataPoints;
+  private final List<WorkerBenchCoarseDataPoint> mDataPoints;
   private List<Long> mThroughputPercentiles;
 
   /**
@@ -187,13 +184,14 @@ public final class WorkerBenchTaskResult implements TaskResult {
    * From the collected operation data, calculates 100 percentiles.
    */
   public void calculatePercentiles() {
-    Histogram throughputHistogram = new Histogram(
-            FormatUtils.parseSpaceSize(mParameters.mFileSize),
-            StressConstants.TIME_HISTOGRAM_PRECISION);
-    mDataPoints.forEach(stat -> throughputHistogram.recordValue(stat.getInThroughput()));
-    for (int i = 0; i <= 100; i++) {
-      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
-    }
+    // TODO: implement percentile calculation for coarse data points
+//    Histogram throughputHistogram = new Histogram(
+//            FormatUtils.parseSpaceSize(mParameters.mFileSize),
+//            StressConstants.TIME_HISTOGRAM_PRECISION);
+//    mDataPoints.forEach(stat -> throughputHistogram.recordValue(stat.getInThroughput()));
+//    for (int i = 0; i <= 100; i++) {
+//      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
+//    }
   }
 
   /**
@@ -206,21 +204,21 @@ public final class WorkerBenchTaskResult implements TaskResult {
   /**
    * @return all data points for I/O operations
    */
-  public List<WorkerBenchDataPoint> getDataPoints() {
+  public List<WorkerBenchCoarseDataPoint> getDataPoints() {
     return mDataPoints;
   }
 
   /**
    * @param point one data point for one I/O operation
    */
-  public void addDataPoint(WorkerBenchDataPoint point) {
+  public void addDataPoint(WorkerBenchCoarseDataPoint point) {
     mDataPoints.add(point);
   }
 
   /**
    * @param stats data points for all recorded I/O operations
    */
-  public void addDataPoints(Collection<WorkerBenchDataPoint> stats) {
+  public void addDataPoints(Collection<WorkerBenchCoarseDataPoint> stats) {
     mDataPoints.addAll(stats);
   }
 
@@ -244,11 +242,10 @@ public final class WorkerBenchTaskResult implements TaskResult {
       WorkerBenchTaskResult mergedTaskResult = new WorkerBenchTaskResult();
 
       for (WorkerBenchTaskResult result : results) {
-        result.calculatePercentiles();
+        // result.calculatePercentiles();
         mergedTaskResult.merge(result);
-        LOG.info("Test results from worker {} has been merged, the data points are now cleared.",
-            result.getBaseParameters().mId);
-        result.clearDataPoints();
+        LOG.info("Test results from worker {} has been merged.", result.getBaseParameters().mId);
+        // result.clearDataPoints();
         nodeResults.put(result.getBaseParameters().mId, result);
       }
 

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -193,8 +193,10 @@ public abstract class Benchmark<T extends TaskResult> {
       // Spawn a new process
       List<String> command = new ArrayList<>();
       command.add(conf.get(PropertyKey.HOME) + "/bin/alluxio");
-      command.add("runClass");
+      command.add("exec");
+      command.add("class");
       command.add(className);
+      command.add("--");
       command.addAll(Arrays.asList(args));
       command.add(BaseParameters.IN_PROCESS_FLAG);
       command.addAll(mBaseParameters.mJavaOpts.stream().map(String::trim)

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -103,10 +103,10 @@ public class StressClientIOBench extends AbstractStressBench
         "# This test will run create a 500MB file with block size 15KB on 1 worker,",
         "# then test the ReadArray operation for 30s and calculate the throughput after 10s "
             + "warmup.",
-        "$ bin/alluxio runClass alluxio.stress.cli.client.StressClientIOBench --operation Write "
-            + "--base alluxio:///stress-client-io-base --file-size 500m --buffer-size 64k "
+        "$ bin/alluxio exec class alluxio.stress.cli.client.StressClientIOBench -- --operation "
+            + "Write --base alluxio:///stress-client-io-base --file-size 500m --buffer-size 64k "
             + "--block-size 16k --write-num-workers 1 --cluster --cluster-limit 1",
-        "$ bin/alluxio runClass alluxio.stress.cli.client.StressClientIOBench --operation "
+        "$ bin/alluxio exec class alluxio.stress.cli.client.StressClientIOBench -- --operation "
             + "ReadArray --base alluxio:///stress-client-io-base --file-size 500m --buffer-size "
             + "64k --block-size 16k --warmup 10s --duration 30s --write-num-workers 1 --cluster "
             + "--cluster-limit 1\n"));

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -123,7 +123,7 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
             + "be prepared for each test thread."
             + "# The threads will keeping reading for 30s including a 10s warmup."
             + "# So the result captures I/O performance from the last 20s.",
-        "$ bin/alluxio runClass alluxio.stress.cli.worker.StressWorkerBench \\\n"
+        "$ bin/alluxio exec class alluxio.stress.cli.worker.StressWorkerBench -- \\\n"
             + "--threads 32 --base alluxio:///stress-worker-base --file-size 100m \\\n"
             + "--warmup 10s --duration 30s --cluster\n"
     ));

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -517,7 +517,7 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
       }
       long endOperation = CommonUtils.getCurrentMs();
       return new WorkerBenchDataPoint(
-              mBaseParameters.mIndex, Thread.currentThread().getId(),
+              mBaseParameters.mIndex, String.valueOf(Thread.currentThread().getId()),
               startOperation, endOperation - startOperation, bytesRead);
     }
 


### PR DESCRIPTION
For random reads, bytes read per file is not a constant any more. In spite of existing duration distribution, need a throughput distribution for better understanding of reading performance.

Also, when duration too long, grpc will receive huge size of output data. Should aggregate data points to transfer more datapoints with limited output size.
Solution 1: group datapoints by threads (Testing)
Example: `{wId: 0, tId: 70, dataPoints: [{startMs: 100, duration: 50, ioBytes: 2000000}, {…}, …]}`
Solution 2: group datapoints by time slices (Work in progress)
Example: `{wId: 0, tId: 70, coarseDataPoints: [{count: 30, ioBytes: 90000000}, {…}, …]}`
