### PR TITLE
[DOCFIX] Update bin/alluxio usage in ufs/compute

### DIFF
--- a/docs/en/compute/Hadoop-MapReduce.md
+++ b/docs/en/compute/Hadoop-MapReduce.md
@@ -76,14 +76,14 @@ Depending on the Hadoop version, you may need to replace `./bin` with `./sbin`.
 Start Alluxio locally:
 
 ```shell
-$ ./bin/alluxio-start.sh local SudoMount
+$ ./bin/alluxio process start local
 ```
 
 You can add a sample file to Alluxio to run MapReduce wordcount on. From your Alluxio directory:
 
 ```shell
 $ ./bin/alluxio fs mkdir /wordcount
-$ ./bin/alluxio fs copyFromLocal LICENSE /wordcount/input.txt
+$ ./bin/alluxio fs cp file://LICENSE /wordcount/input.txt
 ```
 
 This command will copy the `LICENSE` file into the Alluxio namespace with the path

--- a/docs/en/compute/Hive.md
+++ b/docs/en/compute/Hive.md
@@ -54,7 +54,7 @@ Unzip this file and upload the file `u.user` into `ml-100k/` on Alluxio:
 
 ```shell
 $ ./bin/alluxio fs mkdir /ml-100k
-$ ./bin/alluxio fs copyFromLocal /path/to/ml-100k/u.user alluxio://master_hostname:port/ml-100k
+$ ./bin/alluxio fs cp file:///path/to/ml-100k/u.user alluxio://master_hostname:port/ml-100k
 ```
 
 View Alluxio WebUI at `http://master_hostname:19999` and you can see the directory and file Hive

--- a/docs/en/compute/Presto.md
+++ b/docs/en/compute/Presto.md
@@ -80,7 +80,7 @@ Unzip this file and upload the file `u.user` into `/ml-100k/` in Alluxio:
 
 ```shell
 $ ./bin/alluxio fs mkdir /ml-100k
-$ ./bin/alluxio fs copyFromLocal /path/to/ml-100k/u.user alluxio:///ml-100k
+$ ./bin/alluxio fs cp file:///path/to/ml-100k/u.user alluxio:///ml-100k
 ```
 
 Create an external Hive table pointing to the Alluxio file location.

--- a/docs/en/compute/Spark.md
+++ b/docs/en/compute/Spark.md
@@ -62,7 +62,7 @@ Copy local data to the Alluxio file system. Put the `LICENSE` file into Alluxio,
 assuming you are in the Alluxio installation directory:
 
 ```shell
-$ ./bin/alluxio fs copyFromLocal LICENSE /Input
+$ ./bin/alluxio fs cp file://LICENSE /Input
 ```
 
 Run the following commands from `spark-shell`, assuming the Alluxio Master is

--- a/docs/en/compute/Tensorflow.md
+++ b/docs/en/compute/Tensorflow.md
@@ -69,7 +69,7 @@ If the data is not in a remote data storage, you can copy it to Alluxio namespac
 ```shell
 $ wget http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz
 $ ./bin/alluxio fs mkdir /training-data/imagenet 
-$ ./bin/alluxio fs copyFromLocal inception-2015-12-05.tgz /training-data/imagenet 
+$ ./bin/alluxio fs cp file://inception-2015-12-05.tgz /training-data/imagenet
 ```
 
 Suppose the ImageNet's data is stored in an S3 bucket `s3://alluxio-tensorflow-imagenet/`,

--- a/docs/en/compute/Trino.md
+++ b/docs/en/compute/Trino.md
@@ -35,7 +35,7 @@ This guide is tested with `Trino-352`.
 
 Trino gets the database and table metadata information (including file system locations) from
 the Hive Metastore, via Trino's Hive connector.
-Here is a example Trino configuration file `${Trino_HOME}/etc/catalog/hive.properties`,
+Here is a example Trino configuration file `${TRINO_HOME}/etc/catalog/hive.properties`,
 for a catalog using the Hive connector, where the metastore is located on `localhost`.
 
 ```properties
@@ -48,12 +48,12 @@ hive.metastore.uri=thrift://localhost:9083
 In order for Trino to be able to communicate with the Alluxio servers, the Alluxio client
 jar must be in the classpath of Trino servers.
 Put the Alluxio client jar `{{site.ALLUXIO_CLIENT_JAR_PATH}}` into the directory
-`${Trino_HOME}/plugin/hive-hadoop2/`
+`${TRINO_HOME}/plugin/hive-hadoop2/`
 (this directory may differ across versions) on all Trino servers. Restart the Trino workers and
 coordinator:
 
 ```shell
-$ ${Trino_HOME}/bin/launcher restart
+$ ${TRINO_HOME}/bin/launcher restart
 ```
 
 After completing the basic configuration,
@@ -72,7 +72,7 @@ Unzip this file and upload the file `u.user` into `/ml-100k/` in Alluxio:
 
 ```shell
 $ ./bin/alluxio fs mkdir /ml-100k
-$ ./bin/alluxio fs copyFromLocal /path/to/ml-100k/u.user alluxio:///ml-100k
+$ ./bin/alluxio fs cp file:///path/to/ml-100k/u.user alluxio:///ml-100k
 ```
 
 Create an external Hive table pointing to the Alluxio file location.
@@ -104,10 +104,10 @@ $ ${HIVE_HOME}/bin/hive --service metastore
 ### Start Trino server
 
 Start your Trino server. Trino server runs on port `8080` by default (configurable with
-`http-server.http.port` in `${Trino_HOME}/etc/config.properties` ):
+`http-server.http.port` in `${TRINO_HOME}/etc/config.properties` ):
 
 ```shell
