### PR TITLE
Fix `NoClassDefFoundError` UnderFileSystemFactory not loaded

### DIFF
--- a/dora/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
+++ b/dora/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
@@ -241,8 +241,12 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>,
         URL extensionURL = jar.toURI().toURL();
         String jarPath = extensionURL.toString();
 
+        ClassLoader defaultClassLoader =
+            Thread.currentThread().getContextClassLoader() == null
+                ? ClassLoader.getSystemClassLoader()
+                : Thread.currentThread().getContextClassLoader();
         ClassLoader extensionsClassLoader = new ExtensionsClassLoader(new URL[] {extensionURL},
-            Thread.currentThread().getContextClassLoader());
+            defaultClassLoader);
         ServiceLoader<T> extensionServiceLoader =
             ServiceLoader.load(mFactoryClass, extensionsClassLoader);
         for (T factory : extensionServiceLoader) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix UFS not loaded in some cases.

### Why are the changes needed?

Fix the following error when loading `UnderFileSystemFactory`:

```
java.lang.NoClassDefFoundError: alluxio/underfs/UnderFileSystemFactory
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at alluxio.extensions.ExtensionsClassLoader.findClass(ExtensionsClassLoader.java:73)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at alluxio.extensions.ExtensionsClassLoader.loadClass(ExtensionsClassLoader.java:82)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:370)
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
	at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
	at alluxio.extensions.ExtensionFactoryRegistry.scan(ExtensionFactoryRegistry.java:248)
	at alluxio.extensions.ExtensionFactoryRegistry.scanLibs(ExtensionFactoryRegistry.java:229)
	at alluxio.extensions.ExtensionFactoryRegistry.findAllWithRecorder(ExtensionFactoryRegistry.java:149)
	at alluxio.underfs.UnderFileSystemFactoryRegistry.findAllWithRecorder(UnderFileSystemFactoryRegistry.java:115)
	at alluxio.underfs.UnderFileSystem$Factory.createWithRecorder(UnderFileSystem.java:111)
	at alluxio.underfs.UnderFileSystem$Factory.create(UnderFileSystem.java:93)
```

This was because when `Thread.currentThread().getContextClassLoader()` is null, it indicates that the class loader is actually the system class loader. If using `null` for the default class loader, it will not be able to resolve `UnderFileSystemFactory` which was already loaded by the system class loader.

### Does this PR introduce any user facing changes?
No.