### PR TITLE
Format reports on Golang CLI

### DIFF
--- a/cli/src/alluxio.org/cli/cmd/info/report.go
+++ b/cli/src/alluxio.org/cli/cmd/info/report.go
@@ -12,11 +12,19 @@
 package info
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/iancoleman/orderedmap"
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	"alluxio.org/cli/cmd/names"
 	"alluxio.org/cli/env"
@@ -82,7 +90,143 @@ func (c *ReportCommand) Run(args []string) error {
 	}
 	// TODO: output all in a serializable format and filter/trim as specified by flags
 	if c.format != "json" && c.format != "yaml" {
-		return stacktrace.NewError("Invalid format %v, must be one of [json, yaml]", c.format)
+		return stacktrace.NewError("unfamiliar output format %s, must be one of [json, yaml]", c.format)
 	}
-	return c.Base().RunAndFormat(c.format, nil, []string{reportArg})
+	buf := &bytes.Buffer{}
+	if err := c.RunWithIO([]string{reportArg}, nil, buf, os.Stderr); err != nil {
+		io.Copy(os.Stdout, buf)
+		return err
+	}
+
+	obj := orderedmap.New()
+	if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
+		return stacktrace.Propagate(err, "error unmarshalling json from java command")
+	}
+
+	if reportArg == "summary" {
+		if val, ok := obj.Get("freeCapacity"); ok {
+			obj.Set("freeCapacity", convertBytesToString(val.(float64)))
+		}
+		if val, ok := obj.Get("started"); ok {
+			obj.Set("started", convertMsToDatetime(val.(float64)))
+		}
+		if val, ok := obj.Get("uptime"); ok {
+			obj.Set("uptime", convertMsToDuration(val.(float64)))
+		}
+		if val, ok := obj.Get("totalCapacityOnTiers"); ok {
+			oMap := val.(orderedmap.OrderedMap)
+			for key := range oMap.Values() {
+				if val, ok := oMap.Get(key); ok {
+					oMap.Set(key, convertBytesToString(val.(float64)))
+				}
+			}
+		}
+		if val, ok := obj.Get("usedCapacityOnTiers"); ok {
+			oMap := val.(orderedmap.OrderedMap)
+			for key := range oMap.Values() {
+				if val, ok := oMap.Get(key); ok {
+					oMap.Set(key, convertBytesToString(val.(float64)))
+				}
+			}
+		}
+	}
+
+	if reportArg == "ufs" {
+		for key := range obj.Values() {
+			if val, ok := obj.Get(key); ok {
+				oMap := val.(orderedmap.OrderedMap)
+				if v, ok := oMap.Get("ufsCapacityBytes"); ok {
+					oMap.Set("ufsCapacityBytes", convertBytesToString(v.(float64)))
+				}
+				if v, ok := oMap.Get("ufsUsedBytes"); ok {
+					oMap.Set("ufsUsedBytes", convertBytesToString(v.(float64)))
+				}
+				obj.Set(key, oMap)
+			}
+		}
+	}
+
+	if reportArg == "jobservice" {
+		if val, ok := obj.Get("masterStatus"); ok {
+			for _, item := range val.([]interface{}) {
+				oMap := item.(orderedmap.OrderedMap)
+				if v, ok := oMap.Get("startTime"); ok {
+					oMap.Set("startTime", convertMsToDatetime(v.(float64)))
+				}
+				item = oMap
+			}
+		}
+		if val, ok := obj.Get("longestRunningJobs"); ok {
+			for _, item := range val.([]interface{}) {
+				oMap := item.(orderedmap.OrderedMap)
+				if v, ok := oMap.Get("timestamp"); ok {
+					oMap.Set("timestamp", convertMsToDatetime(v.(float64)))
+				}
+				item = oMap
+			}
+		}
+		if val, ok := obj.Get("recentFailedJobs"); ok {
+			for _, item := range val.([]interface{}) {
+				oMap := item.(orderedmap.OrderedMap)
+				if v, ok := oMap.Get("timestamp"); ok {
+					oMap.Set("timestamp", convertMsToDatetime(v.(float64)))
+				}
+				item = oMap
+			}
+		}
+		if val, ok := obj.Get("recentModifiedJobs"); ok {
+			for _, item := range val.([]interface{}) {
+				oMap := item.(orderedmap.OrderedMap)
+				if v, ok := oMap.Get("timestamp"); ok {
+					oMap.Set("timestamp", convertMsToDatetime(v.(float64)))
+				}
+				item = oMap
+			}
+		}
+	}
+
+	if c.format == "json" {
+		prettyJson, err := json.MarshalIndent(obj, "", "    ")
+		if err != nil {
+			return stacktrace.Propagate(err, "error marshalling json to pretty format")
+		}
+		os.Stdout.Write(append(prettyJson, '\n'))
+	} else if c.format == "yaml" {
+		out, err := yaml.Marshal(obj)
+		if err != nil {
+			return stacktrace.Propagate(err, "error marshalling yaml")
+		}
+		os.Stdout.Write(out)
+	}
+	return nil
+}
+
+func convertMsToDatetime(timeMs float64) string {
+	tm := time.Unix(int64(timeMs)/1000, 0)
+	format := "2006-01-02T15:04:05-07:00"
+	return tm.Format(format)
+}
+
+func convertMsToDuration(timeMs float64) string {
+	duration := time.Duration(int64(timeMs)) * time.Millisecond
+	days := duration / (24 * time.Hour)
+	duration = duration % (24 * time.Hour)
+	hours := duration / time.Hour
+	duration = duration % time.Hour
+	minutes := duration / time.Minute
+	seconds := duration % time.Minute / time.Second
+	return fmt.Sprintf("%dd %02dh%02dm%02ds", days, hours, minutes, seconds)
+}
+
+func convertBytesToString(bytes float64) string {
+	const unit = 1024
+	div, exp := 1, 0
+	for n := int64(bytes); n > 5*unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	value := bytes / float64(div)
+	size := strconv.FormatFloat(value, 'f', 2, 64)
+	suffixes := []string{"B", "KB", "MB", "GB", "TB", "PB"}
+	return size + suffixes[exp]
 }

