### PR TITLE
Check UFS rename operation result and throw exception if failed

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -731,7 +731,8 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
       boolean exists = ufs.exists(path);
       if (!overWrite && exists) {
         throw new RuntimeException(
-            new FileAlreadyExistsException("File already exists but no overwrite flag"));
+            new FileAlreadyExistsException(
+                String.format("File %s already exists but no overwrite flag", path)));
       } else if (overWrite) {
         // client is going to overwrite this file. We need to invalidate the cached meta and data.
         mMetaManager.removeFromMetaStore(path);
@@ -816,24 +817,32 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
       throws IOException, AccessControlException {
     UnderFileSystem srcUfs = getUfsInstance(src);
     UnderFileSystem dstUfs = getUfsInstance(dst);
+    LOG.debug("Renaming from {} to {}", src, dst);
     // use strong reference comparison as UnderFileSystem does not support equality check
     // except by UFS type
     if (srcUfs != dstUfs) {
       throw new FailedPreconditionException("Cannot rename a file in one UFS to another UFS");
     }
 
+    boolean rc;
     try {
       UfsStatus status = srcUfs.getStatus(src);
       if (status.isFile()) {
-        srcUfs.renameFile(src, dst);
+        rc = srcUfs.renameFile(src, dst);
       } else {
-        srcUfs.renameDirectory(src, dst);
+        rc = srcUfs.renameDirectory(src, dst);
       }
-      mMetaManager.removeFromMetaStore(src);
-      mMetaManager.loadFromUfs(dst);
-      mMetaManager.invalidateListingCacheOfParent(dst);
+      if (rc) {
+        mMetaManager.removeFromMetaStore(src);
+        mMetaManager.loadFromUfs(dst);
+        mMetaManager.invalidateListingCacheOfParent(dst);
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
+    }
+    LOG.debug("Renaming from {} to {} done: {}", src, dst, rc);
+    if (!rc) {
+      throw new RuntimeException(String.format("Failed to rename from '%s' to '%s'", src, dst));
     }
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Worker checks UFS rename operation result and throws expcetion if failed

### Why are the changes needed?

The rename operation result is omitted before. If operation fails, Alluxio client does not know the result.

### Does this PR introduce any user facing changes?
N/A
