### PR TITLE
Modify StressWorkerBench: calculate elapsed time in nanoseconds

### DIFF
--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
@@ -36,31 +36,8 @@ public class WorkerBenchDataPoint {
     mIOBytes = ioBytes;
   }
 
-  /**
-   * @return number of files read
-   */
-  public long getCount() {
-    return mCount;
-  }
-
-  /**
-   * @return total bytes read
-   */
-  public long getIOBytes() {
-    return mIOBytes;
-  }
-
-  /**
-   * @param count number of files read
-   */
-  public void setCount(long count) {
-    mCount = count;
-  }
-
-  /**
-   * @param ioBytes bytes read
-   */
-  public void setIOBytes(long ioBytes) {
-    mIOBytes = ioBytes;
+  public WorkerBenchDataPoint() {
+    mCount = 0;
+    mIOBytes = 0;
   }
 }

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchDataPoint.java
@@ -36,6 +36,9 @@ public class WorkerBenchDataPoint {
     mIOBytes = ioBytes;
   }
 
+  /**
+   * A constructor without parameters.
+   */
   public WorkerBenchDataPoint() {
     mCount = 0;
     mIOBytes = 0;

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -381,8 +381,7 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
 
     public synchronized void mergeThreadResult(WorkerBenchTaskResult threadResult) {
       if (mResult == null) {
-        mResult = threadResult;
-        return;
+        mResult = new WorkerBenchTaskResult();
       }
       try {
         mResult.merge(threadResult);


### PR DESCRIPTION
For now StressWorkerBench uses milliseconds as the smallest unit of recording. In random read, if file is very small, it is possible to have a duration <1ms. Since instant throughput = bytes read / duration, it will lead to a divide by zero error.
This PR replace millisecond-level record of a file read with a nanosecond-level approach. It also makes the following updates on StressWorkerBench:
- record file read time within `applyOperation()` function, instead of before entering or after exiting it
- wrap metrics about the `applyOperation()` function to a private class, instead of returning bytes read only
- remove getter and setters for WorkerBenchDataPoint, since all elements inside is public
- standardize the unit of output throughput, now unit is MB/s