--- a/cli/src/alluxio.org/cli/cmd/info/report.go
+++ b/cli/src/alluxio.org/cli/cmd/info/report.go
@@ -21,11 +21,12 @@ import (
 	"strings"
 	"time"
 
-	"alluxio.org/cli/cmd/names"
-	"alluxio.org/cli/env"
 	"github.com/iancoleman/orderedmap"
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/cmd/names"
+	"alluxio.org/cli/env"
 )
 
 var Report = &ReportCommand{

--- a/cli/src/alluxio.org/cli/cmd/info/report.go
+++ b/cli/src/alluxio.org/cli/cmd/info/report.go
@@ -32,6 +32,7 @@ var Report = &ReportCommand{
 
 type ReportCommand struct {
 	*env.BaseJavaCommand
+	format string
 }
 
 func (c *ReportCommand) Base() *env.BaseJavaCommand {
@@ -56,6 +57,8 @@ Defaults to summary if no arg is provided
 			return c.Run(args)
 		},
 	})
+	cmd.Flags().StringVar(&c.format, "format", "json",
+		"Set output format, any of [json, yaml]")
 	return cmd
 }
 
@@ -78,5 +81,8 @@ func (c *ReportCommand) Run(args []string) error {
 		reportArg = args[0]
 	}
 	// TODO: output all in a serializable format and filter/trim as specified by flags
-	return c.Base().Run([]string{reportArg})
+	if c.format != "json" && c.format != "yaml" {
+		return stacktrace.NewError("Invalid format %v, must be one of [json, yaml]", c.format)
+	}
+	return c.Base().RunAndFormat(c.format, nil, []string{reportArg})
 }

--- a/cli/src/alluxio.org/cli/cmd/info/report.go
+++ b/cli/src/alluxio.org/cli/cmd/info/report.go
@@ -43,7 +43,7 @@ const (
 
 type ReportCommand struct {
 	*env.BaseJavaCommand
-	readable bool
+	raw bool
 }
 
 func (c *ReportCommand) Base() *env.BaseJavaCommand {
@@ -68,8 +68,8 @@ Defaults to summary if no arg is provided
 			return c.Run(args)
 		},
 	})
-	cmd.Flags().BoolVar(&c.readable, "readable", false,
-		"Determine whether to use human-readable format for bytes, datetime, and duration.")
+	cmd.Flags().BoolVar(&c.raw, "raw", false,
+		"Output raw JSON data instead of human-readable format for bytes, datetime, and duration.")
 	return cmd
 }
 
@@ -103,7 +103,7 @@ func (c *ReportCommand) Run(args []string) error {
 		return stacktrace.Propagate(err, "error unmarshalling json from java command")
 	}
 
