### PR TITLE
Check for more results when the filtered result is empty

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/job/FileIterable.java
+++ b/core/server/master/src/main/java/alluxio/master/job/FileIterable.java
@@ -165,6 +165,7 @@ public class FileIterable implements Iterable<FileInfo> {
           &&  (mFiles = fileInfos.stream().filter(mFilter).collect(Collectors.toList())).isEmpty()
           && !fileInfos.isEmpty()) {
         mStartAfter = fileInfos.get(fileInfos.size() - 1).getPath();
+        mListOptions.setDisableAreDescendantsLoadedCheck(true);
       }
       if (mFiles.size() > 0) {
         mStartAfter = mFiles

--- a/core/server/master/src/test/java/alluxio/master/file/scheduler/LoadTestUtils.java
+++ b/core/server/master/src/test/java/alluxio/master/file/scheduler/LoadTestUtils.java
@@ -89,12 +89,13 @@ public final class LoadTestUtils {
     Random random = new Random();
     FileInfo info = new FileInfo();
     String ufs = CommonUtils.randomAlphaNumString(6);
+    String filePath = CommonUtils.randomAlphaNumString(6);
     long blockSize = Math.abs(random.nextLong() % blockSizeLimit);
     List<Long> blockIds = LongStream.range(0, blockCount)
         .map(i -> random.nextLong())
         .boxed()
         .collect(ImmutableList.toImmutableList());
-    info.setUfsPath(ufs)
+    info.setUfsPath(ufs).setPath(filePath)
         .setBlockSizeBytes(blockSize)
         .setLength(blockSizeLimit * blockCount)
         .setBlockIds(blockIds)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Check for more results when the filtered result is null when loading data.

### Why are the changes needed?
Fix #18043.

