### PR TITLE
Make fuse max reader concurrency configurable

### DIFF
--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6209,8 +6209,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey FUSE_MAX_READER_CONCURRENCY =
       intBuilder(Name.FUSE_MAX_READER_CONCURRENCY)
           .setDefaultValue(128)
-          .setDescription("The max reader concurrency in FUSE. This controllers the max"
-                  + " number of locks that can be acquired.")
+          .setDescription("Max number of concurrent readers per file in FUSE")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.ALL)
           .build();
@@ -8266,7 +8265,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String FUSE_FS_NAME = "alluxio.fuse.fs.name";
     public static final String FUSE_LOGGING_THRESHOLD = "alluxio.fuse.logging.threshold";
     public static final String FUSE_MAX_READER_CONCURRENCY =
-        "alluxio.fuse.reader.concurrency";
+        "alluxio.max.fuse.reader.concurrency";
     public static final String FUSE_MOUNT_ALLUXIO_PATH =
         "alluxio.fuse.mount.alluxio.path";
     public static final String FUSE_MOUNT_OPTIONS =

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6206,6 +6206,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey FUSE_MAX_READER_CONCURRENCY =
+      intBuilder(Name.FUSE_MAX_READER_CONCURRENCY)
+          .setDefaultValue(128)
+          .setDescription("The max reader concurrency in FUSE. This controllers the max"
+                  + " number of locks that can be acquired.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.ALL)
+          .build();
   public static final PropertyKey FUSE_MOUNT_ALLUXIO_PATH =
       stringBuilder(Name.FUSE_MOUNT_ALLUXIO_PATH)
           .setAlias(Name.WORKER_FUSE_MOUNT_ALLUXIO_PATH)
@@ -8257,6 +8265,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String FUSE_DEBUG_ENABLED = "alluxio.fuse.debug.enabled";
     public static final String FUSE_FS_NAME = "alluxio.fuse.fs.name";
     public static final String FUSE_LOGGING_THRESHOLD = "alluxio.fuse.logging.threshold";
+    public static final String FUSE_MAX_READER_CONCURRENCY =
+        "alluxio.fuse.reader.concurrency";
     public static final String FUSE_MOUNT_ALLUXIO_PATH =
         "alluxio.fuse.mount.alluxio.path";
     public static final String FUSE_MOUNT_OPTIONS =

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/lock/FuseReadWriteLockManager.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/lock/FuseReadWriteLockManager.java
@@ -17,6 +17,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import alluxio.Constants;
 import alluxio.concurrent.ClientRWLock;
 import alluxio.concurrent.LockMode;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.runtime.CancelledRuntimeException;
 import alluxio.exception.runtime.DeadlineExceededRuntimeException;
 import alluxio.resource.CloseableResource;
@@ -34,7 +36,8 @@ import java.util.concurrent.locks.Lock;
 public class FuseReadWriteLockManager {
   private static final long TRY_LOCK_TIMEOUT = 20 * Constants.SECOND_MS;
   // Maximum readers allowed for each file
-  private static final int MAX_READER_CONCURRENCY = 64;
+  private static final int MAX_READER_CONCURRENCY = Configuration.global()
+      .getInt(PropertyKey.FUSE_MAX_READER_CONCURRENCY);
 
   private final LoadingCache<String, ClientRWLock> mLockCache
       = CacheBuilder.newBuilder().weakValues()


### PR DESCRIPTION
Make fuse max reader concurrency configurable. The default value was 64 and it was unchangeable.