### PR TITLE
Handle the reserved character ':' for HTTP server

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
@@ -176,6 +176,7 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
 
   private String handleReservedCharacters(String path) {
     path = path.replace("%2F", "/");
+    path = path.replace("%3A", ":");
     return path;
   }
 


### PR DESCRIPTION
Handle the reserved character ':' for HTTP server.