### PR TITLE
Parse JSON-style reports in golang side

### DIFF
--- a/cli/src/alluxio.org/cli/cmd/info/report.go
+++ b/cli/src/alluxio.org/cli/cmd/info/report.go
@@ -32,6 +32,7 @@ var Report = &ReportCommand{
 
 type ReportCommand struct {
 	*env.BaseJavaCommand
+	format string
 }
 
 func (c *ReportCommand) Base() *env.BaseJavaCommand {
@@ -56,6 +57,8 @@ Defaults to summary if no arg is provided
 			return c.Run(args)
 		},
 	})
+	cmd.Flags().StringVar(&c.format, "format", "yaml",
+		"Set output format, any of [json, yaml]")
 	return cmd
 }
 
@@ -78,5 +81,8 @@ func (c *ReportCommand) Run(args []string) error {
 		reportArg = args[0]
 	}
 	// TODO: output all in a serializable format and filter/trim as specified by flags
-	return c.Base().Run([]string{reportArg})
+	if c.format != "json" && c.format != "yaml" {
+		return stacktrace.NewError("Invalid format %v, must be one of [json, yaml]", c.format)
+	}
+	return c.Base().RunAndFormat(c.format, nil, []string{reportArg})
 }

--- a/cli/src/alluxio.org/cli/cmd/info/report.go
+++ b/cli/src/alluxio.org/cli/cmd/info/report.go
@@ -57,7 +57,7 @@ Defaults to summary if no arg is provided
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().StringVar(&c.format, "format", "yaml",
+	cmd.Flags().StringVar(&c.format, "format", "json",
 		"Set output format, any of [json, yaml]")
 	return cmd
 }

--- a/cli/src/alluxio.org/cli/env/command.go
+++ b/cli/src/alluxio.org/cli/env/command.go
@@ -119,7 +119,7 @@ func (c *BaseJavaCommand) RunAndFormat(format string, stdin io.Reader, args []st
 			io.Copy(os.Stdout, buf)
 			return err
 		}
-		var obj interface{}
+		var obj json.RawMessage
 		if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
 			return stacktrace.Propagate(err, "error unmarshalling json from java command")
 		}

--- a/cli/src/alluxio.org/cli/env/command.go
+++ b/cli/src/alluxio.org/cli/env/command.go
@@ -123,11 +123,11 @@ func (c *BaseJavaCommand) RunAndFormat(format string, stdin io.Reader, args []st
 		if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
 			return stacktrace.Propagate(err, "error unmarshalling json from java command")
 		}
-		if prettyJson, err := json.MarshalIndent(obj, "", "    "); err == nil {
-			os.Stdout.Write(append(prettyJson, '\n'))
-		} else {
+		prettyJson, err := json.MarshalIndent(obj, "", "    ")
+		if err != nil {
 			return stacktrace.Propagate(err, "error marshalling json to pretty format")
 		}
+		os.Stdout.Write(append(prettyJson, '\n'))
 	case "yaml":
 		buf := &bytes.Buffer{}
 		if err := c.RunWithIO(args, stdin, buf, os.Stderr); err != nil {


### PR DESCRIPTION
Update the Golang side commands to be able to use this output:
1. Return either the yaml or json (default) output to the console.
2. Users can define the format they want with `--format` flag, like `bin/alluxio info report --format yaml`
3. In JSON format, print properties in a fixed, easy-to-read order
4. In YAML format, print properties alphabetically (since YAML specification regards property order non-significant)

Before:
```
{"safeMode":false,"masterVersions":[{"version":"304-SNAPSHOT","host":"localhost","port":19998,"state":"PRIMARY"}],"masterAddress":"localhost:19998","zookeeperAddress":[],"useZookeeper":false,"raftJournalAddress":["localhost:19200"],"useRaftJournal":true,"liveWorkers":1,"lostWorkers":0,"freeCapacity":"1024.00MB","totalCapacityOnTiers":{"MEM":"1024.00MB"},"usedCapacityOnTiers":{"MEM":"0B"},"version":"304-SNAPSHOT","webPort":19999,"started":"09-15-2023 15:54:56:635","uptime":"0 day(s), 0 hour(s), 26 minute(s), and 37 second(s)","rpcPort":19998}
```

After (in JSON):
```
{
    "rpcPort": 19998,
    "started": "09-15-2023 15:54:56:635",
    "uptime": "0 day(s), 0 hour(s), 55 minute(s), and 31 second(s)",
    "safeMode": false,
    "version": "304-SNAPSHOT",
    "webPort": 19999,
    "masterVersions": [
        {
            "version": "304-SNAPSHOT",
            "host": "localhost",
            "port": 19998,
            "state": "PRIMARY"
        }
    ],
    "masterAddress": "localhost:19998",
    "zookeeperAddress": [],
    "useZookeeper": false,
    "raftJournalAddress": [
        "localhost:19200"
    ],
    "useRaftJournal": true,
    "liveWorkers": 1,
    "lostWorkers": 0,
    "freeCapacity": "1024.00MB",
    "totalCapacityOnTiers": {
        "MEM": "1024.00MB"
    },
    "usedCapacityOnTiers": {
        "MEM": "0B"
    }
}
```

After (in YAML):
```
freeCapacity: 1024.00MB
liveWorkers: 1
lostWorkers: 0
masterAddress: localhost:19998
masterVersions:
    - host: localhost
      port: 19998
      state: PRIMARY
      version: 304-SNAPSHOT
raftJournalAddress:
    - localhost:19200
rpcPort: 19998
safeMode: false
started: 09-15-2023 15:54:56:635
totalCapacityOnTiers:
    MEM: 1024.00MB
uptime: 0 day(s), 1 hour(s), 1 minute(s), and 36 second(s)
useRaftJournal: true
useZookeeper: false
usedCapacityOnTiers:
    MEM: 0B
version: 304-SNAPSHOT
webPort: 19999
zookeeperAddress: []
```