-	if c.readable {
+	if !c.raw {
 		newObj := orderedmap.New()
 		for _, key := range obj.Keys() {
 			if val, ok := obj.Get(key); ok {

--- a/cli/src/alluxio.org/cli/cmd/info/report.go
+++ b/cli/src/alluxio.org/cli/cmd/info/report.go
@@ -37,6 +37,10 @@ var Report = &ReportCommand{
 	},
 }
 
+const (
+	RFC3339 = "2006-01-02T15:04:05Z07:00"
+)
+
 type ReportCommand struct {
 	*env.BaseJavaCommand
 }
@@ -188,8 +192,7 @@ func (c *ReportCommand) Run(args []string) error {
 
 func convertMsToDatetime(timeMs float64) string {
 	tm := time.Unix(int64(timeMs)/1000, 0)
-	format := "2006-01-02T15:04:05-07:00"
-	return tm.Format(format)
+	return tm.Format(RFC3339)
 }
 
 func convertMsToDuration(timeMs float64) string {

--- a/cli/src/alluxio.org/cli/env/command.go
+++ b/cli/src/alluxio.org/cli/env/command.go
@@ -114,7 +114,20 @@ func (c *BaseJavaCommand) RunWithIO(args []string, stdin io.Reader, stdout, stde
 func (c *BaseJavaCommand) RunAndFormat(format string, stdin io.Reader, args []string) error {
 	switch strings.ToLower(format) {
 	case "json":
-		return c.RunWithIO(args, stdin, os.Stdout, os.Stderr)
+		buf := &bytes.Buffer{}
+		if err := c.RunWithIO(args, stdin, buf, os.Stderr); err != nil {
+			io.Copy(os.Stdout, buf)
+			return err
+		}
+		var obj json.RawMessage
+		if err := json.Unmarshal(buf.Bytes(), &obj); err != nil {
+			return stacktrace.Propagate(err, "error unmarshalling json from java command")
+		}
+		prettyJson, err := json.MarshalIndent(obj, "", "    ")
+		if err != nil {
+			return stacktrace.Propagate(err, "error marshalling json to pretty format")
+		}
+		os.Stdout.Write(append(prettyJson, '\n'))
 	case "yaml":
 		buf := &bytes.Buffer{}
 		if err := c.RunWithIO(args, stdin, buf, os.Stderr); err != nil {

--- a/cli/src/alluxio.org/go.mod
+++ b/cli/src/alluxio.org/go.mod
@@ -3,6 +3,7 @@ module alluxio.org
 go 1.18
 
 require (
+	github.com/iancoleman/orderedmap v0.3.0
 	github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/sirupsen/logrus v1.9.0

--- a/cli/src/alluxio.org/go.sum
+++ b/cli/src/alluxio.org/go.sum
@@ -123,6 +123,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
+github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJDkXXS7VoV7XGE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommand.java
@@ -23,11 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.FormatStyle;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * Prints job service metric information.
@@ -53,10 +49,6 @@ public class JobServiceMetricsCommand {
     mDateFormatPattern = dateFormatPattern;
   }
 
-  public static final DateTimeFormatter DATETIME_FORMAT =
-      DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT).ofPattern("yyyyMMdd-HHmmss")
-          .withLocale(Locale.getDefault()).withZone(ZoneId.systemDefault());
-
   /**
    * Runs a job services report metrics command.
    *
@@ -68,8 +60,8 @@ public class JobServiceMetricsCommand {
     List<JobWorkerHealth> allWorkerHealth = mJobMasterClient.getAllWorkerHealth();
     JobServiceSummary jobServiceSummary = mJobMasterClient.getJobServiceSummary();
 
-    JobServiceOutput jobServiceInfo = new JobServiceOutput(allMasterStatus, allWorkerHealth,
-        jobServiceSummary, mDateFormatPattern);
+    JobServiceOutput jobServiceInfo = new JobServiceOutput(
+        allMasterStatus, allWorkerHealth, jobServiceSummary);
     try {
       String json = objectMapper.writeValueAsString(jobServiceInfo);
       mPrintStream.println(json);

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceOutput.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceOutput.java
@@ -16,7 +16,6 @@ import alluxio.job.wire.JobInfo;
 import alluxio.job.wire.JobServiceSummary;
 import alluxio.job.wire.JobWorkerHealth;
 import alluxio.job.wire.StatusSummary;
-import alluxio.util.CommonUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,15 +35,15 @@ public class JobServiceOutput {
     private String mHost;
     private int mPort;
     private String mState;
-    private String mStartTime;
+    private long mStartTime;
     private String mVersion;
     private String mRevision;
 
-    public SerializableJobMasterStatus(JobMasterStatus jobMasterStatus, String dateFormat) {
+    public SerializableJobMasterStatus(JobMasterStatus jobMasterStatus) {
       mHost = jobMasterStatus.getMasterAddress().getHost();
       mPort = jobMasterStatus.getMasterAddress().getRpcPort();
       mState = jobMasterStatus.getState();
-      mStartTime = CommonUtils.convertMsToDate(jobMasterStatus.getStartTime(), dateFormat);
+      mStartTime = jobMasterStatus.getStartTime();
       mVersion = jobMasterStatus.getVersion().getVersion();
       mRevision = jobMasterStatus.getVersion().getRevision();
     }
@@ -73,11 +72,11 @@ public class JobServiceOutput {
       mState = state;
     }
 
-    public String getStartTime() {
+    public long getStartTime() {
       return mStartTime;
     }
 
-    public void setStartTime(String startTime) {
+    public void setStartTime(long startTime) {
       mStartTime = startTime;
     }
 
@@ -201,23 +200,23 @@ public class JobServiceOutput {
   }
 
   private static class SerializableJobInfo {
-    private String mTimestamp;
+    private long mTimestamp;
     private long mId;
     private String mName;
     private String mStatus;
 
-    public SerializableJobInfo(JobInfo jobInfo, String dateFormat) {
-      mTimestamp = CommonUtils.convertMsToDate(jobInfo.getLastUpdated(), dateFormat);
+    public SerializableJobInfo(JobInfo jobInfo) {
+      mTimestamp = jobInfo.getLastUpdated();
       mId = jobInfo.getId();
       mName = jobInfo.getName();
       mStatus = jobInfo.getStatus().toString();
     }
 
-    public String getTimestamp() {
+    public long getTimestamp() {
       return mTimestamp;
     }
 
-    public void setTimestamp(String timestamp) {
+    public void setTimestamp(long timestamp) {
       mTimestamp = timestamp;
     }
 
@@ -252,15 +251,13 @@ public class JobServiceOutput {
    * @param allMasterStatus status of all masters
    * @param allWorkerHealth health info of all workers
    * @param jobServiceSummary summary of job service
-   * @param dateFormat specify the pattern of dates
    */
   public JobServiceOutput(List<JobMasterStatus> allMasterStatus,
                           List<JobWorkerHealth> allWorkerHealth,
-                          JobServiceSummary jobServiceSummary,
-                          String dateFormat) {
+                          JobServiceSummary jobServiceSummary) {
     mMasterStatus = new ArrayList<>();
     for (JobMasterStatus masterStatus : allMasterStatus) {
-      mMasterStatus.add(new SerializableJobMasterStatus(masterStatus, dateFormat));
+      mMasterStatus.add(new SerializableJobMasterStatus(masterStatus));
     }
 
     mWorkerHealth = new ArrayList<>();
@@ -276,13 +273,13 @@ public class JobServiceOutput {
     mRecentFailedJobs = new ArrayList<>();
     mLongestRunningJobs = new ArrayList<>();
     for (JobInfo jobInfo : jobServiceSummary.getRecentActivities()) {
-      mRecentModifiedJobs.add(new SerializableJobInfo(jobInfo, dateFormat));
+      mRecentModifiedJobs.add(new SerializableJobInfo(jobInfo));
     }
     for (JobInfo jobInfo : jobServiceSummary.getRecentFailures()) {
-      mRecentFailedJobs.add(new SerializableJobInfo(jobInfo, dateFormat));
+      mRecentFailedJobs.add(new SerializableJobInfo(jobInfo));
     }
     for (JobInfo jobInfo : jobServiceSummary.getLongestRunning()) {
-      mLongestRunningJobs.add(new SerializableJobInfo(jobInfo, dateFormat));
+      mLongestRunningJobs.add(new SerializableJobInfo(jobInfo));
     }
   }
 

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceOutput.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/report/JobServiceOutput.java
@@ -200,24 +200,24 @@ public class JobServiceOutput {
   }
 
   private static class SerializableJobInfo {
-    private long mTimestamp;
+    private long mLastUpdatedTime;
     private long mId;
     private String mName;
     private String mStatus;
 
     public SerializableJobInfo(JobInfo jobInfo) {
-      mTimestamp = jobInfo.getLastUpdated();
+      mLastUpdatedTime = jobInfo.getLastUpdated();
       mId = jobInfo.getId();
       mName = jobInfo.getName();
       mStatus = jobInfo.getStatus().toString();
     }
 
-    public long getTimestamp() {
-      return mTimestamp;
+    public long getLastUpdatedTime() {
+      return mLastUpdatedTime;
     }
 
-    public void setTimestamp(long timestamp) {
-      mTimestamp = timestamp;
+    public void setLastUpdatedTime(long lastUpdatedTime) {
+      mLastUpdatedTime = lastUpdatedTime;
     }
 
     public long getId() {

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryCommand.java
@@ -78,7 +78,7 @@ public class SummaryCommand {
     BlockMasterInfo blockMasterInfo = mBlockMasterClient.getBlockMasterInfo(blockMasterInfoFilter);
 
     ObjectMapper objectMapper = new ObjectMapper();
-    SummaryOutput summaryInfo = new SummaryOutput(masterInfo, blockMasterInfo, mDateFormatPattern);
+    SummaryOutput summaryInfo = new SummaryOutput(masterInfo, blockMasterInfo);
     try {
       String json = objectMapper.writeValueAsString(summaryInfo);
       mPrintStream.println(json);

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryOutput.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryOutput.java
@@ -14,8 +14,6 @@ package alluxio.cli.fsadmin.report;
 import alluxio.cli.fsadmin.FileSystemAdminShellUtils;
 import alluxio.grpc.MasterInfo;
 import alluxio.grpc.MasterVersion;
-import alluxio.util.CommonUtils;
-import alluxio.util.FormatUtils;
 import alluxio.wire.BlockMasterInfo;
 
 import java.util.ArrayList;
@@ -30,8 +28,8 @@ public class SummaryOutput {
   private String mMasterAddress;
   private int mWebPort;
   private int mRpcPort;
-  private String mStarted;
-  private String mUptime;
+  private long mStarted;
+  private long mUptime;
   private String mVersion;
   private boolean mSafeMode;
 
@@ -43,9 +41,9 @@ public class SummaryOutput {
 
   private int mLiveWorkers;
   private int mLostWorkers;
-  private Map<String, String> mTotalCapacityOnTiers;
-  private Map<String, String> mUsedCapacityOnTiers;
-  private String mFreeCapacity;
+  private Map<String, Long> mTotalCapacityOnTiers;
+  private Map<String, Long> mUsedCapacityOnTiers;
+  private long mFreeCapacity;
 
   private static class SerializableMasterVersion {
     private String mHost;
@@ -98,16 +96,14 @@ public class SummaryOutput {
    *
    * @param masterInfo given master info
    * @param blockMasterInfo given block master info
-   * @param dateFormatPattern specify the pattern of dates
    */
-  public SummaryOutput(MasterInfo masterInfo, BlockMasterInfo blockMasterInfo,
-        String dateFormatPattern) {
+  public SummaryOutput(MasterInfo masterInfo, BlockMasterInfo blockMasterInfo) {
     // give values to internal properties
     mMasterAddress = masterInfo.getLeaderMasterAddress();
     mWebPort = masterInfo.getWebPort();
     mRpcPort = masterInfo.getRpcPort();
-    mStarted = CommonUtils.convertMsToDate(masterInfo.getStartTimeMs(), dateFormatPattern);
-    mUptime = CommonUtils.convertMsToClockTime(masterInfo.getUpTimeMs());
+    mStarted = masterInfo.getStartTimeMs();
+    mUptime = masterInfo.getUpTimeMs();
     mVersion = masterInfo.getVersion();
     mSafeMode = masterInfo.getSafeMode();
 
@@ -132,18 +128,12 @@ public class SummaryOutput {
     Map<String, Long> totalBytesOnTiers =
         new TreeMap<>(FileSystemAdminShellUtils::compareTierNames);
     totalBytesOnTiers.putAll(blockMasterInfo.getCapacityBytesOnTiers());
-    for (Map.Entry<String, Long> totalBytesOnTier : totalBytesOnTiers.entrySet()) {
-      mTotalCapacityOnTiers.put(totalBytesOnTier.getKey(),
-          FormatUtils.getSizeFromBytes(totalBytesOnTier.getValue()));
-    }
+    mTotalCapacityOnTiers.putAll(totalBytesOnTiers);
     Map<String, Long> usedBytesOnTiers =
         new TreeMap<>(FileSystemAdminShellUtils::compareTierNames);
     usedBytesOnTiers.putAll(blockMasterInfo.getUsedBytesOnTiers());
-    for (Map.Entry<String, Long> usedBytesOnTier : usedBytesOnTiers.entrySet()) {
-      mUsedCapacityOnTiers.put(usedBytesOnTier.getKey(),
-          FormatUtils.getSizeFromBytes(usedBytesOnTier.getValue()));
-    }
-    mFreeCapacity = FormatUtils.getSizeFromBytes(blockMasterInfo.getFreeBytes());
+    mUsedCapacityOnTiers.putAll(usedBytesOnTiers);
+    mFreeCapacity = blockMasterInfo.getFreeBytes();
   }
 
   /**
@@ -205,7 +195,7 @@ public class SummaryOutput {
    *
    * @return started time
    */
-  public String getStarted() {
+  public long getStarted() {
     return mStarted;
   }
 
@@ -214,7 +204,7 @@ public class SummaryOutput {
    *
    * @param started started time
    */
-  public void setStarted(String started) {
+  public void setStarted(long started) {
     mStarted = started;
   }
 
@@ -223,7 +213,7 @@ public class SummaryOutput {
    *
    * @return time running
    */
-  public String getUptime() {
+  public long getUptime() {
     return mUptime;
   }
 
@@ -232,7 +222,7 @@ public class SummaryOutput {
    *
    * @param uptime time running
    */
-  public void setUptime(String uptime) {
+  public void setUptime(long uptime) {
     mUptime = uptime;
   }
 
@@ -403,7 +393,7 @@ public class SummaryOutput {
    *
    * @return free capacity
    */
-  public String getFreeCapacity() {
+  public long getFreeCapacity() {
     return mFreeCapacity;
   }
 
@@ -412,7 +402,7 @@ public class SummaryOutput {
    *
    * @param freeCapacity free capacity
    */
-  public void setFreeCapacity(String freeCapacity) {
+  public void setFreeCapacity(long freeCapacity) {
     mFreeCapacity = freeCapacity;
   }
 
@@ -421,7 +411,7 @@ public class SummaryOutput {
    *
    * @return capacity by tiers
    */
-  public Map<String, String> getTotalCapacityOnTiers() {
+  public Map<String, Long> getTotalCapacityOnTiers() {
     return mTotalCapacityOnTiers;
   }
 
@@ -430,7 +420,7 @@ public class SummaryOutput {
    *
    * @param totalCapacityOnTiers capacity by tiers
    */
-  public void setTotalCapacityOnTiers(Map<String, String> totalCapacityOnTiers) {
+  public void setTotalCapacityOnTiers(Map<String, Long> totalCapacityOnTiers) {
     mTotalCapacityOnTiers = totalCapacityOnTiers;
   }
 
@@ -439,7 +429,7 @@ public class SummaryOutput {
    *
    * @return used capacity by tiers
    */
-  public Map<String, String> getUsedCapacityOnTiers() {
+  public Map<String, Long> getUsedCapacityOnTiers() {
     return mUsedCapacityOnTiers;
   }
 
@@ -448,7 +438,7 @@ public class SummaryOutput {
    *
    * @param usedCapacityOnTiers used capacity by tiers
    */
-  public void setUsedCapacityOnTiers(Map<String, String> usedCapacityOnTiers) {
+  public void setUsedCapacityOnTiers(Map<String, Long> usedCapacityOnTiers) {
     mUsedCapacityOnTiers = usedCapacityOnTiers;
   }
 }

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryOutput.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryOutput.java
@@ -11,7 +11,6 @@
 
 package alluxio.cli.fsadmin.report;
 
-import alluxio.cli.fsadmin.FileSystemAdminShellUtils;
 import alluxio.grpc.MasterInfo;
 import alluxio.grpc.MasterVersion;
 import alluxio.wire.BlockMasterInfo;
@@ -125,12 +124,12 @@ public class SummaryOutput {
 
     mTotalCapacityOnTiers = new TreeMap<>();
     Map<String, Long> totalBytesOnTiers = blockMasterInfo.getCapacityBytesOnTiers();
-    for (Map.Entry<String, Long> entry : totalBytesOnTiers.entrySet()){
+    for (Map.Entry<String, Long> entry : totalBytesOnTiers.entrySet()) {
       mTotalCapacityOnTiers.put(entry.getKey() + "Bytes", entry.getValue());
     }
     mUsedCapacityOnTiers = new TreeMap<>();
     Map<String, Long> usedBytesOnTiers = blockMasterInfo.getUsedBytesOnTiers();
-    for (Map.Entry<String, Long> entry : usedBytesOnTiers.entrySet()){
+    for (Map.Entry<String, Long> entry : usedBytesOnTiers.entrySet()) {
       mUsedCapacityOnTiers.put(entry.getKey() + "Bytes", entry.getValue());
     }
     mFreeCapacityBytes = blockMasterInfo.getFreeBytes();

--- a/dora/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryOutput.java
+++ b/dora/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryOutput.java
@@ -28,8 +28,8 @@ public class SummaryOutput {
   private String mMasterAddress;
   private int mWebPort;
   private int mRpcPort;
-  private long mStarted;
-  private long mUptime;
+  private long mStartTime;
+  private long mUptimeDuration;
   private String mVersion;
   private boolean mSafeMode;
 
@@ -43,7 +43,7 @@ public class SummaryOutput {
   private int mLostWorkers;
   private Map<String, Long> mTotalCapacityOnTiers;
   private Map<String, Long> mUsedCapacityOnTiers;
-  private long mFreeCapacity;
+  private long mFreeCapacityBytes;
 
   private static class SerializableMasterVersion {
     private String mHost;
@@ -102,8 +102,8 @@ public class SummaryOutput {
     mMasterAddress = masterInfo.getLeaderMasterAddress();
     mWebPort = masterInfo.getWebPort();
     mRpcPort = masterInfo.getRpcPort();
-    mStarted = masterInfo.getStartTimeMs();
-    mUptime = masterInfo.getUpTimeMs();
+    mStartTime = masterInfo.getStartTimeMs();
+    mUptimeDuration = masterInfo.getUpTimeMs();
     mVersion = masterInfo.getVersion();
     mSafeMode = masterInfo.getSafeMode();
 
@@ -124,16 +124,16 @@ public class SummaryOutput {
     mLostWorkers = blockMasterInfo.getLostWorkerNum();
 
     mTotalCapacityOnTiers = new TreeMap<>();
+    Map<String, Long> totalBytesOnTiers = blockMasterInfo.getCapacityBytesOnTiers();
+    for (Map.Entry<String, Long> entry : totalBytesOnTiers.entrySet()){
+      mTotalCapacityOnTiers.put(entry.getKey() + "Bytes", entry.getValue());
+    }
     mUsedCapacityOnTiers = new TreeMap<>();
-    Map<String, Long> totalBytesOnTiers =
-        new TreeMap<>(FileSystemAdminShellUtils::compareTierNames);
-    totalBytesOnTiers.putAll(blockMasterInfo.getCapacityBytesOnTiers());
-    mTotalCapacityOnTiers.putAll(totalBytesOnTiers);
-    Map<String, Long> usedBytesOnTiers =
-        new TreeMap<>(FileSystemAdminShellUtils::compareTierNames);
-    usedBytesOnTiers.putAll(blockMasterInfo.getUsedBytesOnTiers());
-    mUsedCapacityOnTiers.putAll(usedBytesOnTiers);
-    mFreeCapacity = blockMasterInfo.getFreeBytes();
+    Map<String, Long> usedBytesOnTiers = blockMasterInfo.getUsedBytesOnTiers();
+    for (Map.Entry<String, Long> entry : usedBytesOnTiers.entrySet()){
+      mUsedCapacityOnTiers.put(entry.getKey() + "Bytes", entry.getValue());
+    }
+    mFreeCapacityBytes = blockMasterInfo.getFreeBytes();
   }
 
   /**
@@ -195,17 +195,17 @@ public class SummaryOutput {
    *
    * @return started time
    */
-  public long getStarted() {
-    return mStarted;
+  public long getStartTime() {
+    return mStartTime;
   }
 
   /**
    * Set started time.
    *
-   * @param started started time
+   * @param startTime started time
    */
-  public void setStarted(long started) {
-    mStarted = started;
+  public void setStartTime(long startTime) {
+    mStartTime = startTime;
   }
 
   /**
@@ -213,17 +213,17 @@ public class SummaryOutput {
    *
    * @return time running
    */
-  public long getUptime() {
-    return mUptime;
+  public long getUptimeDuration() {
+    return mUptimeDuration;
   }
 
   /**
    * Set time running.
    *
-   * @param uptime time running
+   * @param uptimeDuration time running
    */
-  public void setUptime(long uptime) {
-    mUptime = uptime;
+  public void setUptimeDuration(long uptimeDuration) {
+    mUptimeDuration = uptimeDuration;
   }
 
   /**
@@ -389,21 +389,21 @@ public class SummaryOutput {
   }
 
   /**
-   * Get free capacity.
+   * Get free capacity in bytes.
    *
    * @return free capacity
    */
-  public long getFreeCapacity() {
-    return mFreeCapacity;
+  public long getFreeCapacityBytes() {
+    return mFreeCapacityBytes;
   }
 
   /**
-   * Set free capacity.
+   * Set free capacity in bytes.
    *
-   * @param freeCapacity free capacity
+   * @param freeCapacityBytes free capacity
    */
-  public void setFreeCapacity(long freeCapacity) {
-    mFreeCapacity = freeCapacity;
+  public void setFreeCapacityBytes(long freeCapacityBytes) {
+    mFreeCapacityBytes = freeCapacityBytes;
   }
 
   /**

--- a/dora/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
+++ b/dora/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;

--- a/dora/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
+++ b/dora/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
@@ -94,8 +94,8 @@ public class JobServiceMetricsCommandTest {
 
     List<JobInfo> jobInfos = new ArrayList<>();
 
-    jobInfos.add(createJobInfo(1, "Test1", Status.RUNNING, "2019-10-17 12:00:00"));
-    jobInfos.add(createJobInfo(2, "Test2", Status.FAILED, "2019-10-17 12:30:15"));
+    jobInfos.add(new PlanInfo(1, "Test1", Status.RUNNING, 1547697600000L, null));
+    jobInfos.add(new PlanInfo(2, "Test2", Status.FAILED, 1547699415000L, null));
 
     Mockito.when(mJobMasterClient.getJobServiceSummary())
             .thenReturn(new JobServiceSummary(jobInfos));

--- a/dora/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
+++ b/dora/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
@@ -63,8 +63,7 @@ public class JobServiceMetricsCommandTest {
   @Test
   public void testBasic() throws IOException, ParseException {
     long now = Instant.now().toEpochMilli();
-    String startTimeStr = JobServiceMetricsCommand.DATETIME_FORMAT
-        .format(Instant.ofEpochMilli(now));
+    String startTimeStr = String.valueOf(now);
     JobMasterStatus primaryMaster = JobMasterStatus.newBuilder()
         .setMasterAddress(NetAddress.newBuilder()
             .setHost("master-node-1").setRpcPort(19998).build())
@@ -157,23 +156,23 @@ public class JobServiceMetricsCommandTest {
     JsonNode recentModifiedJobs = jsonNode.get("recentModifiedJobs");
     assertEquals("2", recentModifiedJobs.get(0).get("id").asText());
     assertEquals("FAILED", recentModifiedJobs.get(0).get("status").asText());
-    assertEquals("20190117-123015", recentModifiedJobs.get(0).get("timestamp").asText());
+    assertEquals("1547699415000", recentModifiedJobs.get(0).get("timestamp").asText());
     assertEquals("Test2", recentModifiedJobs.get(0).get("name").asText());
     assertEquals("1", recentModifiedJobs.get(1).get("id").asText());
     assertEquals("RUNNING", recentModifiedJobs.get(1).get("status").asText());
-    assertEquals("20190117-120000", recentModifiedJobs.get(1).get("timestamp").asText());
+    assertEquals("1547697600000", recentModifiedJobs.get(1).get("timestamp").asText());
     assertEquals("Test1", recentModifiedJobs.get(1).get("name").asText());
 
     JsonNode recentFailedJobs = jsonNode.get("recentFailedJobs");
     assertEquals("2", recentFailedJobs.get(0).get("id").asText());
     assertEquals("FAILED", recentFailedJobs.get(0).get("status").asText());
-    assertEquals("20190117-123015", recentFailedJobs.get(0).get("timestamp").asText());
+    assertEquals("1547699415000", recentFailedJobs.get(0).get("timestamp").asText());
     assertEquals("Test2", recentFailedJobs.get(0).get("name").asText());
 
     JsonNode longestRunningJobs = jsonNode.get("longestRunningJobs");
     assertEquals("1", longestRunningJobs.get(0).get("id").asText());
     assertEquals("RUNNING", longestRunningJobs.get(0).get("status").asText());
-    assertEquals("20190117-120000", longestRunningJobs.get(0).get("timestamp").asText());
+    assertEquals("1547697600000", longestRunningJobs.get(0).get("timestamp").asText());
     assertEquals("Test1", longestRunningJobs.get(0).get("name").asText());
   }
 

--- a/dora/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
+++ b/dora/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
@@ -155,23 +155,23 @@ public class JobServiceMetricsCommandTest {
     JsonNode recentModifiedJobs = jsonNode.get("recentModifiedJobs");
     assertEquals("2", recentModifiedJobs.get(0).get("id").asText());
     assertEquals("FAILED", recentModifiedJobs.get(0).get("status").asText());
-    assertEquals("1547699415000", recentModifiedJobs.get(0).get("timestamp").asText());
+    assertEquals("1547699415000", recentModifiedJobs.get(0).get("lastUpdatedTime").asText());
     assertEquals("Test2", recentModifiedJobs.get(0).get("name").asText());
     assertEquals("1", recentModifiedJobs.get(1).get("id").asText());
     assertEquals("RUNNING", recentModifiedJobs.get(1).get("status").asText());
-    assertEquals("1547697600000", recentModifiedJobs.get(1).get("timestamp").asText());
+    assertEquals("1547697600000", recentModifiedJobs.get(1).get("lastUpdatedTime").asText());
     assertEquals("Test1", recentModifiedJobs.get(1).get("name").asText());
 
     JsonNode recentFailedJobs = jsonNode.get("recentFailedJobs");
     assertEquals("2", recentFailedJobs.get(0).get("id").asText());
     assertEquals("FAILED", recentFailedJobs.get(0).get("status").asText());
-    assertEquals("1547699415000", recentFailedJobs.get(0).get("timestamp").asText());
+    assertEquals("1547699415000", recentFailedJobs.get(0).get("lastUpdatedTime").asText());
     assertEquals("Test2", recentFailedJobs.get(0).get("name").asText());
 
     JsonNode longestRunningJobs = jsonNode.get("longestRunningJobs");
     assertEquals("1", longestRunningJobs.get(0).get("id").asText());
     assertEquals("RUNNING", longestRunningJobs.get(0).get("status").asText());
-    assertEquals("1547697600000", longestRunningJobs.get(0).get("timestamp").asText());
+    assertEquals("1547697600000", longestRunningJobs.get(0).get("lastUpdatedTime").asText());
     assertEquals("Test1", longestRunningJobs.get(0).get("name").asText());
   }
 }

--- a/dora/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
+++ b/dora/shell/src/test/java/alluxio/cli/fsadmin/report/JobServiceMetricsCommandTest.java
@@ -175,11 +175,4 @@ public class JobServiceMetricsCommandTest {
     assertEquals("1547697600000", longestRunningJobs.get(0).get("timestamp").asText());
     assertEquals("Test1", longestRunningJobs.get(0).get("name").asText());
   }
-
-  private JobInfo createJobInfo(int id, String name, Status status, String datetime)
-      throws ParseException {
-    long timeMillis = new SimpleDateFormat("yyyy-mm-dd HH:mm:ss").parse(datetime).getTime();
-    PlanInfo jobInfo = new PlanInfo(id, name, status, timeMillis, null);
-    return jobInfo;
-  }
 }

--- a/dora/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
+++ b/dora/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
@@ -185,8 +185,8 @@ public class SummaryCommandTest {
     assertEquals("1231", jsonNode.get("webPort").asText());
     assertEquals("8462", jsonNode.get("rpcPort").asText());
     assertEquals("testVersion", jsonNode.get("version").asText());
-    assertEquals("1131242343122", jsonNode.get("started").asText());
-    assertEquals("12412412312", jsonNode.get("uptime").asText());
+    assertEquals("1131242343122", jsonNode.get("startTime").asText());
+    assertEquals("12412412312", jsonNode.get("uptimeDuration").asText());
     assertEquals("false", jsonNode.get("safeMode").asText());
 
     // check zookeeper and raft
@@ -215,12 +215,12 @@ public class SummaryCommandTest {
     // check worker
     assertEquals("12", jsonNode.get("liveWorkers").asText());
     assertEquals("4", jsonNode.get("lostWorkers").asText());
-    assertEquals("1278919", jsonNode.get("freeCapacity").asText());
-    assertEquals("236501", jsonNode.get("totalCapacityOnTiers").get("DOM").asText());
-    assertEquals("1341353", jsonNode.get("totalCapacityOnTiers").get("MEM").asText());
-    assertEquals("23112", jsonNode.get("totalCapacityOnTiers").get("RAM").asText());
-    assertEquals("74235", jsonNode.get("usedCapacityOnTiers").get("DOM").asText());
-    assertEquals("62434", jsonNode.get("usedCapacityOnTiers").get("MEM").asText());
-    assertEquals("6243", jsonNode.get("usedCapacityOnTiers").get("RAM").asText());
+    assertEquals("1278919", jsonNode.get("freeCapacityBytes").asText());
+    assertEquals("236501", jsonNode.get("totalCapacityOnTiers").get("DOMBytes").asText());
+    assertEquals("1341353", jsonNode.get("totalCapacityOnTiers").get("MEMBytes").asText());
+    assertEquals("23112", jsonNode.get("totalCapacityOnTiers").get("RAMBytes").asText());
+    assertEquals("74235", jsonNode.get("usedCapacityOnTiers").get("DOMBytes").asText());
+    assertEquals("62434", jsonNode.get("usedCapacityOnTiers").get("MEMBytes").asText());
+    assertEquals("6243", jsonNode.get("usedCapacityOnTiers").get("RAMBytes").asText());
   }
 }

--- a/dora/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
+++ b/dora/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
@@ -27,7 +27,6 @@ import alluxio.conf.PropertyKey;
 import alluxio.grpc.MasterInfo;
 import alluxio.grpc.MasterVersion;
 import alluxio.grpc.NetAddress;
-import alluxio.util.CommonUtils;
 import alluxio.wire.BlockMasterInfo;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -183,13 +182,11 @@ public class SummaryCommandTest {
 
     // check cluster summary
     // Skip checking startTime which relies on system time zone
-    String startTime =  CommonUtils.convertMsToDate(1131242343122L, dateFormatPattern);
     assertEquals("1231", jsonNode.get("webPort").asText());
     assertEquals("8462", jsonNode.get("rpcPort").asText());
     assertEquals("testVersion", jsonNode.get("version").asText());
-    assertEquals(startTime, jsonNode.get("started").asText());
-    assertEquals("143 day(s), 15 hour(s), 53 minute(s), and 32 second(s)",
-        jsonNode.get("uptime").asText());
+    assertEquals("1131242343122", jsonNode.get("started").asText());
+    assertEquals("12412412312", jsonNode.get("uptime").asText());
     assertEquals("false", jsonNode.get("safeMode").asText());
 
     // check zookeeper and raft
@@ -218,12 +215,12 @@ public class SummaryCommandTest {
     // check worker
     assertEquals("12", jsonNode.get("liveWorkers").asText());
     assertEquals("4", jsonNode.get("lostWorkers").asText());
-    assertEquals("1248.94KB", jsonNode.get("freeCapacity").asText());
-    assertEquals("230.96KB", jsonNode.get("totalCapacityOnTiers").get("DOM").asText());
-    assertEquals("1309.92KB", jsonNode.get("totalCapacityOnTiers").get("MEM").asText());
-    assertEquals("22.57KB", jsonNode.get("totalCapacityOnTiers").get("RAM").asText());
-    assertEquals("72.50KB", jsonNode.get("usedCapacityOnTiers").get("DOM").asText());
-    assertEquals("60.97KB", jsonNode.get("usedCapacityOnTiers").get("MEM").asText());
-    assertEquals("6.10KB", jsonNode.get("usedCapacityOnTiers").get("RAM").asText());
+    assertEquals("1278919", jsonNode.get("freeCapacity").asText());
+    assertEquals("236501", jsonNode.get("totalCapacityOnTiers").get("DOM").asText());
+    assertEquals("1341353", jsonNode.get("totalCapacityOnTiers").get("MEM").asText());
+    assertEquals("23112", jsonNode.get("totalCapacityOnTiers").get("RAM").asText());
+    assertEquals("74235", jsonNode.get("usedCapacityOnTiers").get("DOM").asText());
+    assertEquals("62434", jsonNode.get("usedCapacityOnTiers").get("MEM").asText());
+    assertEquals("6243", jsonNode.get("usedCapacityOnTiers").get("RAM").asText());
   }
 }


### PR DESCRIPTION
For now, Java is in charge of formatting the output of reports, e.g. file size in bytes to readable values; date formats.

This PR moves the format job to the golang CLI side. When checking reports, data transferred to golang CLI, and CLI deal with the formatting.

Current date format: `2006-01-02T15:04:05Z07:00`
Current duration format: `0d 12h34m56s`
Current file size format: `1024.00MB` (scale up when number > 5120)

Format on dates:
- `summary` object -> `started` object
- `job_service` object -> `masterStatus` array -> `startTime` object
- `job_service` object -> `recentModifiedJobs` array -> `timestamp` object
- `job_service` object -> `recentFailedJobs` array -> `timestamp` object
- `job_service` object -> `longestRunningJobs` array -> `timestamp` object

Format on duration:
- `summary` object -> `uptime` object

Format on file size:
- `summary` object -> `freeCapacity` object
- `summary` object -> `totalCapacityOnTiers` map
- `summary` object -> `usedCapacityOnTiers` map
- `ufs` map -> `ufsCapacityBytes` object
- `ufs` map -> `ufsUsedBytes` object