### PR TITLE
Fix the array out of bound exception in presto

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -193,7 +193,6 @@ public class LocalCacheFileInStream extends FileInStream {
     int bytesLeftInPage = (int) (mPageSize - currentPageOffset);
     int bytesToReadInPage = Math.min(bytesLeftInPage, length);
     stopwatch.reset().start();
-    int offsetInBuffer = bytesBuffer.offset();
     int bytesRead =
         mCacheManager.get(pageId, currentPageOffset, bytesToReadInPage, bytesBuffer, mCacheContext);
     stopwatch.stop();
@@ -205,9 +204,6 @@ public class LocalCacheFileInStream extends FileInStream {
             stopwatch.elapsed(TimeUnit.NANOSECONDS));
       }
       return bytesRead;
-    } else {
-      //In case any error in cache manager, revert the offset change in the bytesBuffer
-      bytesBuffer.offset(offsetInBuffer);
     }
     // on local cache miss, read a complete page from external storage. This will always make
     // progress or throw an exception

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -193,6 +193,7 @@ public class LocalCacheFileInStream extends FileInStream {
     int bytesLeftInPage = (int) (mPageSize - currentPageOffset);
     int bytesToReadInPage = Math.min(bytesLeftInPage, length);
     stopwatch.reset().start();
+    int offsetInBuffer = bytesBuffer.offset();
     int bytesRead =
         mCacheManager.get(pageId, currentPageOffset, bytesToReadInPage, bytesBuffer, mCacheContext);
     stopwatch.stop();
@@ -204,6 +205,9 @@ public class LocalCacheFileInStream extends FileInStream {
             stopwatch.elapsed(TimeUnit.NANOSECONDS));
       }
       return bytesRead;
+    } else {
+      //In case any error in cache manager, revert the offset change in the bytesBuffer
+      bytesBuffer.offset(offsetInBuffer);
     }
     // on local cache miss, read a complete page from external storage. This will always make
     // progress or throw an exception

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
@@ -76,11 +76,18 @@ public class NoExceptionCacheManager implements CacheManager {
   @Override
   public int get(PageId pageId, int pageOffset, ReadTargetBuffer buffer,
                  CacheContext cacheContext) {
+    int originalOffset = buffer.offset();
     try {
-      return mCacheManager.get(pageId, pageOffset, buffer, cacheContext);
+      int bytesRead =  mCacheManager.get(pageId, pageOffset, buffer, cacheContext);
+      if (bytesRead == -1) {
+        buffer.offset(originalOffset);
+      }
+      return bytesRead;
     } catch (Exception e) {
       LOG.error("Failed to get page {}", pageId, e);
       Metrics.GET_ERRORS.inc();
+      //In case any error in cache manager, revert the offset change in the buffer
+      buffer.offset(originalOffset);
       return -1;
     }
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix the array out of bound exception in presto

### Why are the changes needed?

Because we saw earlier that the LocalCacheManager swallows all exceptions, if there is an error accessing one of the cached files, the exception will be ignored. However, the offset may have changed during the failed read attempt in LocalCacheManager. When LocalCacheManager returns -1 on error and tries to reread from the lower layer storage, the offset could be out of bounds.

Regarding why this issue only appears in versions 2.9.3 and later, it's because the offset became a member variable of our target buffer starting from 2.9.3. In earlier versions it was always a local variable, so there was no compounding of offset errors.

### Does this PR introduce any user facing changes?

no
