### PR TITLE
Extract path resolution in DoraCacheFS into static utility

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -518,6 +518,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
    * If local file system is used, please add "file://" scheme before the path.
    *
    * @param alluxioPath Alluxio based path
+   * @param ufsRootPath the UFS root path to resolve against
    * @return UfsBaseFileSystem based full path
    */
   public static AlluxioURI convertAlluxioPathToUfsPath(
@@ -548,6 +549,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
    * This is the opposite operation to {@link #convertAlluxioPathToUfsPath(AlluxioURI, AlluxioURI)}.
    *
    * @param ufsPath UfsBaseFileSystem based full path
+   * @param ufsRootPath the UFS root path to resolve against
    * @return an Alluxio path
    */
   public static AlluxioURI convertUfsPathToAlluxioPath(AlluxioURI ufsPath, AlluxioURI ufsRootPath) {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -53,6 +53,7 @@ import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import com.codahale.metrics.Counter;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -438,13 +439,11 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
    * @return UfsBaseFileSystem based full path
    */
   public AlluxioURI convertToUfsPath(AlluxioURI alluxioPath) {
-    if (mDelegatedFileSystem instanceof UfsBaseFileSystem) {
-      UfsBaseFileSystem under = (UfsBaseFileSystem) mDelegatedFileSystem;
-      AlluxioURI rootUFS = under.getRootUFS();
-      return convertAlluxioPathToUfsPath(alluxioPath, rootUFS);
-    } else {
-      return alluxioPath;
-    }
+    Preconditions.checkArgument(mDelegatedFileSystem instanceof UfsBaseFileSystem,
+        "FileSystem is not UfsBaseFileSystem");
+    UfsBaseFileSystem under = (UfsBaseFileSystem) mDelegatedFileSystem;
+    AlluxioURI rootUFS = under.getRootUFS();
+    return convertAlluxioPathToUfsPath(alluxioPath, rootUFS);
   }
 
   /**
@@ -456,12 +455,10 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
    * @return an Alluxio path
    */
   public AlluxioURI convertToAlluxioPath(AlluxioURI ufsPath) {
-    if (mDelegatedFileSystem instanceof UfsBaseFileSystem) {
-      AlluxioURI rootUfs = ((UfsBaseFileSystem) mDelegatedFileSystem).getRootUFS();
-      return convertUfsPathToAlluxioPath(ufsPath, rootUfs);
-    } else {
-      return ufsPath;
-    }
+    Preconditions.checkArgument(mDelegatedFileSystem instanceof UfsBaseFileSystem,
+        "FileSystem is not UfsBaseFileSystem");
+    AlluxioURI rootUfs = ((UfsBaseFileSystem) mDelegatedFileSystem).getRootUFS();
+    return convertUfsPathToAlluxioPath(ufsPath, rootUfs);
   }
 
   @Override

--- a/dora/core/server/worker/src/main/java/alluxio/worker/s3/S3NettyHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/s3/S3NettyHandler.java
@@ -622,7 +622,7 @@ public class S3NettyHandler {
    */
   public AlluxioURI getUfsPath(AlluxioURI objectPath) throws S3Exception {
     if (mFsClient instanceof DoraCacheFileSystem) {
-      return ((DoraCacheFileSystem) mFsClient).convertAlluxioPathToUFSPath(objectPath);
+      return ((DoraCacheFileSystem) mFsClient).convertToUfsPath(objectPath);
     } else {
       throw new S3Exception(objectPath.toString(), S3ErrorCode.INTERNAL_ERROR);
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?

In this change the path conversion logic is extracted to static utility methods for code reuse (because other classes may use the same path resolution logic). 

The method names are slightly improved, to distinguish the member methods in `DoraCacheFileSystem` (may be inherited) from the static utility methods.