-$ ${Trino_HOME}/bin/launcher run
+$ ${TRINO_HOME}/bin/launcher run
 ```
 
 ### Query tables using Trino
@@ -140,7 +140,7 @@ $ -Xbootclasspath/a:<path-to-alluxio-conf>
 
 Alternatively, add Alluxio properties to the Hadoop configuration files
 (`core-site.xml`, `hdfs-site.xml`), and use the Trino property `hive.config.resources` in the
-file `${Trino_HOME}/etc/catalog/hive.properties` to point to the Hadoop resource locations for
+file `${TRINO_HOME}/etc/catalog/hive.properties` to point to the Hadoop resource locations for
 every Trino worker. 
 
 ```properties

--- a/docs/en/ufs/CephFS.md
+++ b/docs/en/ufs/CephFS.md
@@ -72,6 +72,12 @@ $ cp conf/alluxio-site.properties.template conf/alluxio-site.properties
 $ cp conf/core-site.xml.template conf/core-site.xml
 ```
 
+Set the following property to define CephFS as the root mount
+
+```properties
+alluxio.dora.client.ufs.root=cephfs://mon1\;mon2\;mon3/
+```
+
 {% navtabs Setup %}
 {% navtab cephfs %}
 
@@ -148,20 +154,15 @@ Modify `conf/core-site.xml` to include:
 
 Once you have configured Alluxio to CephFS, try [running Alluxio locally]({{ '/en/ufs/Storage-Overview.html#running-alluxio-locally' | relativize_url}}) to see that everything works.
 
-{% navtabs Test %}
-{% navtab cephfs %}
-
-Issue the following command to use the ufs cephfs:
-
 ```shell
-$ ./bin/alluxio fs mkdir /mnt/cephfs
-$ ./bin/alluxio fs mount /mnt/cephfs cephfs://mon1\;mon2\;mon3/
+$ ./bin/alluxio init format
+$ ./bin/alluxio process start local
 ```
 
 Run a simple example program:
 
 ```shell
-$ ./bin/alluxio runTests --path cephfs://mon1\;mon2\;mon3/
+$ ./bin/alluxio exec basicIOTest
 ```
 
 Visit your cephfs to verify the files and directories created by Alluxio exist. You should see files named like:
@@ -176,38 +177,6 @@ In Alluxio, you can visit the nested directory in the Alluxio. Alluxio's [Comman
 ```
 /mnt/cephfs/default_tests_files/Basic_CACHE_THROUGH
 ```
-
-{% endnavtab %}
-{% navtab cephfs-hadoop %}
-
-Issue the following command to use the ufs cephfs-hadoop:
-
-```shell
-$ ./bin/alluxio fs mkdir /mnt/cephfs-hadoop
-$ ./bin/alluxio fs mount /mnt/cephfs-hadoop cephfs://mon1\;mon2\;mon3/
-```
-
-Run a simple example program:
-
-```shell
-$ ./bin/alluxio runTests --path cephfs://mon1\;mon2\;mon3/
-```
-
-Visit your cephfs-hadoop to verify the files and directories created by Alluxio exist. You should see files named like:
-
-```
-${cephfs-hadoop-dir}/default_tests_files/Basic_CACHE_THROUGH
-```
-In cephfs, you can visit cephfs with ceph-fuse or mount by POSIX APIs. [Mounting CephFS](https://docs.ceph.com/en/latest/cephfs/#mounting-cephfs){:target="_blank"}
-
-In Alluxio, you can visit the nested directory in the Alluxio. Alluxio's [Command Line Interface]({{ '/en/operation/User-CLI.html' | relativize_url }}) can be used for this purpose.
-
-```
-/mnt/cephfs-hadoop/default_tests_files/Basic_CACHE_THROUGH
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 ## Contributed by the Alluxio Community
 

--- a/docs/en/ufs/Storage-Overview.md
+++ b/docs/en/ufs/Storage-Overview.md
@@ -135,8 +135,8 @@ For the purposes of this guide, the following are placeholders.
 Once you have configured Alluxio to your desired under storage system, start up Alluxio locally to see that everything works.
 
 ```shell
-$ ./bin/alluxio format
-$ ./bin/alluxio-start.sh local
+$ ./bin/alluxio init format
+$ ./bin/alluxio process start local
 ```
 
 This should start an Alluxio master and an Alluxio worker. You can see the master UI at
@@ -145,7 +145,7 @@ This should start an Alluxio master and an Alluxio worker. You can see the maste
 Run a simple example program:
 
 ```shell
-$ ./bin/alluxio runTests
+$ ./bin/alluxio exec basicIOTest
 ```
 
 Visit your container `<CONTAINER>/<DIRECTORY>` or bucket `<BUCKET>/<DIRECTORY>` to verify the files and directories created by Alluxio exist. If there are no errors, then you have successfully configured your storage system!
@@ -153,5 +153,5 @@ Visit your container `<CONTAINER>/<DIRECTORY>` or bucket `<BUCKET>/<DIRECTORY>` 
 To stop Alluxio, you can run:
 
 ``` shell
-$ ./bin/alluxio-stop.sh local
+$ ./bin/alluxio process stop local
 ```


### PR DESCRIPTION
update usages of bin/alluxio, bin/alluxio-start.sh and bin/alluxio-stop.sh to their new counterparts

simplify section of CephFS.md and remove sections related to mounting. the ufs must be configured as the root mount via alluxio-site.properties.