### PR TITLE
Add isReadOnly() for FuseFileStream

### DIFF
--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -165,4 +165,9 @@ public class FuseFileInOrOutStream implements FuseFileStream {
   public boolean isClosed() {
     return mClosed;
   }
+
+  @Override
+  public boolean isReadOnly() {
+    return false;
+  }
 }

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
@@ -166,4 +166,9 @@ public class FuseFileInStream implements FuseFileStream {
   public boolean isClosed() {
     return mClosed;
   }
+
+  @Override
+  public boolean isReadOnly() {
+    return true;
+  }
 }

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -270,4 +270,9 @@ public class FuseFileOutStream implements FuseFileStream {
     LOG.debug("Filled {} zero bytes to file {} to fulfill the extended file length of {}",
         originalBytesGap, mURI, mFileStatus.getFileLength());
   }
+
+  @Override
+  public boolean isReadOnly() {
+    return false;
+  }
 }

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
@@ -63,4 +63,9 @@ public interface FuseFileStream extends AutoCloseable {
    * @return if the stream is closed
    */
   boolean isClosed();
+
+  /**
+   * @return if this stream is for read only
+   */
+  boolean isReadOnly();
 }

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReadOrOutStream.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReadOrOutStream.java
@@ -178,4 +178,9 @@ public class FusePositionReadOrOutStream implements FuseFileStream {
   public boolean isClosed() {
     return mClosed;
   }
+
+  @Override
+  public boolean isReadOnly() {
+    return false;
+  }
 }

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReader.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReader.java
@@ -141,4 +141,9 @@ public class FusePositionReader implements FuseFileStream {
   public boolean isClosed() {
     return mClosed;
   }
+
+  @Override
+  public boolean isReadOnly() {
+    return true;
+  }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add isReadOnly() for FuseFileStream and implement this interface in various Streams.

### Why are the changes needed?

This interface is used to determine if the Stream is only. This is needed to determine if a real data flush is needed.

### Does this PR introduce any user facing changes?

N/A