### PR TITLE
Avoid using bash -c in checking Java version in Golang CLI

### DIFF
--- a/cli/src/alluxio.org/cli/env/env.go
+++ b/cli/src/alluxio.org/cli/env/env.go
@@ -240,7 +240,7 @@ var (
 )
 
 func checkJavaVersion(javaPath string) error {
-	cmd := exec.Command("bash", "-c", fmt.Sprintf("%v -version", javaPath))
+	cmd := exec.Command(javaPath, "-version")
 	javaVer, err := cmd.CombinedOutput()
 	if err != nil {
 		return stacktrace.Propagate(err, "error finding java version from `%v -version`", javaPath)


### PR DESCRIPTION
Run `bash -c java -version` might be not work on remote machines, reporting the following bug.
```
java.lang.RuntimeException: Failed to successfully complete the job: Task execution failed: Error: error defining alluxio environment
 --- at /cli/src/alluxio.org/cli/launch/launch.go:49 (Run.func1) ---
Caused by: error checking java version compatibility
 --- at /cli/src/alluxio.org/cli/env/env.go:132 (InitAlluxioEnv) ---
Caused by: error finding java version from `/usr/lib/jvm/java/bin/java -version`
 --- at /cli/src/alluxio.org/cli/env/env.go:246 (checkJavaVersion) ---
Caused by: exec: "bash": executable file not found in $PATH
```
Run `java -version` directly can solve this problem.