### PR TITLE
Enable config the virtual nodes num per node

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashPolicy.java
@@ -46,7 +46,7 @@ public class ConsistentHashPolicy implements WorkerLocationPolicy {
    * @param conf the configuration used by the policy
    */
   public ConsistentHashPolicy(AlluxioConfiguration conf) {
-    mNumVirtualNodes = conf.getInt(PropertyKey.USER_CONSISTENT_HASH_VIRTUAL_NODE_COUNT);
+    mNumVirtualNodes = conf.getInt(PropertyKey.USER_CONSISTENT_HASH_VIRTUAL_NODE_COUNT_PER_WORKER);
   }
 
   @Override

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashProvider.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashProvider.java
@@ -12,7 +12,6 @@
 package alluxio.client.file.dora;
 
 import static com.google.common.hash.Hashing.murmur3_32_fixed;
-import static java.lang.Math.ceil;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashProvider.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashProvider.java
@@ -241,9 +241,8 @@ public class ConsistentHashProvider {
           List<BlockWorkerInfo> workerInfos, int numVirtualNodes) {
     Preconditions.checkArgument(!workerInfos.isEmpty(), "worker list is empty");
     NavigableMap<Integer, BlockWorkerInfo> activeNodesByConsistentHashing = new TreeMap<>();
-    int weight = (int) ceil(1.0 * numVirtualNodes / workerInfos.size());
     for (BlockWorkerInfo workerInfo : workerInfos) {
-      for (int i = 0; i < weight; i++) {
+      for (int i = 0; i < numVirtualNodes; i++) {
         activeNodesByConsistentHashing.put(
             HASH_FUNCTION.hashString(format("%s%d", workerInfo.getNetAddress().dumpMainInfo(), i),
                 UTF_8).asInt(),

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5594,11 +5594,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey USER_CONSISTENT_HASH_VIRTUAL_NODE_COUNT =
-      intBuilder(Name.USER_CONSISTENT_HASH_VIRTUAL_NODE_COUNT)
+  public static final PropertyKey USER_CONSISTENT_HASH_VIRTUAL_NODE_COUNT_PER_WORKER =
+      intBuilder(Name.USER_CONSISTENT_HASH_VIRTUAL_NODE_COUNT_PER_WORKER)
           .setDefaultValue(2000)
-          .setDescription("This is the number of virtual nodes in the consistent hashing "
-              + "algorithm. In a consistent hashing algorithm, on membership changes, some "
+          .setDescription("This is the number of virtual nodes for one worker in the consistent "
+              + "hashing algorithm. In a consistent hashing algorithm, on membership changes, some "
               + "virtual nodes are re-distributed instead of rebuilding the whole hash table. "
               + "This guarantees the hash table is changed only in a minimal. In order to achieve "
               + "that, the number of virtual nodes should be X times the physical nodes in "
@@ -8160,8 +8160,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.client.cache.timeout.threads";
     public static final String USER_CLIENT_REPORT_VERSION_ENABLED =
         "alluxio.user.client.report.version.enabled";
-    public static final String USER_CONSISTENT_HASH_VIRTUAL_NODE_COUNT =
-        "alluxio.user.consistent.hash.virtual.node.count";
+    public static final String USER_CONSISTENT_HASH_VIRTUAL_NODE_COUNT_PER_WORKER =
+        "alluxio.user.consistent.hash.virtual.node.count.per.worker";
     public static final String USER_CONF_CLUSTER_DEFAULT_ENABLED =
         "alluxio.user.conf.cluster.default.enabled";
     public static final String USER_CONF_SYNC_INTERVAL = "alluxio.user.conf.sync.interval";


### PR DESCRIPTION
The configuration `alluxio.user.consistent.hash.virtual.node.count` is for total virtual nodes of all workers. We need to adjust the configuration according to the number of worker nodes. However, it is difficult to determine how many virtual nodes are enough to avoid the data skew issue.

Based on this background, a better way to solve the data skew issue is to allow user to set the virtual nodes number for a worker node, but not the total virtual nodes of all worker nodes. This is what this PR does.