### PR TITLE
Remove non-unique fields in generating workerid

### DIFF
--- a/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
@@ -258,7 +258,6 @@ public final class WorkerNetAddress implements Serializable {
   public String dumpMainInfo() {
     return MoreObjects.toStringHelper(this)
         .add("host", mHost)
-        .add("containerHost", mContainerHost)
         .add("rpcPort", mRpcPort)
         .add("dataPort", mDataPort)
         .add("webPort", mWebPort)


### PR DESCRIPTION
### What changes are proposed in this pull request?

remove containerHost from workernetaddr.dumpMainInfo as in k8s we can not ensure containerHost kept the same after restart

### Why are the changes needed?

both workerId generation and consistent hash ring generation is from WorkerNetAddress.dumpMainInfo, in which containerHost is part of the fields to generate unique workerId, but in k8s containerHost will change after restart worker pod, therefore removing it in  dumpMainInfo.

### Does this PR introduce any user facing changes?

N/A