### PR TITLE
Split the fuse stream close() method

### DIFF
--- a/dora/core/common/src/main/java/alluxio/resource/CloseableResource.java
+++ b/dora/core/common/src/main/java/alluxio/resource/CloseableResource.java
@@ -31,6 +31,8 @@ public abstract class CloseableResource<T> implements Closeable {
 
   private final T mResource;
 
+  private boolean mClosed = false;
+
   @Nullable
   private final ResourceLeakTracker<CloseableResource> mTracker = DETECTOR.track(this);
 
@@ -57,10 +59,18 @@ public abstract class CloseableResource<T> implements Closeable {
       mTracker.close(this);
     }
     closeResource();
+    mClosed = true;
   }
 
   /**
    * Performs any cleanup operations necessary when the resource is no longer in use.
    */
   public abstract void closeResource();
+
+  /**
+   * @return if the resource has been closed
+   */
+  public boolean isClosed() {
+    return mClosed;
+  }
 }

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -150,15 +150,33 @@ public class FuseFileInOrOutStream implements FuseFileStream {
 
   @Override
   public synchronized void close() {
+    try {
+      closeStream();
+    } finally {
+      releaseLock();
+    }
+  }
+
+  @Override
+  public synchronized void releaseLock() {
+    if (mInStream.isPresent()) {
+      mInStream.get().releaseLock();
+      return;
+    }
+    mOutStream.ifPresent(FuseFileOutStream::releaseLock);
+  }
+
+  @Override
+  public synchronized void closeStream() {
     if (mClosed) {
       return;
     }
     mClosed = true;
     if (mInStream.isPresent()) {
-      mInStream.get().close();
+      mInStream.get().closeStream();
       return;
     }
-    mOutStream.ifPresent(FuseFileOutStream::close);
+    mOutStream.ifPresent(FuseFileOutStream::closeStream);
   }
 
   @Override

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
@@ -149,6 +149,15 @@ public class FuseFileInStream implements FuseFileStream {
 
   @Override
   public synchronized void close() {
+    try {
+      closeStream();
+    } finally {
+      releaseLock();
+    }
+  }
+
+  @Override
+  public synchronized void closeStream() {
     if (mClosed) {
       return;
     }
@@ -157,7 +166,12 @@ public class FuseFileInStream implements FuseFileStream {
       mInStream.close();
     } catch (IOException e) {
       throw AlluxioRuntimeException.from(e);
-    } finally {
+    }
+  }
+
+  @Override
+  public synchronized void releaseLock() {
+    if (!mLockResource.isClosed()) {
       mLockResource.close();
     }
   }

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -69,6 +69,7 @@ public class FuseFileOutStream implements FuseFileStream {
    */
   public static FuseFileOutStream create(FileSystem fileSystem, AuthPolicy authPolicy,
       FuseReadWriteLockManager lockManager, AlluxioURI uri, int flags, long mode) {
+    System.out.println("Creating file system for " + uri.toString());
     Preconditions.checkNotNull(fileSystem);
     Preconditions.checkNotNull(authPolicy);
     Preconditions.checkNotNull(lockManager);
@@ -216,15 +217,27 @@ public class FuseFileOutStream implements FuseFileStream {
 
   @Override
   public synchronized void close() {
+    try {
+      closeStream();
+    } finally {
+      releaseLock();
+    }
+  }
+
+  @Override
+  public synchronized void releaseLock() {
+    if (!mLockResource.isClosed()) {
+      mLockResource.close();
+    }
+  }
+
+  @Override
+  public synchronized void closeStream() {
     if (mClosed) {
       return;
     }
     mClosed = true;
-    try {
-      closeStreams();
-    } finally {
-      mLockResource.close();
-    }
+    closeStreams();
   }
 
   @Override

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
@@ -55,7 +55,7 @@ public interface FuseFileStream extends AutoCloseable {
   void truncate(long size);
 
   /**
-   * Closes the stream.
+   * Closes the stream and releases the lock.
    */
   void close();
 
@@ -68,4 +68,14 @@ public interface FuseFileStream extends AutoCloseable {
    * @return if this stream is for read only
    */
   boolean isReadOnly();
+
+  /**
+   * Releases the lock resource the stream obtained.
+   */
+  void releaseLock();
+
+  /**
+   * Closes the stream without releasing the locking resource.
+   */
+  void closeStream();
 }

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReadOrOutStream.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReadOrOutStream.java
@@ -186,7 +186,9 @@ public class FusePositionReadOrOutStream implements FuseFileStream {
       mPositionReader.get().releaseLock();
       return;
     }
-    mOutStream.ifPresent(FuseFileOutStream::releaseLock);
+    synchronized (this) {
+      mOutStream.ifPresent(FuseFileOutStream::releaseLock);
+    }
   }
 
   @Override
@@ -199,6 +201,8 @@ public class FusePositionReadOrOutStream implements FuseFileStream {
       mPositionReader.get().closeStream();
       return;
     }
-    mOutStream.ifPresent(FuseFileOutStream::closeStream);
+    synchronized (this) {
+      mOutStream.ifPresent(FuseFileOutStream::closeStream);
+    }
   }
 }

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReadOrOutStream.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReadOrOutStream.java
@@ -146,15 +146,11 @@ public class FusePositionReadOrOutStream implements FuseFileStream {
 
   @Override
   public void close() {
-    if (mClosed) {
-      return;
+    try {
+      closeStream();
+    } finally {
+      releaseLock();
     }
-    mClosed = true;
-    if (mPositionReader.isPresent()) {
-      mPositionReader.get().close();
-      return;
-    }
-    mOutStream.ifPresent(FuseFileOutStream::close);
   }
 
   private synchronized FusePositionReader getOrInitPrositionReader() {
@@ -182,5 +178,27 @@ public class FusePositionReadOrOutStream implements FuseFileStream {
   @Override
   public boolean isReadOnly() {
     return false;
+  }
+
+  @Override
+  public void releaseLock() {
+    if (mPositionReader.isPresent()) {
+      mPositionReader.get().releaseLock();
+      return;
+    }
+    mOutStream.ifPresent(FuseFileOutStream::releaseLock);
+  }
+
+  @Override
+  public void closeStream() {
+    if (mClosed) {
+      return;
+    }
+    mClosed = true;
+    if (mPositionReader.isPresent()) {
+      mPositionReader.get().closeStream();
+      return;
+    }
+    mOutStream.ifPresent(FuseFileOutStream::closeStream);
   }
 }

--- a/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReader.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/file/FusePositionReader.java
@@ -124,16 +124,10 @@ public class FusePositionReader implements FuseFileStream {
 
   @Override
   public synchronized void close() {
-    if (mClosed) {
-      return;
-    }
-    mClosed = true;
     try {
-      mPositionReader.close();
-    } catch (IOException e) {
-      throw AlluxioRuntimeException.from(e);
+      closeStream();
     } finally {
-      mLockResource.close();
+      releaseLock();
     }
   }
 
@@ -145,5 +139,25 @@ public class FusePositionReader implements FuseFileStream {
   @Override
   public boolean isReadOnly() {
     return true;
+  }
+
+  @Override
+  public synchronized void releaseLock() {
+    if (!mLockResource.isClosed()) {
+      mLockResource.close();
+    }
+  }
+
+  @Override
+  public synchronized void closeStream() {
+    if (mClosed) {
+      return;
+    }
+    mClosed = true;
+    try {
+      mPositionReader.close();
+    } catch (IOException e) {
+      throw AlluxioRuntimeException.from(e);
+    }
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Split the fuse stream close() method into two individual methods:
1. Close the fuse stream
2. Release the lock

Currently no behavior changes on the close function as the function will call these two functions to achieve the same functionality as before. 

### Why are the changes needed?

When we handle some fuse operations, we sometimes want to close the stream only but want to keep the lock there, to avoid inconsistency.  

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  3. addition or removal of property keys
  4. webui
