### PR TITLE
return an all zero fsstat

### DIFF
--- a/dora/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -113,6 +113,8 @@ public class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem {
   private final boolean mUfsEnabled;
   private final FuseOptions mFuseOptions;
 
+  private static final BlockMasterInfo ZERO_BLOCK_MASTER_INFO = new BlockMasterInfo();
+
   /** df command will treat -1 as an unknown value. */
   @VisibleForTesting
   public static final int UNKNOWN_INODES = -1;
@@ -651,7 +653,9 @@ public class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem {
     if (res != 0) {
       return res;
     }
-    BlockMasterInfo info = mFsStatCache.get();
+
+    // Alluxio does not keep valid nor useful block info at this moment.
+    BlockMasterInfo info = ZERO_BLOCK_MASTER_INFO;
     if (info == null) {
       LOG.error("Failed to statfs {}: cannot get block master info", path);
       return -ErrorCodes.EIO();


### PR DESCRIPTION
Alluxio does not have a valid Block Info at this moment.

### What changes are proposed in this pull request?

return an all zero block info for fsstat

### Why are the changes needed?

No valid block info is managed by Alluxio at this moment.
Alluxio does not have 'master' node, and no block info is stored/managed by other components.

This may change in future, e.g. statfs() can gather the block info from all worker nodes.

### Does this PR introduce any user facing changes?

N/A
