### PR TITLE
Add a test to monitor the distribution of vnode to physical node

### DIFF
--- a/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashProviderTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashProviderTest.java
@@ -20,13 +20,11 @@ import static org.junit.Assert.fail;
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.wire.WorkerNetAddress;
-import alluxio.worker.block.BlockWorker;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashProviderTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashProviderTest.java
@@ -58,15 +58,15 @@ public class ConsistentHashProviderTest {
     ConsistentHashProvider provider = new ConsistentHashProvider(1, WORKER_LIST_TTL_MS);
     List<BlockWorkerInfo> workerList = generateRandomWorkerList(50);
     // set initial state
-    provider.refresh(workerList, 2000);
+    provider.refresh(workerList,  2000);
     NavigableMap<Integer, BlockWorkerInfo> map = provider.getActiveNodesMap();
     Map<BlockWorkerInfo, Long> count = new HashMap<>();
-    long last = 0;
+    long last = Integer.MIN_VALUE;
     for(Map.Entry<Integer, BlockWorkerInfo> entry: map.entrySet()) {
       count.put(entry.getValue(),  count.getOrDefault(entry.getValue(), 0L) + (entry.getKey()- last));
       last = entry.getKey().intValue();
     }
-
+    System.out.println(count.values());
 
     System.out.println(calcSD(count.values()));
   }

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashProviderTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashProviderTest.java
@@ -69,8 +69,9 @@ public class ConsistentHashProviderTest {
     NavigableMap<Integer, BlockWorkerInfo> map = provider.getActiveNodesMap();
     Map<BlockWorkerInfo, Long> count = new HashMap<>();
     long last = Integer.MIN_VALUE;
-    for(Map.Entry<Integer, BlockWorkerInfo> entry: map.entrySet()) {
-      count.put(entry.getValue(),  count.getOrDefault(entry.getValue(), 0L) + (entry.getKey()- last));
+    for (Map.Entry<Integer, BlockWorkerInfo> entry: map.entrySet()) {
+      count.put(entry.getValue(),  count.getOrDefault(entry.getValue(), 0L)
+          + (entry.getKey() - last));
       last = entry.getKey().intValue();
     }
     assertTrue(calcSDoverMean(count.values()) < 0.25);

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashProviderTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashProviderTest.java
@@ -68,10 +68,10 @@ public class ConsistentHashProviderTest {
     }
     System.out.println(count.values());
 
-    System.out.println(calcSD(count.values()));
+    System.out.println(calcSDoverMean(count.values()));
   }
 
-  private double calcSD(Collection<Long> list) {
+  private double calcSDoverMean(Collection<Long> list) {
     long sum = 0L;
     double var = 0;
     for (long num : list) {
@@ -81,7 +81,7 @@ public class ConsistentHashProviderTest {
     for (long num : list) {
       var = var + (num - avg) * (num - avg);
     }
-    return Math.sqrt(var / list.size());
+    return Math.sqrt(var / list.size()) / avg;
   }
 
   @Test

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashProviderTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashProviderTest.java
@@ -54,7 +54,16 @@ public class ConsistentHashProviderTest {
   }
 
   @Test
-  public void initializeVirtualNode() {
+  /**
+   * This test calculates the standard deviation over mean on the collection of
+   * virtual nodes assigned to physical nodes. It arbitrarily bounds it at 0.25,
+   * but ideally this number should get smaller over time as we improve hashing algorithm
+   * and use better ways to assign virtual nodes to physical nodes.
+   *
+   * This uses 2000 virtual nodes and 50 physical nodes, if these parameters change,
+   * the bound is likely going to change.
+   */
+  public void virtualNodeDistribution() {
     ConsistentHashProvider provider = new ConsistentHashProvider(1, WORKER_LIST_TTL_MS);
     List<BlockWorkerInfo> workerList = generateRandomWorkerList(50);
     // set initial state
@@ -66,9 +75,7 @@ public class ConsistentHashProviderTest {
       count.put(entry.getValue(),  count.getOrDefault(entry.getValue(), 0L) + (entry.getKey()- last));
       last = entry.getKey().intValue();
     }
-    System.out.println(count.values());
-
-    System.out.println(calcSDoverMean(count.values()));
+    assertTrue(calcSDoverMean(count.values()) < 0.25);
   }
 
   private double calcSDoverMean(Collection<Long> list) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a test so we can monitor the vnode distribution is not too uneven. 

This test calculates the standard deviation over mean on the collection of virtual nodes assigned to physical nodes. It arbitrarily bounds it at 0.25, but ideally this number should get smaller over time as we improve hashing algorithm
and use better ways to assign virtual nodes to physical nodes.


### Why are the changes needed?

We may change hashing algorithm and virtual node assignment in the future, this will provide guidance and catch errors. 

### Does this PR introduce any user facing changes?
No. 
