### PR TITLE
Change CosNUnderFileSystemFactory implementation UnderFileSystemFactory

### DIFF
--- a/underfs/cosn/src/main/java/alluxio/underfs/cosn/CosNUnderFileSystemFactory.java
+++ b/underfs/cosn/src/main/java/alluxio/underfs/cosn/CosNUnderFileSystemFactory.java
@@ -17,7 +17,7 @@ import alluxio.CosnUfsConstants;
 import alluxio.conf.PropertyKey;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
-import alluxio.underfs.hdfs.HdfsUnderFileSystemFactory;
+import alluxio.underfs.UnderFileSystemFactory;
 
 import com.google.common.base.Preconditions;
 
@@ -27,7 +27,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * Factory for creating {@link CosnUnderFileSystem}.
  */
 @ThreadSafe
-public class CosNUnderFileSystemFactory extends HdfsUnderFileSystemFactory {
+public class CosNUnderFileSystemFactory implements UnderFileSystemFactory {
 
   @Override
   public UnderFileSystem create(String path, UnderFileSystemConfiguration conf) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Don't have to inherit the HdfsUnderFileSystemFactory CosNUnderFileSystemFactory directly implement UnderFileSystemFactory interface


### Why are the changes needed?

- Possibly to resolve package conflicts, #17024 removed HdfsUnderFileSystemFactory from COSN UFS jar, resulting in inability to use COSN interface
- However, CosNUnderFileSystemFactory inherits from HdfsUnderFileSystemFactory,the ServiceLoader.load method loads CosNUnderFileSystemFactory and first searches for its parent class, so removing HdfsUnderFileSystemFactory directly will result in an error.
```
failed to load jar alluxio-underfs-hadoop-cosn-3.1.0-5.8.5-2.9.3.jar NoClassdDefFoundError :alluxio/underfs/hdfs/HdfsUnderFileSystemFactory
```



