### PR TITLE
Fix static shaded client version in dora example pom

### DIFF
--- a/dora/examples/pom.xml
+++ b/dora/examples/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-shaded-client</artifactId>
-      <version>2.9.0</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
This PR fixed the shaded client version problem in dora example pom.
Current version in dora/example/pom.xml written as `<version>2.9.0</version>`. As a result, all updates on the shaded client after 2.9.0 won't work (e.g. removal of swift ufs). Now it is written as `<version>${project.version}</version>`