### PR TITLE
Fix issue when starting master with STATIC membership type

### DIFF
--- a/dora/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -126,7 +126,7 @@ import alluxio.master.scheduler.JournaledJobMetaStore;
 import alluxio.master.scheduler.MembershipManagerWorkerProvider;
 import alluxio.master.scheduler.Scheduler;
 import alluxio.master.scheduler.WorkerProvider;
-import alluxio.membership.EtcdMembershipManager;
+import alluxio.membership.MembershipManager;
 import alluxio.membership.MembershipType;
 import alluxio.metrics.Metric;
 import alluxio.metrics.MetricInfo;
@@ -504,7 +504,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       case STATIC:
       case ETCD:
         workerProvider = new MembershipManagerWorkerProvider(
-            EtcdMembershipManager.create(Configuration.global()), schedulerFsContext);
+            MembershipManager.Factory.create(Configuration.global()), schedulerFsContext);
         break;
       case NOOP:
         workerProvider = new DefaultWorkerProvider(this, schedulerFsContext);


### PR DESCRIPTION
### What changes are proposed in this pull request?
should use interface factory for membership mgr module for scheduler at time of master startup, otherwise setting STATIC membership mgr will not start master.

### Why are the changes needed?

if alluxio.worker.membership.manager.type is set to STATIC, master won't be able to start as it needs etcd related info.

### Does this PR introduce any user facing changes?

N/A
