### PR TITLE
[DOCFIX] Update bin/alluxio usage format

### DIFF
--- a/cli/src/alluxio.org/cli/launch/launch.go
+++ b/cli/src/alluxio.org/cli/launch/launch.go
@@ -39,7 +39,9 @@ func Run(jarEnvVars map[bool]map[string]string, appendClasspathJars map[string]f
 	var flagDebugLog bool
 	rootCmd.PersistentFlags().BoolVar(&flagDebugLog, "debug-log", false, "True to enable debug logging")
 	var flagIsDeployed bool
-	rootCmd.PersistentFlags().BoolVar(&flagIsDeployed, "deployed-env", false, "True to set paths to be compatible with a deployed environment")
+	const deployedEnv = "deployed-env"
+	rootCmd.PersistentFlags().BoolVar(&flagIsDeployed, deployedEnv, false, "True to set paths to be compatible with a deployed environment")
+	rootCmd.PersistentFlags().MarkHidden(deployedEnv)
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		if flagDebugLog {

--- a/docs/en/api/REST-API.md
+++ b/docs/en/api/REST-API.md
@@ -21,8 +21,8 @@ can use in-memory streams, the REST API decouples the stream creation and access
 `create` and `open` REST API methods and the `streams` resource endpoints for details).
 
 The HTTP proxy is a standalone server that can be started using
-`${ALLUXIO_HOME}/bin/alluxio-start.sh proxy` and stopped using `${ALLUXIO_HOME}/bin/alluxio-stop.sh
-proxy`. By default, the REST API is available on port 39999.
+`${ALLUXIO_HOME}/bin/alluxio process start proxy` and stopped using `${ALLUXIO_HOME}/bin/alluxio process stop proxy`.
+By default, the REST API is available on port 39999.
 
 There are performance implications of using the HTTP proxy. In particular, using the proxy requires
 an extra network hop to perform filesystem operations. For optimal performance, it is recommended to

--- a/docs/en/contributor/Contributor-Tools.md
+++ b/docs/en/contributor/Contributor-Tools.md
@@ -31,11 +31,10 @@ list.
 
 Some source files in Alluxio are generated from templates or compiled from other languages.
 
-1. gRPC and ProtoBuf definitions are compiled into Java source files. Alluxio 2.2 moved generated 
-   gRPC proto source files into `core/transport/target/generated-sources/protobuf/`.
-2. Compile time project constants are defined in 
-   `core/common/src/main/java-templates/` and compiled to
-   `core/common/target/generated-sources/java-templates/`.
+1. gRPC and ProtoBuf definitions are compiled into Java source files and generated files are located in `common/transport/target/generated-sources/protobuf/`.
+1. Compile time project constants are defined in 
+   `dora/core/common/src/main/java-templates/` and compiled to
+   `dora/core/common/target/generated-sources/java-templates/`.
 
 You will need to mark these directories as "Generated Sources Root" for IntelliJ to resolve the 
 source files. Alternatively, you can let IntelliJ generate them and mark the directories 
@@ -50,13 +49,12 @@ action from the `Navigate > Search Everywhere` dialog.
 
 ##### Start a single master Alluxio cluster
 1. Run `dev/intellij/install-runconfig.sh`
-2. Restart IntelliJ IDEA
-3. Edit `conf/alluxio-site.properties` to contain these configurations
+1. Restart IntelliJ IDEA
+1. Edit `conf/alluxio-site.properties` to contain these configurations
    ```properties
    alluxio.master.hostname=localhost
-   alluxio.job.master.hostname=localhost
    ```
-4. Edit `conf/log4j.properties` to print log in console
+1. Edit `conf/log4j.properties` to print log in console
    Replace the `log4j.rootLogger` configuration with
     ```properties
     log4j.rootLogger=INFO, ${alluxio.logger.type}, ${alluxio.remote.logger.type}, stdout
@@ -68,13 +66,10 @@ action from the `Navigate > Search Everywhere` dialog.
     log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
     log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
     ```
-5. Format the Alluxio master by running `bin/alluxio formatMasters`
-6. In Intellij, start Alluxio master process by selecting `Run > Run > AlluxioMaster`
-7. In Intellij, start Alluxio job master process by selecting `Run > Run > AlluxioJobMaster`
-8. Prepare the RamFS and format the Alluxio Worker with `bin/alluxio-mount.sh SudoMount && bin/alluxio formatWorker`
-9. In Intellij, start Alluxio worker process by selecting `Run > Run > AlluxioWorker`
-10. In Intellij, start Alluxio job worker process by selecting `Run > Run > AlluxioJobWorker`
-11. [Verify the Alluxio cluster is up]({{ '/en/deploy/Get-Started.html#starting-alluxio' | relativize_url }}).
+1. Format the Alluxio master by running `bin/alluxio journal format`
+1. In Intellij, start Alluxio master process by selecting `Run > Run > AlluxioMaster`
+1. In Intellij, start Alluxio worker process by selecting `Run > Run > AlluxioWorker`
+1. [Verify the Alluxio cluster is up]({{ '/en/deploy/Get-Started.html#starting-alluxio' | relativize_url }}).
 
 ##### Start a High Availability (HA) Alluxio cluster
 1. Create journal directories for the masters 
@@ -87,9 +82,9 @@ action from the `Navigate > Search Everywhere` dialog.
    `alluxio/dev/intellij/runConfigurations/AlluxioMaster_0.xml`.
     > Note: If the journal folders exist, and you want to apply a new HA cluster, you should clear 
     > files in the journal folders first.  
-2. Run `dev/intellij/install-runconfig.sh`
-3. Restart IntelliJ IDEA
-4. Edit `conf/alluxio-site.properties` to contain these configurations
+1. Run `dev/intellij/install-runconfig.sh`
+1. Restart IntelliJ IDEA
+1. Edit `conf/alluxio-site.properties` to contain these configurations
     ```properties
     alluxio.master.hostname=localhost
     alluxio.job.master.hostname=localhost
@@ -97,57 +92,17 @@ action from the `Navigate > Search Everywhere` dialog.
     alluxio.master.rpc.addresses=localhost:19998,localhost:19988,localhost:19978
     ```
    The ports are defined in the run configurations.
-5. In Intellij, start the Alluxio master processes by selecting `Run > Run > 
+1. In Intellij, start the Alluxio master processes by selecting `Run > Run > 
    AlluxioMaster-0`, `Run > Run > AlluxioMaster-1`, and `Run > Run > AlluxioMaster-2`
-6. Prepare the RamFS and format the Alluxio Worker with `bin/alluxio-mount.sh SudoMount && bin/alluxio formatWorker`
-7. In Intellij, start the Alluxio worker process by selecting `Run > Run > AlluxioWorker`
-8. In Intellij, start the Alluxio job master process by selecting `Run > Run > AlluxioJobMaster`
-9. In Intellij, start the Alluxio job worker process by selecting `Run > Run > AlluxioJobWorker`
-10. Verify the HA Alluxio cluster is up, by running 
-    `bin/alluxio fsadmin journal quorum info -domain MASTER`, and you will see output like this:
-    ```shell
-    Journal domain	: MASTER
-    Quorum size	: 3
-    Quorum leader	: localhost:19201
-    
-    STATE       | PRIORITY | SERVER ADDRESS
-    AVAILABLE   | 0        | localhost:19200
-    AVAILABLE   | 0        | localhost:19201
-    AVAILABLE   | 0        | localhost:19202
-    ```
-
-**You can also start a High Availability (HA) Job Master process on this basis.**
-
-1. Stop the Alluxio job master and job worker processes from steps 8 and 9 if they are running. 
-2. Edit `conf/alluxio-site.properties` and add these configurations
-   ```properties
-   alluxio.job.master.rpc.addresses=localhost:20001,localhost:20011,localhost:20021
-   alluxio.job.master.embedded.journal.addresses=localhost:20003,localhost:20013,localhost:20023
-   ```
-3. In Intellij, start the Alluxio job master processes by selecting `Run > Run > 
-   AlluxioJobMaster-0`, `Run > Run > AlluxioJobMaster-1`, and `Run > Run > AlluxioJobMaster-2`
-4. In Intellij, start the Alluxio job worker process by selecting `Run > Run > AlluxioJobWorker`
-5. Verify the HA JobMaster cluster is up, by running 
-`bin/alluxio fsadmin journal quorum info -domain JOB_MASTER`, and you will 
-   see output like this:
-   ```shell
-   Journal domain	: JOB_MASTER
-   Quorum size	: 3
-   Quorum leader	: localhost:20013
-    
-   STATE       | PRIORITY | SERVER ADDRESS
-   AVAILABLE   | 0        | localhost:20003
-   AVAILABLE   | 0        | localhost:20013
-   AVAILABLE   | 0        | localhost:20023
-   ```
+1. In Intellij, start the Alluxio worker process by selecting `Run > Run > AlluxioWorker`
 
 ##### Start an AlluxioFuse process
 
 1. Start a [single master Alluxio cluster](#start-a-single-master-alluxio-cluster) 
    or a [High Availability cluster](#start-a-high-availability-ha-alluxio-cluster) in Intellij.
-2. In Intellij, start AlluxioFuse process by selecting `Run > Run > AlluxioFuse`. 
+1. In Intellij, start AlluxioFuse process by selecting `Run > Run > AlluxioFuse`. 
    This creates a FUSE mount point at `/tmp/alluxio-fuse`.
-3. Verify the FUSE filesystem is working by running these commands:
+1. Verify the FUSE filesystem is working by running these commands:
     ```shell
     $ touch /tmp/alluxio-fuse/tmp1
     $ ls /tmp/alluxio-fuse
@@ -169,7 +124,7 @@ You may also have to add the classpath variable `M2_REPO` by running:
 $ mvn -Declipse.workspace="your Eclipse Workspace" eclipse:configure-workspace
 ```
 
-> Note: Alluxio 2.2 moved generated gRPC proto source files into `alluxio/core/transport/target/generated-sources/protobuf/`.
+> Note: Generated gRPC proto source files are located in `alluxio/core/transport/target/generated-sources/protobuf/`.
 You will need to mark the directory as a source folder for Eclipse to resolve the source files.
 
 ## Maven Targets and Plugins

--- a/docs/en/deploy/Get-Started.md
+++ b/docs/en/deploy/Get-Started.md
@@ -131,14 +131,13 @@ Alluxio needs to be formatted before starting the process. The following command
 the Alluxio journal and worker storage directories.
 
 ```shell
-$ ./bin/alluxio format
+$ ./bin/alluxio init format
 ```
 
 Start the Alluxio services
 
 ```shell
-$ ./bin/alluxio-start.sh master
-$ ./bin/alluxio-start.sh worker SudoMount
+$ ./bin/alluxio process start local
 ```
 
 Congratulations! Alluxio is now up and running!
@@ -201,8 +200,7 @@ When the file is read, it will also be cached by Alluxio to speed up future data
 Stop Alluxio with the following command:
 
 ```shell
-$ ./bin/alluxio-stop.sh master
-$ ./bin/alluxio-stop.sh worker
+$ ./bin/alluxio process stop local
 ```
 
 ## Next Steps
@@ -226,7 +224,7 @@ our documentation, such as [Data Caching]({{ '/en/core-services/Data-Caching.htm
 
 For the users who are using macOS 11(Big Sur) or later, when running the command
 ```shell
-$ ./bin/alluxio format
+$ ./bin/alluxio init format
 ```
 you might get the error message:
 ```

--- a/docs/en/deploy/Install-Alluxio-Cluster-with-HA.md
+++ b/docs/en/deploy/Install-Alluxio-Cluster-with-HA.md
@@ -89,10 +89,10 @@ Before Alluxio can be started for the first time, the Alluxio master journal and
 
 On all the Alluxio master nodes, list all the worker hostnames in the `conf/workers` file, and list all the masters in the `conf/masters` file. 
 This will allow alluxio scripts to run operations on the cluster nodes.
-`format` Alluxio cluster with the following command in one of the master nodes:
+`init format` Alluxio cluster with the following command in one of the master nodes:
 
 ```shell
-$ ./bin/alluxio format
+$ ./bin/alluxio init format
 ```
 
 ### Launch Alluxio
@@ -100,14 +100,11 @@ $ ./bin/alluxio format
 In one of the master nodes, start the Alluxio cluster with the following command:
 
 ```shell
-$ ./bin/alluxio-start.sh all SudoMount
+$ ./bin/alluxio process start all
 ```
 
 This will start Alluxio masters on all the nodes specified in `conf/masters`, and start the workers
 on all the nodes specified in `conf/workers`.
-Argument `SudoMount` indicates to mount the RamFS on each worker using `sudo` privilege, if it is
-not already mounted.
-On MacOS, make sure your terminal has full disk access (tutorial [here](https://osxdaily.com/2018/10/09/fix-operation-not-permitted-terminal-error-macos/)).
 
 ### Verify Alluxio Cluster
 
@@ -115,7 +112,7 @@ To verify that Alluxio is running, you can visit the web UI of the leading maste
 leading master, run:
 
 ```shell
-$ ./bin/alluxio fs masterInfo
+$ ./bin/alluxio info report
 ```
 
 Then, visit `http://<LEADER_HOSTNAME>:19999` to see the status page of the Alluxio leading master.
@@ -124,7 +121,7 @@ Alluxio comes with a simple program that writes and reads sample files in Alluxi
 program with:
 
 ```shell
-$ ./bin/alluxio runTests
+$ ./bin/alluxio exec basicIOTest
 ```
 
 ## Access an Alluxio Cluster with HA
@@ -217,7 +214,7 @@ Below are common operations to perform on an Alluxio cluster.
 To stop an Alluxio service, run:
 
 ```shell
-$ ./bin/alluxio-stop.sh all
+$ ./bin/alluxio process stop all
 ```
 
 This will stop all the processes on all nodes listed in `conf/workers` and `conf/masters`.
@@ -225,8 +222,8 @@ This will stop all the processes on all nodes listed in `conf/workers` and `conf
 You can stop just the masters and just the workers with the following commands:
 
 ```shell
-$ ./bin/alluxio-stop.sh masters # stops all masters in conf/masters
-$ ./bin/alluxio-stop.sh workers # stops all workers in conf/workers
+$ ./bin/alluxio process stop masters # stops all masters in conf/masters
+$ ./bin/alluxio process stop workers # stops all workers in conf/workers
 ```
 
 If you do not want to use `ssh` to login to all the nodes and stop all the processes, you can run
@@ -234,8 +231,8 @@ commands on each node individually to stop each component.
 For any node, you can stop a master or worker with:
 
 ```shell
-$ ./bin/alluxio-stop.sh master # stops the local master
-$ ./bin/alluxio-stop.sh worker # stops the local worker
+$ ./bin/alluxio process stop master # stops the local master
+$ ./bin/alluxio process stop worker # stops the local worker
 ```
 
 ### Restart Alluxio
@@ -244,14 +241,14 @@ Starting Alluxio is similar. If `conf/workers` and `conf/masters` are both popul
 the cluster with:
 
 ```shell
-$ ./bin/alluxio-start.sh all
+$ ./bin/alluxio process start all
 ```
 
 You can start just the masters and just the workers with the following commands:
 
 ```shell
-$ ./bin/alluxio-start.sh masters # starts all masters in conf/masters
-$ ./bin/alluxio-start.sh workers # starts all workers in conf/workers
+$ ./bin/alluxio process start masters # starts all masters in conf/masters
+$ ./bin/alluxio process start workers # starts all workers in conf/workers
 ```
 
 If you do not want to use `ssh` to login to all the nodes and start all the processes, you can run
@@ -259,8 +256,8 @@ commands on each node individually to start each component. For any node, you ca
 worker with:
 
 ```shell
-$ ./bin/alluxio-start.sh master # starts the local master
-$ ./bin/alluxio-start.sh worker # starts the local worker
+$ ./bin/alluxio process start master # starts the local master
+$ ./bin/alluxio process start worker # starts the local worker
 ```
 
 ### Add/Remove Workers Dynamically
@@ -271,7 +268,7 @@ In most cases, the new worker's configuration should be the same as all the othe
 Run the following command on the new worker to add
 
 ```shell
-$ ./bin/alluxio-start.sh worker SudoMount # starts the local worker
+$ ./bin/alluxio process start worker # starts the local worker
 ```
 
 Once the worker is started, it will register itself with the Alluxio leading master and become part of the Alluxio cluster.
@@ -279,7 +276,7 @@ Once the worker is started, it will register itself with the Alluxio leading mas
 Removing a worker is as simple as stopping the worker process.
 
 ```shell
-$ ./bin/alluxio-stop.sh worker # stops the local worker
+$ ./bin/alluxio process stop worker # stops the local worker
 ```
 
 Once the worker is stopped, and after

--- a/docs/en/operation/Configuration.md
+++ b/docs/en/operation/Configuration.md
@@ -32,37 +32,6 @@ to `CACHE_THROUGH`.
 Clients can ignore or overwrite the cluster-wide default values by following the approaches
 described in [Configure Applications](#configure-applications) to overwrite the same properties.
 
-### Path Defaults
-
-Alluxio administrators can set default client-side configurations for specific
-Alluxio filesystem paths.
-Filesystem client operations have options which are derived from client side configuration
-properties.
-Only client-side configuration properties can be set as path defaults.
-
-For example, the `createFile` operation has an option to specify write type.
-By default, the write type is the value of the configuration key `alluxio.user.file.writetype.default`.
-The administrator can set default value of `alluxio.user.file.write.type.default` to `MUST_CACHE`
-for all paths with prefix `/tmp` by running:
-
-```shell
-$ bin/alluxio fsadmin pathConf add --property alluxio.user.file.writetype.default=MUST_CACHE /tmp`
-```
-
-After executing this command any create operations on paths with prefix `/tmp` will use the
-`MUST_CACHE` write type by default unless the application configuration overrides the cluster
-defaults.
-
-Path defaults will be automatically propagated to long-running clients if they are updated.
-If the administrator updates path defaults using the following:
-
-```shell
-$ bin/alluxio fsadmin pathConf add --property alluxio.user.file.writetype.default=THROUGH /tmp
-```
-
-All write operations that occur on a path with the prefix `/tmp` prefix will use
-the `THROUGH` write type by default.
-
 ## Configuration Sources
 
 Alluxio properties can be configured from multiple sources.
@@ -85,16 +54,16 @@ To check the value of a specific configuration property and the source of its va
 users can run the following command:
 
 ```shell
-$ ./bin/alluxio getConf alluxio.worker.rpc.port
+$ ./bin/alluxio conf get alluxio.worker.rpc.port
 29998
-$ ./bin/alluxio getConf --source alluxio.worker.rpc.port
+$ ./bin/alluxio conf get --source alluxio.worker.rpc.port
 DEFAULT
 ```
 
 To list all of the configuration properties with sources:
 
 ```shell
-$ ./bin/alluxio getConf --source
+$ ./bin/alluxio conf get --source
 alluxio.conf.dir=/Users/bob/alluxio/conf (SYSTEM_PROPERTY)
 alluxio.debug=false (DEFAULT)
 ...
@@ -102,12 +71,12 @@ alluxio.debug=false (DEFAULT)
 
 Users can also specify the `--master` option to list all
 of the cluster-wide configuration properties served by the masters.
-Note that with the `--master` option, `getConf` will query the
+Note that with the `--master` option, `bin/alluxio conf get` will query the
 master which requires the master process to be running.
 Otherwise, without `--master` option, this command only checks the local configuration.
 
 ```shell
-$ ./bin/alluxio getConf --master --source
+$ ./bin/alluxio conf get --master --source
 alluxio.conf.dir=/Users/bob/alluxio/conf (SYSTEM_PROPERTY)
 alluxio.debug=false (DEFAULT)
 ...
@@ -126,16 +95,16 @@ by other applications running in the same environment.
 ## Server Configuration Checker
 
 The server-side configuration checker helps discover configuration errors and warnings.
-Suspected configuration errors are reported through the web UI, `fsadmin doctor` CLI, and master logs.
+Suspected configuration errors are reported through the web UI, `info doctor` CLI, and master logs.
 
 The web UI shows the result of the server configuration check.
 
 ![webUi]({{ '/img/screenshot_configuration_checker_webui.png' | relativize_url }})
 
-Users can also run the `fsadmin doctor` command to get the same results.
+Users can also run the `info doctor` command to get the same results.
 
 ```shell
-$ ./bin/alluxio fsadmin doctor configuration
+$ ./bin/alluxio info doctor configuration
 ```
 
 Configuration warnings can also be found in the master logs.

--- a/docs/en/operation/Logging.md
+++ b/docs/en/operation/Logging.md
@@ -122,19 +122,19 @@ For example, the following command sets the logger level of the class `alluxio.u
 `DEBUG` on master as well as a worker at `192.168.100.100:30000`:
 
 ```shell
-$ ./bin/alluxio logLevel --logName=alluxio.underfs.hdfs.HdfsUnderFileSystem \
+$ ./bin/alluxio conf log --name=alluxio.underfs.hdfs.HdfsUnderFileSystem \
   --target=master,192.168.100.100:30000 --level=DEBUG
 ```
 
 And the following command returns the log level of the class `alluxio.underfs.hdfs.HdfsUnderFileSystem` among all the workers:
 ```shell
-$ ./bin/alluxio logLevel --logName=alluxio.underfs.hdfs.HdfsUnderFileSystem --target=workers
+$ ./bin/alluxio conf log --name=alluxio.underfs.hdfs.HdfsUnderFileSystem --target=workers
 ```
 
 You can also update the log level at a package level.
 For example, you can update the log level of all classes in `alluxio.underfs` package with the following command:
 ```shell
-$ ./bin/alluxio logLevel --logName=alluxio.underfs --target=workers --level=DEBUG
+$ ./bin/alluxio conf log --name=alluxio.underfs --target=workers --level=DEBUG
 ```
 This works because log4j loggers will inherit the log level from their ancestors.
 In this case `alluxio.underfs.hdfs.HdfsUnderFileSystem` inherits the log level if it is set on `alluxio.underfs`
@@ -145,12 +145,12 @@ in a running cluster, and turn it off when you are done.
 
 ```shell
 # Turn on Alluxio debug logging and start debugging
-$ ./bin/alluxio logLevel --logName=alluxio --level=DEBUG
+$ ./bin/alluxio conf log --name=alluxio --level=DEBUG
 ```
 
 ```shell
 # Turn off Alluxio debug logging when you are done
-$ ./bin/alluxio logLevel --logName=alluxio --level=INFO
+$ ./bin/alluxio conf log --name=alluxio --level=INFO
 ```
 
 Finally, if your Alluxio deployment uses custom web ports (e.g. `alluxio.master.web.port` is different from 19999, or
@@ -158,12 +158,12 @@ Finally, if your Alluxio deployment uses custom web ports (e.g. `alluxio.master.
 `role` can be one of `master` or `worker` or `job_master` or `job_worker`.
 For example, if your master running on `10.10.10.10` has `alluxio.master.web.port=2181` configured, you would use:
 ```shell
-$ ./bin/alluxio logLevel --logName=alluxio --target=10.10.10.10:2181:master --level=DEBUG
+$ ./bin/alluxio conf log --name=alluxio --target=10.10.10.10:2181:master --level=DEBUG
 ```
 
 If your worker is running on `127.0.0.1` with `alluxio.worker.web.port=25252` configured, you would use:
 ```shell
-$ ./bin/alluxio logLevel --logName=alluxio --target=127.0.0.1:25252:worker --level=DEBUG
+$ ./bin/alluxio conf log --name=alluxio --target=127.0.0.1:25252:worker --level=DEBUG
 ```
 
 ## Enabling Advanced Logging

--- a/docs/en/reference/Troubleshooting.md
+++ b/docs/en/reference/Troubleshooting.md
@@ -59,7 +59,7 @@ export ALLUXIO_USER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,sus
 export ALLUXIO_USER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:60000"
 ```
 
-After setting this parameter, you can add the `-debug` flag to start a debug server such as `bin/alluxio fs -debug ls /`.
+After setting this parameter, you can add the `-debug` flag to start a debug server such as `bin/alluxio fs ls / --attach-debug`.
 
 After completing this setup, learn how [to attach](#to-attach).
 
@@ -91,10 +91,10 @@ Then all the tarballs will be bundled into the final tarball, which contains all
 You should ALWAYS CHECK what is in the tarball and REMOVE the sensitive information from the tarball before sharing it with someone!
 
 ### Collect Alluxio cluster information
-`collectAlluxioInfo` will run a set of Alluxio commands that collect information about the Alluxio cluster, like `bin/alluxio fsadmin report` etc.
+`collectAlluxioInfo` will run a set of Alluxio commands that collect information about the Alluxio cluster, like `bin/alluxio info report` etc.
 When the Alluxio cluster is not running, this command will fail to collect some information.
-This sub-command will run both `alluxio getConf` which collects local configuration properties, 
-and `alluxio getConf --master --source` which prints configuration properties that are received from the master.
+This sub-command will run both `bin/alluxio conf get` which collects local configuration properties,
+and `bin/alluxio conf get --master --source` which prints configuration properties that are received from the master.
 Both of them mask credential properties. The difference is the latter command fails if the Alluxio cluster is not up. 
 
 ### Collect Alluxio configuration files
@@ -140,19 +140,39 @@ like `-Daws.access.key=XXX`, DO NOT share the collected tarball with anybody unl
 The `collectInfo` command has the below options.
 
 ```shell
-$ bin/alluxio collectInfo 
-    [--max-threads <threadNum>] 
-    [--local] 
-    [--help]
-    [--additional-logs <filename-prefixes>] 
-    [--exclude-logs <filename-prefixes>] 
-    [--include-logs <filename-prefixes>] 
-    [--start-time <datetime>] 
-    [--end-time <datetime>]
-    COMMAND <outputPath>
+Collects information such as logs, config, metrics, and more from the running Alluxio cluster and bundle into a single tarball
+[command] must be one of the following values:
+  all      runs all the commands below
+  cluster: runs a set of Alluxio commands to collect information about the Alluxio cluster
+  conf:    collects the configuration files under ${ALLUXIO_HOME}/config/
+  env:     runs a set of linux commands to collect information about the cluster
+  jvm:     collects jstack from the JVMs
+  log:     collects the log files under ${ALLUXIO_HOME}/logs/
+  metrics: collects Alluxio system metrics
+
+WARNING: This command MAY bundle credentials. To understand the risks refer to the docs here.
+https://docs.alluxio.io/os/user/edge/en/operation/Troubleshooting.html#collect-alluxio-cluster-information
+
+Usage:
+  bin/alluxio info collect [command] [flags]
+
+Flags:
+      --additional-logs strings   Additional file name prefixes from ${ALLUXIO_HOME}/logs to include in the tarball, inclusive of the default log files
+      --attach-debug              True to attach debug opts specified by $ALLUXIO_USER_ATTACH_OPTS
+      --end-time string           Logs that do not contain entries before this time will be ignored, format must be like 2006-01-02T15:04:05
+      --exclude-logs strings      File name prefixes from ${ALLUXIO_HOME}/logs to exclude; this is evaluated after adding files from --additional-logs
+      --exclude-worker-metrics    True to skip worker metrics collection
+  -h, --help                      help for collect
+      --include-logs strings      File name prefixes from ${ALLUXIO_HOME}/logs to include in the tarball, ignoring the default log files; cannot be used with --exclude-logs or --additional-logs
+  -D, --java-opts strings         Alluxio properties to apply, ex. -Dkey=value
+      --local                     True to only collect information from the local machine
+      --max-threads int           Parallelism of the command; use a smaller value to limit network I/O when transferring tarballs (default 1)
+      --output-dir string         Output directory to write collect info tarball to
+      --start-time string         Logs that do not contain entries after this time will be ignored, format must be like 2006-01-02T15:04:05
+
 ```
 
-`<outputPath>` is the directory you want the final tarball to be written into.
+`--output-dir` is a required flag, specifying the directory to write the final tarball to.
 
 Options:
 1. `--max-threads threadNum` option configures how many threads to use for concurrently collecting information and transmitting tarballs.


### PR DESCRIPTION
besides the User-CLI.md doc, update other doc files that refer to `bin/alluxio` commands
- remove docs on path config
- remove starting/stopping job master/worker from contributor docs