### PR TITLE
Add throughput distribution and coarse datapoints for StressWorkerBench

### DIFF
--- a/dora/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
+++ b/dora/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
@@ -125,7 +125,7 @@ public final class StressBenchDefinition
   @Override
   public String runTask(StressBenchConfig config, ArrayList<String> args,
       RunTaskContext runTaskContext) throws Exception {
-    List<String> command = new ArrayList<>(3 + config.getArgs().size());
+    List<String> command = new ArrayList<>(5 + config.getArgs().size());
     command.add(Configuration.get(PropertyKey.HOME) + "/bin/alluxio");
     command.add("exec");
     command.add("class");

--- a/dora/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
+++ b/dora/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
@@ -125,12 +125,12 @@ public final class StressBenchDefinition
   @Override
   public String runTask(StressBenchConfig config, ArrayList<String> args,
       RunTaskContext runTaskContext) throws Exception {
-    List<String> command = new ArrayList<>(5 + config.getArgs().size());
+    List<String> command = new ArrayList<>(3 + config.getArgs().size());
     command.add(Configuration.get(PropertyKey.HOME) + "/bin/alluxio");
     command.add("exec");
     command.add("class");
-    command.add("--");
     command.add(config.getClassName());
+    command.add("--");
 
     // the cluster will run distributed tasks
     command.add(BaseParameters.DISTRIBUTED_FLAG);

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
@@ -1,0 +1,53 @@
+package alluxio.stress.worker;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.List;
+
+@JsonDeserialize(using = WorkerBenchCoarseDataPointDeserializer.class)
+public class WorkerBenchCoarseDataPoint {
+    // properties: workerId, threadId, sliceId, records
+    @JsonProperty("wid")
+    private Long mWid;
+    @JsonProperty("tid")
+    private Long mTid;
+    @JsonProperty("data")
+    private List<List<WorkerBenchDataPoint>> mData;
+
+    // constructor
+    public WorkerBenchCoarseDataPoint(Long workerID, Long threadID, List<List<WorkerBenchDataPoint>> data) {
+        mWid = workerID;
+        mTid = threadID;
+        mData = data;
+    }
+
+    // getter & setters
+    public Long getWid() {
+        return mWid;
+    }
+
+    public void setWid(Long wid) {
+        mWid = wid;
+    }
+
+    public Long getTid() {
+        return mTid;
+    }
+
+    public void setTid(Long tid) {
+        mTid = tid;
+    }
+
+    public List<List<WorkerBenchDataPoint>> getData() {
+        return mData;
+    }
+
+    public void setData(List<List<WorkerBenchDataPoint>> data) {
+        mData = data;
+    }
+
+    public void addDataPoints(List<WorkerBenchDataPoint> data) {
+        mData.add(data);
+    }
+}

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
@@ -14,15 +14,16 @@ package alluxio.stress.worker;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * One coarse data point captures a series of data points.
- * All data points are group by thread and time slices.
+ * One coarse data point captures and merges the performance of I/O operations in a specified window.
+ * The I/O operations are grouped by worker and by thread. In other words, I/O operations in
+ * a window in different threads will be recorded in different coarse data points.
  */
 @JsonDeserialize(using = WorkerBenchCoarseDataPointDeserializer.class)
 public class WorkerBenchCoarseDataPoint {
-  // properties: workerId, threadId, sliceId, records
   @JsonProperty("workerId")
   private Long mWorkerId;
   @JsonProperty("threadId")
@@ -33,7 +34,20 @@ public class WorkerBenchCoarseDataPoint {
   private List<Long> mThroughput;
 
   /**
-   * Creates a coarse data point.
+   * Creates a coarse data point without data and throughput arrays.
+   *
+   * @param workerID the ID of the worker
+   * @param threadID the ID of the thread
+   */
+  public WorkerBenchCoarseDataPoint(Long workerID, Long threadID) {
+    mWorkerId = workerID;
+    mThreadId = threadID;
+    mData = new ArrayList<>();
+    mThroughput = new ArrayList<>();
+  }
+
+  /**
+   * Creates a coarse data point with data and throughput arrays.
    *
    * @param workerID the ID of the worker
    * @param threadID the ID of the thread

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
@@ -3,6 +3,7 @@ package alluxio.stress.worker;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @JsonDeserialize(using = WorkerBenchCoarseDataPointDeserializer.class)
@@ -14,12 +15,16 @@ public class WorkerBenchCoarseDataPoint {
     private Long mTid;
     @JsonProperty("data")
     private List<List<WorkerBenchDataPoint>> mData;
+    @JsonProperty("throughput")
+    private List<Long> mThroughput;
 
     // constructor
-    public WorkerBenchCoarseDataPoint(Long workerID, Long threadID, List<List<WorkerBenchDataPoint>> data) {
+    public WorkerBenchCoarseDataPoint(Long workerID, Long threadID, List<List<WorkerBenchDataPoint>> data,
+                                      List<Long> throughput) {
         mWid = workerID;
         mTid = threadID;
         mData = data;
+        mThroughput = throughput;
     }
 
     // getter & setters
@@ -49,5 +54,17 @@ public class WorkerBenchCoarseDataPoint {
 
     public void addDataPoints(List<WorkerBenchDataPoint> data) {
         mData.add(data);
+    }
+
+    public List<Long> getThroughput() {
+        return mThroughput;
+    }
+
+    public void setThroughput(List<Long> throughput) {
+        mThroughput = throughput;
+    }
+
+    public void clearThroughput() {
+        mThroughput.clear();
     }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
@@ -20,21 +20,20 @@ import java.util.List;
  * One coarse data point captures a series of data points.
  * All data points are group by thread and time slices.
  */
-// TODO(tongyu): compress data points in a coarse data point summary
 @JsonDeserialize(using = WorkerBenchCoarseDataPointDeserializer.class)
 public class WorkerBenchCoarseDataPoint {
   // properties: workerId, threadId, sliceId, records
-  @JsonProperty("wid")
-  private Long mWid;
-  @JsonProperty("tid")
-  private Long mTid;
+  @JsonProperty("workerId")
+  private Long mWorkerId;
+  @JsonProperty("threadId")
+  private Long mThreadId;
   @JsonProperty("data")
-  private List<List<WorkerBenchDataPoint>> mData;
+  private List<WorkerBenchDataPoint> mData;
   @JsonProperty("throughput")
   private List<Long> mThroughput;
 
   /**
-   * Create a coarse data point.
+   * Creates a coarse data point.
    *
    * @param workerID the ID of the worker
    * @param threadID the ID of the thread
@@ -42,10 +41,10 @@ public class WorkerBenchCoarseDataPoint {
    * @param throughput the list of throughput
    */
   public WorkerBenchCoarseDataPoint(Long workerID, Long threadID,
-                                    List<List<WorkerBenchDataPoint>> data,
+                                    List<WorkerBenchDataPoint> data,
                                     List<Long> throughput) {
-    mWid = workerID;
-    mTid = threadID;
+    mWorkerId = workerID;
+    mThreadId = threadID;
     mData = data;
     mThroughput = throughput;
   }
@@ -54,48 +53,48 @@ public class WorkerBenchCoarseDataPoint {
    * @return the ID of the worker
    */
   public Long getWid() {
-    return mWid;
+    return mWorkerId;
   }
 
   /**
    * @param wid the ID of the worker
    */
   public void setWid(Long wid) {
-    mWid = wid;
+    mWorkerId = wid;
   }
 
   /**
    * @return the ID of the thread
    */
   public Long getTid() {
-    return mTid;
+    return mThreadId;
   }
 
   /**
    * @param tid the ID of the thread
    */
   public void setTid(Long tid) {
-    mTid = tid;
+    mThreadId = tid;
   }
 
   /**
    * @return the list of data point lists
    */
-  public List<List<WorkerBenchDataPoint>> getData() {
+  public List<WorkerBenchDataPoint> getData() {
     return mData;
   }
 
   /**
    * @param data the list of data point lists
    */
-  public void setData(List<List<WorkerBenchDataPoint>> data) {
+  public void setData(List<WorkerBenchDataPoint> data) {
     mData = data;
   }
 
   /**
    * @param data add a data point list to the list of data point lists
    */
-  public void addDataPoints(List<WorkerBenchDataPoint> data) {
+  public void addDataPoint(WorkerBenchDataPoint data) {
     mData.add(data);
   }
 
@@ -114,7 +113,7 @@ public class WorkerBenchCoarseDataPoint {
   }
 
   /**
-   * remove the list of all throughput after worker aggregation.
+   * removes the list of all throughput after worker aggregation.
    */
   public void clearThroughput() {
     mThroughput.clear();

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.stress.worker;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
@@ -3,68 +3,109 @@ package alluxio.stress.worker;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * One coarse data point captures a series of data points.
+ * All data points are group by thread and time slices.
+ */
+// TODO(tongyu): compress data points in a coarse data point summary
 @JsonDeserialize(using = WorkerBenchCoarseDataPointDeserializer.class)
 public class WorkerBenchCoarseDataPoint {
-    // properties: workerId, threadId, sliceId, records
-    @JsonProperty("wid")
-    private Long mWid;
-    @JsonProperty("tid")
-    private Long mTid;
-    @JsonProperty("data")
-    private List<List<WorkerBenchDataPoint>> mData;
-    @JsonProperty("throughput")
-    private List<Long> mThroughput;
+  // properties: workerId, threadId, sliceId, records
+  @JsonProperty("wid")
+  private Long mWid;
+  @JsonProperty("tid")
+  private Long mTid;
+  @JsonProperty("data")
+  private List<List<WorkerBenchDataPoint>> mData;
+  @JsonProperty("throughput")
+  private List<Long> mThroughput;
 
-    // constructor
-    public WorkerBenchCoarseDataPoint(Long workerID, Long threadID, List<List<WorkerBenchDataPoint>> data,
-                                      List<Long> throughput) {
-        mWid = workerID;
-        mTid = threadID;
-        mData = data;
-        mThroughput = throughput;
-    }
+  /**
+   * Create a coarse data point.
+   *
+   * @param workerID the ID of the worker
+   * @param threadID the ID of the thread
+   * @param data the list of data point lists
+   * @param throughput the list of throughput
+   */
+  public WorkerBenchCoarseDataPoint(Long workerID, Long threadID,
+                                    List<List<WorkerBenchDataPoint>> data,
+                                    List<Long> throughput) {
+    mWid = workerID;
+    mTid = threadID;
+    mData = data;
+    mThroughput = throughput;
+  }
 
-    // getter & setters
-    public Long getWid() {
-        return mWid;
-    }
+  /**
+   * @return the ID of the worker
+   */
+  public Long getWid() {
+    return mWid;
+  }
 
-    public void setWid(Long wid) {
-        mWid = wid;
-    }
+  /**
+   * @param wid the ID of the worker
+   */
+  public void setWid(Long wid) {
+    mWid = wid;
+  }
 
-    public Long getTid() {
-        return mTid;
-    }
+  /**
+   * @return the ID of the thread
+   */
+  public Long getTid() {
+    return mTid;
+  }
 
-    public void setTid(Long tid) {
-        mTid = tid;
-    }
+  /**
+   * @param tid the ID of the thread
+   */
+  public void setTid(Long tid) {
+    mTid = tid;
+  }
 
-    public List<List<WorkerBenchDataPoint>> getData() {
-        return mData;
-    }
+  /**
+   * @return the list of data point lists
+   */
+  public List<List<WorkerBenchDataPoint>> getData() {
+    return mData;
+  }
 
-    public void setData(List<List<WorkerBenchDataPoint>> data) {
-        mData = data;
-    }
+  /**
+   * @param data the list of data point lists
+   */
+  public void setData(List<List<WorkerBenchDataPoint>> data) {
+    mData = data;
+  }
 
-    public void addDataPoints(List<WorkerBenchDataPoint> data) {
-        mData.add(data);
-    }
+  /**
+   * @param data add a data point list to the list of data point lists
+   */
+  public void addDataPoints(List<WorkerBenchDataPoint> data) {
+    mData.add(data);
+  }
 
-    public List<Long> getThroughput() {
-        return mThroughput;
-    }
+  /**
+   * @return the list of all throughput
+   */
+  public List<Long> getThroughput() {
+    return mThroughput;
+  }
 
-    public void setThroughput(List<Long> throughput) {
-        mThroughput = throughput;
-    }
+  /**
+   * @param throughput the list of all throughput
+   */
+  public void setThroughput(List<Long> throughput) {
+    mThroughput = throughput;
+  }
 
-    public void clearThroughput() {
-        mThroughput.clear();
-    }
+  /**
+   * remove the list of all throughput after worker aggregation.
+   */
+  public void clearThroughput() {
+    mThroughput.clear();
+  }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPoint.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * One coarse data point captures and merges the performance of I/O operations in a specified window.
+ * One coarseDataPoint captures and merges the performance of I/O operations in a specified window.
  * The I/O operations are grouped by worker and by thread. In other words, I/O operations in
  * a window in different threads will be recorded in different coarse data points.
  */

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.stress.worker;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
@@ -31,8 +31,8 @@ public class WorkerBenchCoarseDataPointDeserializer
       throws IOException {
     ObjectMapper mapper = (ObjectMapper) parser.getCodec();
     JsonNode node = parser.getCodec().readTree(parser);
-    Long wId = node.get("wid").asLong();
-    Long tId = node.get("tid").asLong();
+    Long wId = node.get("workerId").asLong();
+    Long tId = node.get("threadId").asLong();
     List<Long> tpList = new ArrayList<>();
     JsonNode tpNode = node.get("throughput");
     if (tpNode != null) {
@@ -40,17 +40,13 @@ public class WorkerBenchCoarseDataPointDeserializer
         tpList.add(throughput.asLong());
       }
     }
-    List<List<WorkerBenchDataPoint>> data = new ArrayList<>();
-    JsonNode dataNode = node.get("data");
-    if (dataNode != null) {
-      for (JsonNode listNode: dataNode) {
-        List<WorkerBenchDataPoint> dataPoints = new ArrayList<>();
-        for (JsonNode subListNode: listNode) {
-          WorkerBenchDataPoint dataPoint = mapper
-              .treeToValue(subListNode, WorkerBenchDataPoint.class);
-          dataPoints.add(dataPoint);
-        }
-        data.add(dataPoints);
+    List<WorkerBenchDataPoint> data = new ArrayList<>();
+    JsonNode dataNodes = node.get("data");
+    if (dataNodes != null) {
+      for (JsonNode dataNode: dataNodes) {
+        WorkerBenchDataPoint dataPoint = mapper
+            .treeToValue(dataNode, WorkerBenchDataPoint.class);
+        data.add(dataPoint);
       }
     }
     return new WorkerBenchCoarseDataPoint(wId, tId, data, tpList);

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
@@ -13,33 +13,35 @@ import java.util.List;
 /**
  * A deserializer converting {@link WorkerBenchCoarseDataPoint} from JSON.
  */
-public class WorkerBenchCoarseDataPointDeserializer extends JsonDeserializer<WorkerBenchCoarseDataPoint> {
-    @Override
-    public WorkerBenchCoarseDataPoint deserialize(JsonParser parser, DeserializationContext ctx)
-            throws IOException {
-        ObjectMapper mapper = (ObjectMapper) parser.getCodec();
-        JsonNode node = parser.getCodec().readTree(parser);
-        Long wId = node.get("wid").asLong();
-        Long tId = node.get("tid").asLong();
-        List<Long> tpList = new ArrayList<>();
-        JsonNode tpNode = node.get("throughput");
-        if (tpNode != null) {
-            for (JsonNode throughput : tpNode){
-                tpList.add(throughput.asLong());
-            }
-        }
-        List<List<WorkerBenchDataPoint>> data = new ArrayList<>();
-        JsonNode dataNode = node.get("data");
-        if (dataNode != null) {
-            for (JsonNode listNode: dataNode){
-                List<WorkerBenchDataPoint> dataPoints = new ArrayList<>();
-                for (JsonNode subListNode: listNode) {
-                    WorkerBenchDataPoint dataPoint = mapper.treeToValue(subListNode, WorkerBenchDataPoint.class);
-                    dataPoints.add(dataPoint);
-                }
-                data.add(dataPoints);
-            }
-        }
-        return new WorkerBenchCoarseDataPoint(wId, tId, data, tpList);
+public class WorkerBenchCoarseDataPointDeserializer
+    extends JsonDeserializer<WorkerBenchCoarseDataPoint> {
+  @Override
+  public WorkerBenchCoarseDataPoint deserialize(JsonParser parser, DeserializationContext ctx)
+      throws IOException {
+    ObjectMapper mapper = (ObjectMapper) parser.getCodec();
+    JsonNode node = parser.getCodec().readTree(parser);
+    Long wId = node.get("wid").asLong();
+    Long tId = node.get("tid").asLong();
+    List<Long> tpList = new ArrayList<>();
+    JsonNode tpNode = node.get("throughput");
+    if (tpNode != null) {
+      for (JsonNode throughput : tpNode) {
+        tpList.add(throughput.asLong());
+      }
     }
+    List<List<WorkerBenchDataPoint>> data = new ArrayList<>();
+    JsonNode dataNode = node.get("data");
+    if (dataNode != null) {
+      for (JsonNode listNode: dataNode) {
+        List<WorkerBenchDataPoint> dataPoints = new ArrayList<>();
+        for (JsonNode subListNode: listNode) {
+          WorkerBenchDataPoint dataPoint = mapper
+              .treeToValue(subListNode, WorkerBenchDataPoint.class);
+          dataPoints.add(dataPoint);
+        }
+        data.add(dataPoints);
+      }
+    }
+    return new WorkerBenchCoarseDataPoint(wId, tId, data, tpList);
+  }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
@@ -1,0 +1,38 @@
+package alluxio.stress.worker;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A deserializer converting {@link WorkerBenchCoarseDataPoint} from JSON.
+ */
+public class WorkerBenchCoarseDataPointDeserializer extends JsonDeserializer<WorkerBenchCoarseDataPoint> {
+    @Override
+    public WorkerBenchCoarseDataPoint deserialize(JsonParser parser, DeserializationContext ctx)
+            throws IOException {
+        ObjectMapper mapper = (ObjectMapper) parser.getCodec();
+        JsonNode node = parser.getCodec().readTree(parser);
+        Long wId = node.get("wid").asLong();
+        Long tId = node.get("tid").asLong();
+        List<List<WorkerBenchDataPoint>> data = new ArrayList<>();
+        JsonNode dataNode = node.get("data");
+        if (dataNode != null) {
+            for (JsonNode listNode: dataNode){
+                List<WorkerBenchDataPoint> dataPoints = new ArrayList<>();
+                for (JsonNode subListNode: listNode) {
+                    WorkerBenchDataPoint dataPoint = mapper.treeToValue(subListNode, WorkerBenchDataPoint.class);
+                    dataPoints.add(dataPoint);
+                }
+                data.add(dataPoints);
+            }
+        }
+        return new WorkerBenchCoarseDataPoint(wId, tId, data);
+    }
+}

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchCoarseDataPointDeserializer.java
@@ -21,6 +21,13 @@ public class WorkerBenchCoarseDataPointDeserializer extends JsonDeserializer<Wor
         JsonNode node = parser.getCodec().readTree(parser);
         Long wId = node.get("wid").asLong();
         Long tId = node.get("tid").asLong();
+        List<Long> tpList = new ArrayList<>();
+        JsonNode tpNode = node.get("throughput");
+        if (tpNode != null) {
+            for (JsonNode throughput : tpNode){
+                tpList.add(throughput.asLong());
+            }
+        }
         List<List<WorkerBenchDataPoint>> data = new ArrayList<>();
         JsonNode dataNode = node.get("data");
         if (dataNode != null) {
@@ -33,6 +40,6 @@ public class WorkerBenchCoarseDataPointDeserializer extends JsonDeserializer<Wor
                 data.add(dataPoints);
             }
         }
-        return new WorkerBenchCoarseDataPoint(wId, tId, data);
+        return new WorkerBenchCoarseDataPoint(wId, tId, data, tpList);
     }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
@@ -14,7 +14,6 @@ package alluxio.stress.worker;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.base.MoreObjects;
 
 /**
  * One data point captures the information we collect from one I/O operation to a worker.
@@ -22,53 +21,23 @@ import com.google.common.base.MoreObjects;
  */
 @JsonDeserialize(using = WorkerBenchDataPointDeserializer.class)
 public class WorkerBenchDataPoint {
-  @JsonProperty("workerID")
-  public String mWorkerID;
-  @JsonProperty("threadID")
-  public String mThreadID;
-
   @JsonProperty("duration")
   public long mDuration;
   @JsonProperty("startMs")
   public long mStartMs;
   @JsonProperty("ioBytes")
   public long mIOBytes;
-  @JsonProperty("inThroughput")
-  public long mInThroughput;
 
   /**
-   * @param workerID the worker this I/O operation reads
-   * @param threadID the thread performing the I/O
    * @param startMs start timestamp of the I/O
    * @param duration duration of the file read operation
    * @param ioBytes bytes read
    */
   @JsonCreator
-  public WorkerBenchDataPoint(@JsonProperty("workerID") String workerID,
-                              @JsonProperty("threadID") String threadID,
-                              @JsonProperty("startMs") long startMs,
-                              @JsonProperty("duration") long duration,
-                              @JsonProperty("ioBytes") long ioBytes) {
-    mWorkerID = workerID;
-    mThreadID = threadID;
+  public WorkerBenchDataPoint(long startMs, long duration, long ioBytes) {
     mStartMs = startMs;
     mDuration = duration;
     mIOBytes = ioBytes;
-    mInThroughput = ioBytes / duration;
-  }
-
-  /**
-   * @return worker ID
-   */
-  public String getWorkerID() {
-    return mWorkerID;
-  }
-
-  /**
-   * @return thread ID
-   */
-  public String getThreadID() {
-    return mThreadID;
   }
 
   /**
@@ -93,27 +62,6 @@ public class WorkerBenchDataPoint {
   }
 
   /**
-   * @return instant throughput
-   */
-  public long getInThroughput() {
-    return mInThroughput;
-  }
-
-  /**
-   * @param workerID worker ID
-   */
-  public void setWorkerID(String workerID) {
-    mWorkerID = workerID;
-  }
-
-  /**
-   * @param threadID the thread ID
-   */
-  public void setThreadID(String threadID) {
-    mThreadID = threadID;
-  }
-
-  /**
    * @param duration duration in ms
    */
   public void setDuration(long duration) {
@@ -132,21 +80,5 @@ public class WorkerBenchDataPoint {
    */
   public void setIOBytes(long ioBytes) {
     mIOBytes = ioBytes;
-  }
-
-  /**
-   * @param inThroughput instant throughput
-   */
-  public void setInThroughput(long inThroughput) {
-    mInThroughput = inThroughput;
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-            .add("threadID", mWorkerID + "-" + mThreadID)
-            .add("startMs", mStartMs)
-            .add("inThroughput", mInThroughput)
-            .toString();
   }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
@@ -25,14 +25,16 @@ public class WorkerBenchDataPoint {
   @JsonProperty("workerID")
   public String mWorkerID;
   @JsonProperty("threadID")
-  public long mThreadID;
+  public String mThreadID;
 
   @JsonProperty("duration")
   public long mDuration;
-  @JsonProperty("start")
+  @JsonProperty("startMs")
   public long mStartMs;
   @JsonProperty("ioBytes")
   public long mIOBytes;
+  @JsonProperty("inThroughput")
+  public long mInThroughput;
 
   /**
    * @param workerID the worker this I/O operation reads
@@ -43,8 +45,8 @@ public class WorkerBenchDataPoint {
    */
   @JsonCreator
   public WorkerBenchDataPoint(@JsonProperty("workerID") String workerID,
-                              @JsonProperty("threadID") long threadID,
-                              @JsonProperty("start") long startMs,
+                              @JsonProperty("threadID") String threadID,
+                              @JsonProperty("startMs") long startMs,
                               @JsonProperty("duration") long duration,
                               @JsonProperty("ioBytes") long ioBytes) {
     mWorkerID = workerID;
@@ -52,6 +54,7 @@ public class WorkerBenchDataPoint {
     mStartMs = startMs;
     mDuration = duration;
     mIOBytes = ioBytes;
+    mInThroughput = ioBytes / duration;
   }
 
   /**
@@ -64,7 +67,7 @@ public class WorkerBenchDataPoint {
   /**
    * @return thread ID
    */
-  public long getThreadID() {
+  public String getThreadID() {
     return mThreadID;
   }
 
@@ -90,6 +93,13 @@ public class WorkerBenchDataPoint {
   }
 
   /**
+   * @return instant throughput
+   */
+  public long getInThroughput() {
+    return mInThroughput;
+  }
+
+  /**
    * @param workerID worker ID
    */
   public void setWorkerID(String workerID) {
@@ -99,7 +109,7 @@ public class WorkerBenchDataPoint {
   /**
    * @param threadID the thread ID
    */
-  public void setThreadID(long threadID) {
+  public void setThreadID(String threadID) {
     mThreadID = threadID;
   }
 
@@ -124,12 +134,19 @@ public class WorkerBenchDataPoint {
     mIOBytes = ioBytes;
   }
 
+  /**
+   * @param inThroughput instant throughput
+   */
+  public void setInThroughput(long inThroughput) {
+    mInThroughput = inThroughput;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-            .add("threadID", mThreadID)
-            .add("ioBytes", mIOBytes)
-            .add("duration", mDuration)
+            .add("threadID", mWorkerID + "-" + mThreadID)
+            .add("startMs", mStartMs)
+            .add("inThroughput", mInThroughput)
             .toString();
   }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
@@ -25,7 +25,7 @@ public class WorkerBenchDataPoint {
   public long mDuration;
   @JsonProperty("startMs")
   public long mStartMs;
-  @JsonProperty("ioBytes")
+  @JsonProperty("iobytes")
   public long mIOBytes;
 
   /**

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
@@ -21,58 +21,40 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  */
 @JsonDeserialize(using = WorkerBenchDataPointDeserializer.class)
 public class WorkerBenchDataPoint {
-  @JsonProperty("duration")
-  public long mDuration;
-  @JsonProperty("startMs")
-  public long mStartMs;
+  @JsonProperty("count")
+  public long mCount;
   @JsonProperty("iobytes")
   public long mIOBytes;
 
   /**
-   * @param startMs start timestamp of the I/O
-   * @param duration duration of the file read operation
-   * @param ioBytes bytes read
+   * @param count number of files read
+   * @param ioBytes total bytes read
    */
   @JsonCreator
-  public WorkerBenchDataPoint(long startMs, long duration, long ioBytes) {
-    mStartMs = startMs;
-    mDuration = duration;
+  public WorkerBenchDataPoint(long count, long ioBytes) {
+    mCount = count;
     mIOBytes = ioBytes;
   }
 
   /**
-   * @return duration in ms
+   * @return number of files read
    */
-  public long getDuration() {
-    return mDuration;
+  public long getCount() {
+    return mCount;
   }
 
   /**
-   * @return start timestamp in long
-   */
-  public long getStartMs() {
-    return mStartMs;
-  }
-
-  /**
-   * @return bytes read
+   * @return total bytes read
    */
   public long getIOBytes() {
     return mIOBytes;
   }
 
   /**
-   * @param duration duration in ms
+   * @param count number of files read
    */
-  public void setDuration(long duration) {
-    mDuration = duration;
-  }
-
-  /**
-   * @param startMs start timestamp in long
-   */
-  public void setStartMs(long startMs) {
-    mStartMs = startMs;
+  public void setCount(long count) {
+    mCount = count;
   }
 
   /**

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
@@ -27,7 +27,7 @@ public class WorkerBenchDataPointDeserializer extends JsonDeserializer<WorkerBen
           throws IOException {
     JsonNode node = parser.getCodec().readTree(parser);
     return new WorkerBenchDataPoint(
-            node.get("startMs").asLong(), node.get("duration").asLong(), node.get("ioBytes").asLong()
+            node.get("startMs").asLong(), node.get("duration").asLong(), node.get("iobytes").asLong()
     );
   }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
@@ -27,7 +27,7 @@ public class WorkerBenchDataPointDeserializer extends JsonDeserializer<WorkerBen
           throws IOException {
     JsonNode node = parser.getCodec().readTree(parser);
     return new WorkerBenchDataPoint(
-            node.get("workerID").asText(), node.get("threadID").asLong(),
+            node.get("workerID").asText(), node.get("threadID").asText(),
             node.get("startMs").asLong(), node.get("duration").asLong(),
             node.get("ioBytes").asLong()
     );

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
@@ -27,8 +27,7 @@ public class WorkerBenchDataPointDeserializer extends JsonDeserializer<WorkerBen
           throws IOException {
     JsonNode node = parser.getCodec().readTree(parser);
     return new WorkerBenchDataPoint(
-        node.get("startMs").asLong(),
-        node.get("duration").asLong(),
+        node.get("count").asLong(),
         node.get("iobytes").asLong()
     );
   }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
@@ -27,7 +27,9 @@ public class WorkerBenchDataPointDeserializer extends JsonDeserializer<WorkerBen
           throws IOException {
     JsonNode node = parser.getCodec().readTree(parser);
     return new WorkerBenchDataPoint(
-            node.get("startMs").asLong(), node.get("duration").asLong(), node.get("iobytes").asLong()
+        node.get("startMs").asLong(),
+        node.get("duration").asLong(),
+        node.get("iobytes").asLong()
     );
   }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPointDeserializer.java
@@ -27,9 +27,7 @@ public class WorkerBenchDataPointDeserializer extends JsonDeserializer<WorkerBen
           throws IOException {
     JsonNode node = parser.getCodec().readTree(parser);
     return new WorkerBenchDataPoint(
-            node.get("workerID").asText(), node.get("threadID").asText(),
-            node.get("startMs").asLong(), node.get("duration").asLong(),
-            node.get("ioBytes").asLong()
+            node.get("startMs").asLong(), node.get("duration").asLong(), node.get("ioBytes").asLong()
     );
   }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
@@ -87,6 +87,10 @@ public final class WorkerBenchParameters extends FileSystemParameters {
       description = "If true, skip the data file creation")
   public boolean mSkipCreation = false;
 
+  @Parameter(names = {"--slice-length"},
+      description = "The granularity of coarse data point slices")
+  public String mSliceLength = "10s";
+
   @DynamicParameter(names = "--conf", description = "HDFS client configuration. Can be repeated.")
   public Map<String, String> mConf = new HashMap<>();
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
@@ -88,10 +88,10 @@ public final class WorkerBenchParameters extends FileSystemParameters {
   public boolean mSkipCreation = false;
 
   @Parameter(names = {"--slice-size"},
-      description = "There will be too many I/O operations during the test, " +
-              "so instead of keeping one data point for each operation, " +
-              "the I/O performed in a small window will be tracked in one result. " +
-              "This argument sets the size of that window.")
+      description = "There will be too many I/O operations during the test, "
+          + "so instead of keeping one data point for each operation, "
+          + "the I/O performed in a small window will be tracked in one result. "
+          + "This argument sets the size of that window.")
   public String mSliceSize = "1s";
 
   @DynamicParameter(names = "--conf", description = "HDFS client configuration. Can be repeated.")

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
@@ -87,9 +87,12 @@ public final class WorkerBenchParameters extends FileSystemParameters {
       description = "If true, skip the data file creation")
   public boolean mSkipCreation = false;
 
-  @Parameter(names = {"--slice-length"},
-      description = "The granularity of coarse data point slices")
-  public String mSliceLength = "10s";
+  @Parameter(names = {"--slice-size"},
+      description = "There will be too many I/O operations during the test, " +
+              "so instead of keeping one data point for each operation, " +
+              "the I/O performed in a small window will be tracked in one result. " +
+              "This argument sets the size of that window.")
+  public String mSliceSize = "1s";
 
   @DynamicParameter(names = "--conf", description = "HDFS client configuration. Can be repeated.")
   public Map<String, String> mConf = new HashMap<>();

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
@@ -14,15 +14,12 @@ package alluxio.stress.worker;
 import alluxio.Constants;
 import alluxio.collections.Pair;
 import alluxio.stress.Parameters;
-import alluxio.stress.StressConstants;
 import alluxio.stress.Summary;
 import alluxio.stress.common.GeneralBenchSummary;
 import alluxio.stress.graph.Graph;
 import alluxio.stress.graph.LineGraph;
-import alluxio.util.FormatUtils;
 
 import com.google.common.base.Splitter;
-import org.HdrHistogram.Histogram;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -65,15 +62,17 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
     mNodeResults = nodes;
     mThroughput = getIOMBps();
 
-    mThroughputPercentiles = new ArrayList<>();
-    Histogram throughputHistogram = new Histogram(
-            FormatUtils.parseSpaceSize(mParameters.mFileSize),
-            StressConstants.TIME_HISTOGRAM_PRECISION);
-    mergedTaskResults.getDataPoints().forEach(stat ->
-            throughputHistogram.recordValue(stat.getInThroughput()));
-    for (int i = 0; i <= 100; i++) {
-      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
-    }
+// TODO: implement percentile calculation for coarse data points
+
+//  mThroughputPercentiles = new ArrayList<>();
+//    Histogram throughputHistogram = new Histogram(
+//            FormatUtils.parseSpaceSize(mParameters.mFileSize),
+//            StressConstants.TIME_HISTOGRAM_PRECISION);
+//    mergedTaskResults.getDataPoints().forEach(stat ->
+//            throughputHistogram.recordValue(stat.getInThroughput()));
+//    for (int i = 0; i <= 100; i++) {
+//      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
+//    }
   }
 
   /**

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
@@ -16,16 +16,18 @@ import alluxio.collections.Pair;
 import alluxio.stress.Parameters;
 import alluxio.stress.StressConstants;
 import alluxio.stress.Summary;
-import alluxio.stress.TaskResult;
 import alluxio.stress.common.GeneralBenchSummary;
 import alluxio.stress.graph.Graph;
 import alluxio.stress.graph.LineGraph;
-
 import alluxio.util.FormatUtils;
+
 import com.google.common.base.Splitter;
 import org.HdrHistogram.Histogram;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
@@ -71,7 +71,6 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
     for (int i = 0; i <= 100; i++) {
       mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
     }
-    // mergedTaskResults.clearAllThroughput();
   }
 
   /**

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
@@ -40,6 +40,7 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
   private long mEndTimeMs;
   private long mIOBytes;
   private List<Long> mDurationPercentiles;
+  private List<Long> mThroughputPercentiles;
 
   /**
    * Creates an instance.
@@ -48,6 +49,7 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
   public WorkerBenchSummary() {
     mNodeResults = new HashMap<>();
     mDurationPercentiles = new ArrayList<>();
+    mThroughputPercentiles = new ArrayList<>();
   }
 
   /**
@@ -74,6 +76,16 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
         durationHistogram.recordValue(stat.getDuration()));
     for (int i = 0; i <= 100; i++) {
       mDurationPercentiles.add(durationHistogram.getValueAtPercentile(i));
+    }
+
+    mThroughputPercentiles = new ArrayList<>();
+    Histogram throughputHistogram = new Histogram(
+            FormatUtils.parseSpaceSize(mParameters.mFileSize),
+            StressConstants.TIME_HISTOGRAM_PRECISION);
+    mergedTaskResults.getDataPoints().forEach(stat ->
+            throughputHistogram.recordValue(stat.getInThroughput()));
+    for (int i = 0; i <= 100; i++) {
+      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
     }
   }
 
@@ -159,6 +171,20 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
    */
   public void setDurationPercentiles(List<Long> percentiles) {
     mDurationPercentiles = percentiles;
+  }
+
+  /**
+   * @return 0~100 percentiles of recorded durations
+   */
+  public List<Long> getThroughputPercentiles() {
+    return mThroughputPercentiles;
+  }
+
+  /**
+   * @param percentiles a list of  calculated percentiles from recorded durations
+   */
+  public void setThroughputPercentiles(List<Long> percentiles) {
+    mThroughputPercentiles = percentiles;
   }
 
   @Override

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
@@ -14,17 +14,18 @@ package alluxio.stress.worker;
 import alluxio.Constants;
 import alluxio.collections.Pair;
 import alluxio.stress.Parameters;
+import alluxio.stress.StressConstants;
 import alluxio.stress.Summary;
+import alluxio.stress.TaskResult;
 import alluxio.stress.common.GeneralBenchSummary;
 import alluxio.stress.graph.Graph;
 import alluxio.stress.graph.LineGraph;
 
+import alluxio.util.FormatUtils;
 import com.google.common.base.Splitter;
+import org.HdrHistogram.Histogram;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -62,17 +63,15 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
     mNodeResults = nodes;
     mThroughput = getIOMBps();
 
-// TODO: implement percentile calculation for coarse data points
-
-//  mThroughputPercentiles = new ArrayList<>();
-//    Histogram throughputHistogram = new Histogram(
-//            FormatUtils.parseSpaceSize(mParameters.mFileSize),
-//            StressConstants.TIME_HISTOGRAM_PRECISION);
-//    mergedTaskResults.getDataPoints().forEach(stat ->
-//            throughputHistogram.recordValue(stat.getInThroughput()));
-//    for (int i = 0; i <= 100; i++) {
-//      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
-//    }
+    mThroughputPercentiles = new ArrayList<>();
+    Histogram throughputHistogram = new Histogram(
+        FormatUtils.parseSpaceSize(mParameters.mFileSize),
+        StressConstants.TIME_HISTOGRAM_PRECISION);
+    mergedTaskResults.getAllThroughput().forEach(throughputHistogram::recordValue);
+    for (int i = 0; i <= 100; i++) {
+      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
+    }
+    // mergedTaskResults.clearAllThroughput();
   }
 
   /**

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchSummary.java
@@ -39,7 +39,6 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
   private long mDurationMs;
   private long mEndTimeMs;
   private long mIOBytes;
-  private List<Long> mDurationPercentiles;
   private List<Long> mThroughputPercentiles;
 
   /**
@@ -48,7 +47,6 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
    */
   public WorkerBenchSummary() {
     mNodeResults = new HashMap<>();
-    mDurationPercentiles = new ArrayList<>();
     mThroughputPercentiles = new ArrayList<>();
   }
 
@@ -66,17 +64,6 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
     mParameters = mergedTaskResults.getParameters();
     mNodeResults = nodes;
     mThroughput = getIOMBps();
-
-    mDurationPercentiles = new ArrayList<>();
-    Histogram durationHistogram = new Histogram(
-        FormatUtils.parseTimeSize(mParameters.mDuration)
-            + FormatUtils.parseTimeSize(mParameters.mWarmup),
-        StressConstants.TIME_HISTOGRAM_PRECISION);
-    mergedTaskResults.getDataPoints().forEach(stat ->
-        durationHistogram.recordValue(stat.getDuration()));
-    for (int i = 0; i <= 100; i++) {
-      mDurationPercentiles.add(durationHistogram.getValueAtPercentile(i));
-    }
 
     mThroughputPercentiles = new ArrayList<>();
     Histogram throughputHistogram = new Histogram(
@@ -162,20 +149,6 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
   /**
    * @return 0~100 percentiles of recorded durations
    */
-  public List<Long> getDurationPercentiles() {
-    return mDurationPercentiles;
-  }
-
-  /**
-   * @param percentiles a list of  calculated percentiles from recorded durations
-   */
-  public void setDurationPercentiles(List<Long> percentiles) {
-    mDurationPercentiles = percentiles;
-  }
-
-  /**
-   * @return 0~100 percentiles of recorded durations
-   */
   public List<Long> getThroughputPercentiles() {
     return mThroughputPercentiles;
   }
@@ -211,7 +184,7 @@ public final class WorkerBenchSummary extends GeneralBenchSummary<WorkerBenchTas
       Pair<List<String>, List<String>> fieldNames = Parameters.partitionFieldNames(
           summaries.stream().map(x -> x.mParameters).collect(Collectors.toList()));
 
-      // Split up common description into 100 character chunks, for the sub title
+      // Split up common description into 100 character chunks, for the subtitle
       List<String> subTitle = new ArrayList<>(Splitter.fixedLength(100).splitToList(
           summaries.get(0).mParameters.getDescription(fieldNames.getFirst())));
 

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
@@ -280,7 +280,8 @@ public final class WorkerBenchTaskResult implements TaskResult {
         result.calculatePercentiles();
         mergedTaskResult.merge(result);
         result.clearAllThroughput();
-        LOG.info("Test results from worker {} has been merged. Individual data points are now cleared from output.",
+        LOG.info("Test results from worker {} has been merged."
+            + "Individual data points are now cleared from output.",
             result.getBaseParameters().mId);
         nodeResults.put(result.getBaseParameters().mId, result);
       }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
@@ -40,7 +40,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
   private long mIOBytes;
   private List<String> mErrors;
   private final List<WorkerBenchCoarseDataPoint> mDataPoints;
-  private List<Long> mAllThroughput;
+  private List<Long> mAllThroughputValues;
   private List<Long> mThroughputPercentiles;
 
   /**
@@ -50,7 +50,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
     // Default constructor required for json deserialization
     mErrors = new ArrayList<>();
     mDataPoints = new ArrayList<>();
-    mAllThroughput = new ArrayList<>();
+    mAllThroughputValues = new ArrayList<>();
     mThroughputPercentiles = new ArrayList<>();
   }
 
@@ -63,20 +63,20 @@ public final class WorkerBenchTaskResult implements TaskResult {
     // When merging results within a node, we need to merge all the error information.
     mErrors.addAll(result.mErrors);
 
-    if (mAllThroughput.isEmpty()) {
+    if (mAllThroughputValues.isEmpty()) {
       for (WorkerBenchCoarseDataPoint dataPoint : mDataPoints) {
-        mAllThroughput.addAll(new ArrayList<>(dataPoint.getThroughput()));
+        mAllThroughputValues.addAll(new ArrayList<>(dataPoint.getThroughput()));
         dataPoint.clearThroughput();
       }
     }
 
-    if (result.mAllThroughput.isEmpty()) {
+    if (result.mAllThroughputValues.isEmpty()) {
       for (WorkerBenchCoarseDataPoint dataPoint : result.mDataPoints) {
-        mAllThroughput.addAll(new ArrayList<>(dataPoint.getThroughput()));
+        mAllThroughputValues.addAll(new ArrayList<>(dataPoint.getThroughput()));
         dataPoint.clearThroughput();
       }
     } else {
-      mAllThroughput.addAll(result.mAllThroughput);
+      mAllThroughputValues.addAll(result.mAllThroughputValues);
     }
 
     mDataPoints.addAll(result.mDataPoints);
@@ -206,14 +206,14 @@ public final class WorkerBenchTaskResult implements TaskResult {
    * @return all instant throughput values of I/O operations
    */
   public List<Long> getAllThroughput() {
-    return mAllThroughput;
+    return mAllThroughputValues;
   }
 
   /**
-   * @param allThroughput all instant throughput values of I/O operations
+   * @param allThroughputValues all instant throughput values of I/O operations
    */
-  public void setAllThroughput(List<Long> allThroughput) {
-    mAllThroughput = allThroughput;
+  public void setAllThroughput(List<Long> allThroughputValues) {
+    mAllThroughputValues = allThroughputValues;
   }
 
   /**
@@ -223,7 +223,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
     Histogram throughputHistogram = new Histogram(
             FormatUtils.parseSpaceSize(mParameters.mFileSize),
             StressConstants.TIME_HISTOGRAM_PRECISION);
-    mAllThroughput.forEach(throughputHistogram::recordValue);
+    mAllThroughputValues.forEach(throughputHistogram::recordValue);
     for (int i = 0; i <= 100; i++) {
       mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
     }
@@ -261,7 +261,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
    * Clears all data points from the result.
    */
   public void clearAllThroughput() {
-    mAllThroughput.clear();
+    mAllThroughputValues.clear();
   }
 
   @Override
@@ -280,7 +280,8 @@ public final class WorkerBenchTaskResult implements TaskResult {
         result.calculatePercentiles();
         mergedTaskResult.merge(result);
         result.clearAllThroughput();
-        LOG.info("Test results from worker {} has been merged.", result.getBaseParameters().mId);
+        LOG.info("Test results from worker {} has been merged. Individual data points are now cleared from output.",
+            result.getBaseParameters().mId);
         nodeResults.put(result.getBaseParameters().mId, result);
       }
 

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
@@ -39,8 +39,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
   private long mEndMs;
   private long mIOBytes;
   private List<String> mErrors;
-  private List<WorkerBenchDataPoint> mDataPoints;
-  private List<Long> mDurationPercentiles;
+  private final List<WorkerBenchDataPoint> mDataPoints;
   private List<Long> mThroughputPercentiles;
 
   /**
@@ -50,7 +49,6 @@ public final class WorkerBenchTaskResult implements TaskResult {
     // Default constructor required for json deserialization
     mErrors = new ArrayList<>();
     mDataPoints = new ArrayList<>();
-    mDurationPercentiles = new ArrayList<>();
     mThroughputPercentiles = new ArrayList<>();
   }
 
@@ -174,20 +172,6 @@ public final class WorkerBenchTaskResult implements TaskResult {
   /**
    * @return 100 percentiles for durations of all I/O operations
    */
-  public List<Long> getDurationPercentiles() {
-    return mDurationPercentiles;
-  }
-
-  /**
-   * @param percentiles 100 percentiles for durations of all I/O operations
-   */
-  public void setDurationPercentiles(List<Long> percentiles) {
-    mDurationPercentiles = percentiles;
-  }
-
-  /**
-   * @return 100 percentiles for durations of all I/O operations
-   */
   public List<Long> getThroughputPercentiles() {
     return mThroughputPercentiles;
   }
@@ -203,14 +187,6 @@ public final class WorkerBenchTaskResult implements TaskResult {
    * From the collected operation data, calculates 100 percentiles.
    */
   public void calculatePercentiles() {
-    Histogram durationHistogram = new Histogram(
-        FormatUtils.parseTimeSize(mParameters.mDuration),
-        StressConstants.TIME_HISTOGRAM_PRECISION);
-    mDataPoints.forEach(stat -> durationHistogram.recordValue(stat.getDuration()));
-    for (int i = 0; i <= 100; i++) {
-      mDurationPercentiles.add(durationHistogram.getValueAtPercentile(i));
-    }
-
     Histogram throughputHistogram = new Histogram(
             FormatUtils.parseSpaceSize(mParameters.mFileSize),
             StressConstants.TIME_HISTOGRAM_PRECISION);

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
@@ -280,7 +280,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
       for (WorkerBenchTaskResult result : results) {
         result.calculatePercentiles();
         mergedTaskResult.merge(result);
-        // result.clearAllThroughput();
+        result.clearAllThroughput();
         LOG.info("Test results from worker {} has been merged.", result.getBaseParameters().mId);
         nodeResults.put(result.getBaseParameters().mId, result);
       }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
@@ -41,6 +41,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
   private List<String> mErrors;
   private List<WorkerBenchDataPoint> mDataPoints;
   private List<Long> mDurationPercentiles;
+  private List<Long> mThroughputPercentiles;
 
   /**
    * Creates an instance.
@@ -50,6 +51,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
     mErrors = new ArrayList<>();
     mDataPoints = new ArrayList<>();
     mDurationPercentiles = new ArrayList<>();
+    mThroughputPercentiles = new ArrayList<>();
   }
 
   /**
@@ -184,6 +186,20 @@ public final class WorkerBenchTaskResult implements TaskResult {
   }
 
   /**
+   * @return 100 percentiles for durations of all I/O operations
+   */
+  public List<Long> getThroughputPercentiles() {
+    return mThroughputPercentiles;
+  }
+
+  /**
+   * @param percentiles 100 percentiles for durations of all I/O operations
+   */
+  public void setThroughputPercentiles(List<Long> percentiles) {
+    mThroughputPercentiles = percentiles;
+  }
+
+  /**
    * From the collected operation data, calculates 100 percentiles.
    */
   public void calculatePercentiles() {
@@ -193,6 +209,14 @@ public final class WorkerBenchTaskResult implements TaskResult {
     mDataPoints.forEach(stat -> durationHistogram.recordValue(stat.getDuration()));
     for (int i = 0; i <= 100; i++) {
       mDurationPercentiles.add(durationHistogram.getValueAtPercentile(i));
+    }
+
+    Histogram throughputHistogram = new Histogram(
+            FormatUtils.parseSpaceSize(mParameters.mFileSize),
+            StressConstants.TIME_HISTOGRAM_PRECISION);
+    mDataPoints.forEach(stat -> throughputHistogram.recordValue(stat.getInThroughput()));
+    for (int i = 0; i <= 100; i++) {
+      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
     }
   }
 

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
@@ -12,11 +12,8 @@
 package alluxio.stress.worker;
 
 import alluxio.stress.BaseParameters;
-import alluxio.stress.StressConstants;
 import alluxio.stress.TaskResult;
-import alluxio.util.FormatUtils;
 
-import org.HdrHistogram.Histogram;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +36,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
   private long mEndMs;
   private long mIOBytes;
   private List<String> mErrors;
-  private final List<WorkerBenchDataPoint> mDataPoints;
+  private final List<WorkerBenchCoarseDataPoint> mDataPoints;
   private List<Long> mThroughputPercentiles;
 
   /**
@@ -187,13 +184,14 @@ public final class WorkerBenchTaskResult implements TaskResult {
    * From the collected operation data, calculates 100 percentiles.
    */
   public void calculatePercentiles() {
-    Histogram throughputHistogram = new Histogram(
-            FormatUtils.parseSpaceSize(mParameters.mFileSize),
-            StressConstants.TIME_HISTOGRAM_PRECISION);
-    mDataPoints.forEach(stat -> throughputHistogram.recordValue(stat.getInThroughput()));
-    for (int i = 0; i <= 100; i++) {
-      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
-    }
+    // TODO: implement percentile calculation for coarse data points
+//    Histogram throughputHistogram = new Histogram(
+//            FormatUtils.parseSpaceSize(mParameters.mFileSize),
+//            StressConstants.TIME_HISTOGRAM_PRECISION);
+//    mDataPoints.forEach(stat -> throughputHistogram.recordValue(stat.getInThroughput()));
+//    for (int i = 0; i <= 100; i++) {
+//      mThroughputPercentiles.add(throughputHistogram.getValueAtPercentile(i));
+//    }
   }
 
   /**
@@ -206,21 +204,21 @@ public final class WorkerBenchTaskResult implements TaskResult {
   /**
    * @return all data points for I/O operations
    */
-  public List<WorkerBenchDataPoint> getDataPoints() {
+  public List<WorkerBenchCoarseDataPoint> getDataPoints() {
     return mDataPoints;
   }
 
   /**
    * @param point one data point for one I/O operation
    */
-  public void addDataPoint(WorkerBenchDataPoint point) {
+  public void addDataPoint(WorkerBenchCoarseDataPoint point) {
     mDataPoints.add(point);
   }
 
   /**
    * @param stats data points for all recorded I/O operations
    */
-  public void addDataPoints(Collection<WorkerBenchDataPoint> stats) {
+  public void addDataPoints(Collection<WorkerBenchCoarseDataPoint> stats) {
     mDataPoints.addAll(stats);
   }
 
@@ -244,11 +242,10 @@ public final class WorkerBenchTaskResult implements TaskResult {
       WorkerBenchTaskResult mergedTaskResult = new WorkerBenchTaskResult();
 
       for (WorkerBenchTaskResult result : results) {
-        result.calculatePercentiles();
+        // result.calculatePercentiles();
         mergedTaskResult.merge(result);
-        LOG.info("Test results from worker {} has been merged, the data points are now cleared.",
-            result.getBaseParameters().mId);
-        result.clearDataPoints();
+        LOG.info("Test results from worker {} has been merged.", result.getBaseParameters().mId);
+        // result.clearDataPoints();
         nodeResults.put(result.getBaseParameters().mId, result);
       }
 

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchTaskResult.java
@@ -14,8 +14,8 @@ package alluxio.stress.worker;
 import alluxio.stress.BaseParameters;
 import alluxio.stress.StressConstants;
 import alluxio.stress.TaskResult;
-
 import alluxio.util.FormatUtils;
+
 import org.HdrHistogram.Histogram;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +70,7 @@ public final class WorkerBenchTaskResult implements TaskResult {
       }
     }
 
-    if (result.mAllThroughput.isEmpty()){
+    if (result.mAllThroughput.isEmpty()) {
       for (WorkerBenchCoarseDataPoint dataPoint : result.mDataPoints) {
         mAllThroughput.addAll(new ArrayList<>(dataPoint.getThroughput()));
         dataPoint.clearThroughput();
@@ -220,7 +220,6 @@ public final class WorkerBenchTaskResult implements TaskResult {
    * From the collected operation data, calculates 100 percentiles.
    */
   public void calculatePercentiles() {
-    // TODO: implement percentile calculation for coarse data points
     Histogram throughputHistogram = new Histogram(
             FormatUtils.parseSpaceSize(mParameters.mFileSize),
             StressConstants.TIME_HISTOGRAM_PRECISION);

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -195,8 +195,8 @@ public abstract class Benchmark<T extends TaskResult> {
       command.add(conf.get(PropertyKey.HOME) + "/bin/alluxio");
       command.add("exec");
       command.add("class");
-      command.add("--");
       command.add(className);
+      command.add("--");
       command.addAll(Arrays.asList(args));
       command.add(BaseParameters.IN_PROCESS_FLAG);
       command.addAll(mBaseParameters.mJavaOpts.stream().map(String::trim)

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -103,10 +103,10 @@ public class StressClientIOBench extends AbstractStressBench
         "# This test will run create a 500MB file with block size 15KB on 1 worker,",
         "# then test the ReadArray operation for 30s and calculate the throughput after 10s "
             + "warmup.",
-        "$ bin/alluxio runClass alluxio.stress.cli.client.StressClientIOBench --operation Write "
-            + "--base alluxio:///stress-client-io-base --file-size 500m --buffer-size 64k "
+        "$ bin/alluxio exec class alluxio.stress.cli.client.StressClientIOBench -- --operation "
+            + "Write --base alluxio:///stress-client-io-base --file-size 500m --buffer-size 64k "
             + "--block-size 16k --write-num-workers 1 --cluster --cluster-limit 1",
-        "$ bin/alluxio runClass alluxio.stress.cli.client.StressClientIOBench --operation "
+        "$ bin/alluxio exec class alluxio.stress.cli.client.StressClientIOBench -- --operation "
             + "ReadArray --base alluxio:///stress-client-io-base --file-size 500m --buffer-size "
             + "64k --block-size 16k --warmup 10s --duration 30s --write-num-workers 1 --cluster "
             + "--cluster-limit 1\n"));

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -464,8 +464,7 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
       }
       WorkerBenchCoarseDataPoint dp = new WorkerBenchCoarseDataPoint(
           Long.parseLong(workerID),
-          Thread.currentThread().getId(),
-          new ArrayList<>(), new ArrayList<>());
+          Thread.currentThread().getId());
       int sliceCount = 0;
       int sliceIoBytes = 0;
       List<Long> throughputList = new ArrayList<>();
@@ -482,6 +481,10 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
             mResult.setIOBytes(mResult.getIOBytes() + bytesRead);
             sliceCount += 1;
             sliceIoBytes += bytesRead;
+            // if duration is 0ms, treat is as 1ms for now
+            if (duration == 0) {
+              throughputList.add(bytesRead);
+            }
             throughputList.add(bytesRead / duration);
             int currentSlice = (int) (startMs
                 / FormatUtils.parseTimeSize(mParameters.mSliceSize));

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -43,7 +43,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -476,9 +480,11 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
           if (bytesRead > 0) {
             mResult.setIOBytes(mResult.getIOBytes() + bytesRead);
             throughputList.add(bytesRead / duration);
-            int currentSlice = (int)(startMs / FormatUtils.parseTimeSize(mParameters.mSliceLength));
-            while (currentSlice > lastSlice){
-              LOG.info("CurrentSlice: {}, LastSlice: {}, adding list to dp.", currentSlice, lastSlice);
+            int currentSlice = (int) (startMs
+                / FormatUtils.parseTimeSize(mParameters.mSliceLength));
+            while (currentSlice > lastSlice) {
+              LOG.info("CurrentSlice: {}, LastSlice: {}, adding list to dp.",
+                  currentSlice, lastSlice);
               dp.addDataPoints(new ArrayList<>(dpList));
               dpList.clear();
               lastSlice++;
@@ -492,9 +498,10 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
         }
       }
 
-      int finalSlice = (int)(FormatUtils.parseTimeSize(mParameters.mDuration) / FormatUtils.parseTimeSize(mParameters.mSliceLength));
+      int finalSlice = (int) (FormatUtils.parseTimeSize(mParameters.mDuration)
+          / FormatUtils.parseTimeSize(mParameters.mSliceLength));
       LOG.info("FinalSlice: {}", finalSlice);
-      while (finalSlice > lastSlice){
+      while (finalSlice > lastSlice) {
         LOG.info("FinalSlice: {}, LastSlice: {}, adding list to dp.", finalSlice, lastSlice);
         dp.addDataPoints(new ArrayList<>(dpList));
         dpList.clear();

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -123,7 +123,7 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
             + "be prepared for each test thread."
             + "# The threads will keeping reading for 30s including a 10s warmup."
             + "# So the result captures I/O performance from the last 20s.",
-        "$ bin/alluxio runClass alluxio.stress.cli.worker.StressWorkerBench \\\n"
+        "$ bin/alluxio exec class alluxio.stress.cli.worker.StressWorkerBench -- \\\n"
             + "--threads 32 --base alluxio:///stress-worker-base --file-size 100m \\\n"
             + "--warmup 10s --duration 30s --cluster\n"
     ));

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -517,7 +517,7 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
       }
       long endOperation = CommonUtils.getCurrentMs();
       return new WorkerBenchDataPoint(
-              mBaseParameters.mIndex, Thread.currentThread().getId(),
+              mBaseParameters.mIndex, String.valueOf(Thread.currentThread().getId()),
               startOperation, endOperation - startOperation, bytesRead);
     }
 


### PR DESCRIPTION
For random reads, bytes read per file is not a constant any more. In spite of existing duration distribution, need a throughput distribution for better understanding of reading performance.

Also, when duration too long, grpc will receive huge size of output data. Should aggregate data points to transfer more datapoints with limited output size.

Group datapoints by threads and time slices:
Example:
```
nodeResults: {
  worker-0: {
    dataPoints: [
      data: [
        { // worker 0, thread 0, slice 0
          count: 1,
          iobytes: 33554432,
        }, { // worker 0, thread 0, other slices
          …
        }
      ], [ // worker 0, other workers
        …
      ]
    ]
    throughputPercentiles: […]
  },
  worker-1: { // other workers
    …
  }
}
```

Slice time with `--slice-size` flag, e.g. `--slice-size 1s`.