### PR TITLE
Return FileNotFound when a file is being create/write

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -389,11 +389,11 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
       }
     }
     if (shouldLoad) {
-      // Let's check if this file is under create/write
+      // Checks if this file is under create/write.
       OpenFileHandle handle = mOpenFileHandleContainer.find(ufsFullPath);
       if (handle != null) {
-        // The target is being written. It's fine to return FileNotFound.
-        LOG.debug("File {} is being written", ufsFullPath);
+        // The target is being written to. It's fine to return FileNotFound.
+        LOG.debug("File {} is being written to.", ufsFullPath);
         status = Optional.empty();
       } else {
         status = mMetaManager.loadFromUfs(ufsFullPath);

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -389,7 +389,15 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
       }
     }
     if (shouldLoad) {
-      status = mMetaManager.loadFromUfs(ufsFullPath);
+      // Let's check if this file is under create/write
+      OpenFileHandle handle = mOpenFileHandleContainer.find(ufsFullPath);
+      if (handle != null) {
+        // The target is being written. It's fine to return FileNotFound.
+        LOG.debug("File {} is being written", ufsFullPath);
+        status = Optional.empty();
+      } else {
+        status = mMetaManager.loadFromUfs(ufsFullPath);
+      }
     }
 
     if (!status.isPresent()) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Return FileNotFound when a file is being create/write. No need to refresh its metadata.
Metadata will be refreshed when file is closed.

### Why are the changes needed?

If a file is being written to, and another getStatus() comes for such file, 
this file probably has not been created in UFS. At that time,
the getStatus() thinks that this file does not exists. So the worker tries to remove its metadata and its data from cache.
ERROR logs were generated in such case.

This patch is to handle this correctly and remove such ERROR logs:
```
2023-09-05 17:16:32,802 ERROR LocalCacheManager - Failed to delete page PageId{FileId=f4b0d1f405d7419069129a1262eae9329e9c19ed2584fc3fe27656a698344047, PageIndex=0} (isTemporary: false) from pageStore.
alluxio.exception.PageNotFoundException: /Volumes/ramdisk/LOCAL/1048576/824/f4b0d1f405d7419069129a1262eae9329e9c19ed2584fc3fe27656a698344047/0
	at alluxio.client.file.cache.store.LocalPageStore.delete(LocalPageStore.java:135)
	at alluxio.client.file.cache.LocalCacheManager.deletePage(LocalCacheManager.java:889)
	at alluxio.client.file.cache.LocalCacheManager.delete(LocalCacheManager.java:694)
	at alluxio.client.file.cache.LocalCacheManager.delete(LocalCacheManager.java:706)
	at alluxio.client.file.cache.LocalCacheManager.lambda$deleteFile$5(LocalCacheManager.java:839)
	at java.lang.Iterable.forEach(Iterable.java:75)
	at alluxio.client.file.cache.LocalCacheManager.deleteFile(LocalCacheManager.java:839)
	at alluxio.client.file.cache.NoExceptionCacheManager.deleteFile(NoExceptionCacheManager.java:209)
	at alluxio.worker.dora.DoraMetaManager.invalidateCachedFile(DoraMetaManager.java:337)
	at alluxio.worker.dora.DoraMetaManager.removeFromMetaStore(DoraMetaManager.java:178)
	at alluxio.worker.dora.DoraMetaManager.loadFromUfs(DoraMetaManager.java:131)
	at alluxio.worker.dora.PagedDoraWorker.getGrpcFileInfo(PagedDoraWorker.java:392)
	at alluxio.worker.grpc.DoraWorkerClientServiceHandler.getStatus(DoraWorkerClientServiceHandler.java:201)
	at alluxio.grpc.BlockWorkerGrpc$MethodHandlers.invoke(BlockWorkerGrpc.java:1589)
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:355)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:867)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```

### Does this PR introduce any user facing changes?
No