### PR TITLE
Support accessing OSS with proxy

### DIFF
--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1411,6 +1411,29 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_OSS_PROTOCOL =
+      stringBuilder(Name.UNDERFS_OSS_PROTOCOL)
+          .setAlias("alluxio.underfs.oss.protocol")
+          .setDefaultValue("http")
+          .setDescription("The protocol of OSS endpoint.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_PROXY_HOST =
+      stringBuilder(Name.UNDERFS_OSS_PROXY_HOST)
+          .setAlias("alluxio.underfs.oss.proxy.host")
+          .setDescription("The proxy host of OSS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_PROXY_PORT =
+      intBuilder(Name.UNDERFS_OSS_PROXY_PORT)
+          .setAlias("alluxio.underfs.oss.proxy.port")
+          .setDefaultValue(0)
+          .setDescription("The proxy port of OSS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_OSS_STS_ECS_METADATA_SERVICE_ENDPOINT =
       stringBuilder(Name.UNDERFS_OSS_STS_ECS_METADATA_SERVICE_ENDPOINT)
           .setAlias("alluxio.underfs.oss.sts.ecs.metadata.service.endpoint")
@@ -7191,6 +7214,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_OSS_SOCKET_TIMEOUT = "alluxio.underfs.oss.socket.timeout";
     public static final String UNDERFS_OSS_ECS_RAM_ROLE = "alluxio.underfs.oss.ecs.ram.role";
     public static final String UNDERFS_OSS_RETRY_MAX = "alluxio.underfs.oss.retry.max";
+    public static final String UNDERFS_OSS_PROTOCOL = "alluxio.underfs.oss.protocol";
+    public static final String UNDERFS_OSS_PROXY_HOST = "alluxio.underfs.oss.proxy.host";
+    public static final String UNDERFS_OSS_PROXY_PORT = "alluxio.underfs.oss.proxy.port";
     public static final String UNDERFS_OSS_STS_ECS_METADATA_SERVICE_ENDPOINT =
         "alluxio.underfs.oss.sts.ecs.metadata.service.endpoint";
     public static final String UNDERFS_OSS_STS_ENABLED = "alluxio.underfs.oss.sts.enabled";

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1415,14 +1415,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       stringBuilder(Name.UNDERFS_OSS_PROTOCOL)
           .setAlias("alluxio.underfs.oss.protocol")
           .setDefaultValue("http")
-          .setDescription("The protocol of OSS endpoint.")
+          .setDescription("The protocol for OSS endpoint, by default http.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey UNDERFS_OSS_PROXY_HOST =
       stringBuilder(Name.UNDERFS_OSS_PROXY_HOST)
           .setAlias("alluxio.underfs.oss.proxy.host")
-          .setDescription("The proxy host of OSS.")
+          .setDescription("The proxy host address for OSS connection, if any.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
@@ -1430,7 +1430,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       intBuilder(Name.UNDERFS_OSS_PROXY_PORT)
           .setAlias("alluxio.underfs.oss.proxy.port")
           .setDefaultValue(0)
-          .setDescription("The proxy port of OSS.")
+          .setDescription("The proxy port for OSS connection, if any.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();

--- a/dora/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/dora/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -383,9 +383,12 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
     ossClientConf.setMaxConnections(alluxioConf.getInt(PropertyKey.UNDERFS_OSS_CONNECT_MAX));
     ossClientConf.setMaxErrorRetry(alluxioConf.getInt(PropertyKey.UNDERFS_OSS_RETRY_MAX));
     if (isProxyEnabled(alluxioConf)) {
-      ossClientConf.setProxyHost(getProxyHost(alluxioConf));
-      ossClientConf.setProxyPort(getProxyPort(alluxioConf));
+      String proxyHost = getProxyHost(alluxioConf);
+      int proxyPort = getProxyPort(alluxioConf);
+      ossClientConf.setProxyHost(proxyHost);
+      ossClientConf.setProxyPort(proxyPort);
       ossClientConf.setProtocol(getProtocol());
+      LOG.info("the proxy for OSS is enabled, the proxy endpoint is: {}:{}", proxyHost, proxyPort);
     }
     return ossClientConf;
   }
@@ -400,7 +403,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
       return proxyPort;
     } else {
       try {
-        return getProxyPortProperty();
+        return getProxyPortFromSystemProperty();
       } catch (NumberFormatException e) {
         return proxyPort;
       }
@@ -412,7 +415,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
     if (proxyHost != null) {
       return proxyHost;
     } else {
-      return getProxyHostProperty();
+      return getProxyHostFromSystemProperty();
     }
   }
 
@@ -428,7 +431,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
    * returns value of http.proxyPort.  Defaults to {@link this.proxyPort}
    * if the system property is not set with a valid port number.
    */
-  private static int getProxyPortProperty() {
+  private static int getProxyPortFromSystemProperty() {
     return getProtocol() == Protocol.HTTPS
         ? Integer.parseInt(getSystemProperty("https.proxyPort"))
         : Integer.parseInt(getSystemProperty("http.proxyPort"));
@@ -440,7 +443,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
    * the value of the system property https.proxyHost, otherwise
    * returns value of http.proxyHost.
    */
-  private static String getProxyHostProperty() {
+  private static String getProxyHostFromSystemProperty() {
     return getProtocol() == Protocol.HTTPS
         ? getSystemProperty("https.proxyHost")
         : getSystemProperty("http.proxyHost");

--- a/dora/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/dora/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.PositionReader;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.retry.RetryPolicy;
 import alluxio.underfs.ObjectUnderFileSystem;
@@ -29,6 +30,7 @@ import com.aliyun.oss.ClientBuilderConfiguration;
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSClientBuilder;
 import com.aliyun.oss.ServiceException;
+import com.aliyun.oss.common.comm.Protocol;
 import com.aliyun.oss.model.AbortMultipartUploadRequest;
 import com.aliyun.oss.model.DeleteObjectsRequest;
 import com.aliyun.oss.model.DeleteObjectsResult;
@@ -380,7 +382,75 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
     ossClientConf.setConnectionTTL(alluxioConf.getMs(PropertyKey.UNDERFS_OSS_CONNECT_TTL));
     ossClientConf.setMaxConnections(alluxioConf.getInt(PropertyKey.UNDERFS_OSS_CONNECT_MAX));
     ossClientConf.setMaxErrorRetry(alluxioConf.getInt(PropertyKey.UNDERFS_OSS_RETRY_MAX));
+    if (isProxyEnabled(alluxioConf)) {
+      ossClientConf.setProxyHost(getProxyHost(alluxioConf));
+      ossClientConf.setProxyPort(getProxyPort(alluxioConf));
+      ossClientConf.setProtocol(getProtocol());
+    }
     return ossClientConf;
+  }
+
+  private static boolean isProxyEnabled(AlluxioConfiguration alluxioConf) {
+    return getProxyHost(alluxioConf) != null && getProxyPort(alluxioConf) > 0;
+  }
+
+  private static int getProxyPort(AlluxioConfiguration alluxioConf) {
+    int proxyPort = alluxioConf.getInt(PropertyKey.UNDERFS_OSS_PROXY_PORT);
+    if (proxyPort >= 0) {
+      return proxyPort;
+    } else {
+      try {
+        return getProxyPortProperty();
+      } catch (NumberFormatException e) {
+        return proxyPort;
+      }
+    }
+  }
+
+  private static String getProxyHost(AlluxioConfiguration alluxioConf) {
+    String proxyHost = alluxioConf.getString(PropertyKey.UNDERFS_OSS_PROXY_HOST);
+    if (proxyHost != null) {
+      return proxyHost;
+    } else {
+      return getProxyHostProperty();
+    }
+  }
+
+  private static Protocol getProtocol() {
+    String protocol = Configuration.getString(PropertyKey.UNDERFS_OSS_PROTOCOL);
+    return protocol.equals(Protocol.HTTPS.toString()) ? Protocol.HTTPS : Protocol.HTTP;
+  }
+
+  /**
+   * Returns the Java system property for proxy port depending on
+   * {@link #getProtocol()}: i.e. if protocol is https, returns
+   * the value of the system property https.proxyPort, otherwise
+   * returns value of http.proxyPort.  Defaults to {@link this.proxyPort}
+   * if the system property is not set with a valid port number.
+   */
+  private static int getProxyPortProperty() {
+    return getProtocol() == Protocol.HTTPS
+        ? Integer.parseInt(getSystemProperty("https.proxyPort"))
+        : Integer.parseInt(getSystemProperty("http.proxyPort"));
+  }
+
+  /**
+   * Returns the Java system property for proxy host depending on
+   * {@link #getProtocol()}: i.e. if protocol is https, returns
+   * the value of the system property https.proxyHost, otherwise
+   * returns value of http.proxyHost.
+   */
+  private static String getProxyHostProperty() {
+    return getProtocol() == Protocol.HTTPS
+        ? getSystemProperty("https.proxyHost")
+        : getSystemProperty("http.proxyHost");
+  }
+
+  /**
+   * Returns the value for the given system property.
+   */
+  private static String getSystemProperty(String property) {
+    return System.getProperty(property);
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support accessing OSS through proxy by configuring alluxio properties or system properties.

### Why are the changes needed?

When accessing OSS through a proxy, the OSS client cannot recognize the proxy configuration in system property and environment variables. So it has to proactively set proxy-related configurations in the configuration.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
