### PR TITLE
[SMALLFIX] Make DoraCacheFileSystem.convertUfsPathToAlluxioPath public

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -470,7 +470,15 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
     }
   }
 
-  private AlluxioURI convertUfsPathToAlluxioPath(AlluxioURI ufsPath) {
+  /**
+   * Converts the UFS path back to Alluxio path.
+   * <p>
+   * This is the opposite operation to {@link #convertAlluxioPathToUFSPath(AlluxioURI)}.
+   *
+   * @param ufsPath UfsBaseFileSystem based full path
+   * @return an Alluxio path
+   */
+  public AlluxioURI convertUfsPathToAlluxioPath(AlluxioURI ufsPath) {
     if (mDelegatedFileSystem instanceof UfsBaseFileSystem) {
       AlluxioURI rootUfs = ((UfsBaseFileSystem) mDelegatedFileSystem).getRootUFS();
       try {


### PR DESCRIPTION
### What changes are proposed in this pull request?

The reverse resolution should follow the same pattern as defined in `DoraCacheFileSystem.convertAlluxioPathToUfsPath()` and be made public. This further allows inheritance and overriding.
