### PR TITLE
Fix a deadlock in FileSystemContext

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -414,13 +414,16 @@ public class FileSystemContext implements Closeable {
    */
   public void reinit(boolean updateClusterConf, boolean updatePathConf)
       throws UnavailableException, IOException {
+    // inquiry primary master address before entering the critical session of mReinitializer,
+    // where all RPCs wait for the monitor object of FileSystemContext (synchronized methods)
+    // will block until initialization completes
+    InetSocketAddress masterAddr;
+    try {
+      masterAddr = getMasterAddress();
+    } catch (IOException e) {
+      throw new UnavailableException("Failed to get master address during reinitialization", e);
+    }
     try (Closeable r = mReinitializer.allow()) {
-      InetSocketAddress masterAddr;
-      try {
-        masterAddr = getMasterAddress();
-      } catch (IOException e) {
-        throw new UnavailableException("Failed to get master address during reinitialization", e);
-      }
       try {
         getClientContext().loadConf(masterAddr, updateClusterConf, updatePathConf);
       } catch (AlluxioStatusException e) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix a deadlock.

### Why are the changes needed?

On the Alluxio client, there is a monitor lock of `FileSystemContext` to sync individual client-to-master operations.

One application thread can successfully hold the monitor lock (`alluxio.client.file.FileSystemContext`)  in order to get worker list, but blocked by another “lock” `FileSystemContextReinitializer`  (waiting for latch on on-going RPCs down to zero) for acquiring the block master client to really connect to master process  (waiting for other callers involving `FileSystemContextReinitializer` to finish). 

On the other hand, another heartbeat thread "config-hash-master-heartbeat-0" is awaking periodically to sync with the master process to fetch the latest configuration. This thread detected the conf update and thus entered `FileSystemContextReinitializer` (bumping latch) but was blocked by waiting for the monitor lock of  `alluxio.client.file.FileSystemContext` in order to get the master address.

This PR moves `getMasterAddress` outside `reinit` block to avoid holding the `Reinitializer` object and wait for the monitor object of `FileSystemContext`.

### Does this PR introduce any user facing changes?

No