### PR TITLE
Change Benchmark's `runClass` to `exec class` 

### DIFF
--- a/dora/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
+++ b/dora/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
@@ -125,9 +125,11 @@ public final class StressBenchDefinition
   @Override
   public String runTask(StressBenchConfig config, ArrayList<String> args,
       RunTaskContext runTaskContext) throws Exception {
-    List<String> command = new ArrayList<>(3 + config.getArgs().size());
+    List<String> command = new ArrayList<>(5 + config.getArgs().size());
     command.add(Configuration.get(PropertyKey.HOME) + "/bin/alluxio");
-    command.add("runClass");
+    command.add("exec");
+    command.add("class");
+    command.add("--");
     command.add(config.getClassName());
 
     // the cluster will run distributed tasks

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -193,7 +193,9 @@ public abstract class Benchmark<T extends TaskResult> {
       // Spawn a new process
       List<String> command = new ArrayList<>();
       command.add(conf.get(PropertyKey.HOME) + "/bin/alluxio");
-      command.add("runClass");
+      command.add("exec");
+      command.add("class");
+      command.add("--");
       command.add(className);
       command.addAll(Arrays.asList(args));
       command.add(BaseParameters.IN_PROCESS_FLAG);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Change `runClass` in Benchmark to `exec class`

### Why are the changes needed?

Since new alluxio cli change from `runClass` to `exec class`, related benchmark code should be change as well to keep it work

### Does this PR introduce any user facing changes?

no
