### PR TITLE
Enable static consistent hash ring

### DIFF
--- a/common/transport/src/main/proto/grpc/block_master.proto
+++ b/common/transport/src/main/proto/grpc/block_master.proto
@@ -158,6 +158,11 @@ service BlockMasterClientService {
   rpc GetWorkerInfoList(GetWorkerInfoListPOptions) returns (GetWorkerInfoListPResponse);
 
   /**
+ * Returns a list of workers information.
+ */
+  rpc GetLostWorkerList(GetWorkerInfoListPOptions) returns (GetWorkerInfoListPResponse);
+
+  /**
    * If target worker is in the decommissioned worker set,
    * return true, remove target worker from decommissioned worker set; else, return false.
    */

--- a/dora/core/client/fs/src/main/java/alluxio/client/block/BlockMasterClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/block/BlockMasterClient.java
@@ -60,6 +60,13 @@ public interface BlockMasterClient extends Client {
   List<WorkerInfo> getWorkerInfoList() throws IOException;
 
   /**
+   * Gets the worker information of lost workers.
+   *
+   * @return a list of lost worker information
+   */
+  List<WorkerInfo> getLostWorkerInfoList() throws IOException;
+
+  /**
    * Revert disabling a worker, enabling it to register to the cluster.
    *
    * @param options contains the info used to find the target worker(s)

--- a/dora/core/client/fs/src/main/java/alluxio/client/block/BlockWorkerInfo.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/block/BlockWorkerInfo.java
@@ -29,6 +29,8 @@ public final class BlockWorkerInfo {
   private final long mCapacityBytes;
   private final long mUsedBytes;
 
+  private final boolean mActive;
+
   /**
    * Constructs the block worker information.
    *
@@ -37,9 +39,23 @@ public final class BlockWorkerInfo {
    * @param usedBytes the used bytes of the worker
    */
   public BlockWorkerInfo(WorkerNetAddress netAddress, long capacityBytes, long usedBytes) {
+    this(netAddress, capacityBytes, usedBytes, true);
+  }
+
+  /**
+   * Constructs the block worker information.
+   *
+   * @param netAddress the address of the worker
+   * @param capacityBytes the capacity of the worker in bytes
+   * @param usedBytes the used bytes of the worker
+   * @param active whether this worker is active or not
+   */
+  public BlockWorkerInfo(WorkerNetAddress netAddress, long capacityBytes, long usedBytes,
+                         boolean active) {
     mNetAddress = Preconditions.checkNotNull(netAddress, "netAddress");
     mCapacityBytes = capacityBytes;
     mUsedBytes = usedBytes;
+    mActive = active;
   }
 
   /**
@@ -63,12 +79,21 @@ public final class BlockWorkerInfo {
     return mUsedBytes;
   }
 
+  /**
+   * Whether this worker is active or not.
+   * @return whether this worker is active or not
+   */
+  public boolean isActive() {
+    return mActive;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("netAddress", mNetAddress)
         .add("capacityBytes", mCapacityBytes)
         .add("usedBytes", mUsedBytes)
+        .add("active", mActive)
         .toString();
   }
 }

--- a/dora/core/client/fs/src/main/java/alluxio/client/block/RetryHandlingBlockMasterClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/block/RetryHandlingBlockMasterClient.java
@@ -121,6 +121,19 @@ public final class RetryHandlingBlockMasterClient extends AbstractMasterClient
   }
 
   @Override
+  public List<WorkerInfo> getLostWorkerInfoList() throws IOException {
+    return retryRPC(() -> {
+      List<WorkerInfo> result = new ArrayList<>();
+      for (alluxio.grpc.WorkerInfo workerInfo : mClient
+          .getLostWorkerList(GetWorkerInfoListPOptions.getDefaultInstance())
+          .getWorkerInfosList()) {
+        result.add(GrpcUtils.fromProto(workerInfo));
+      }
+      return result;
+    }, RPC_LOG, "GetLostWorkerInfoList", "");
+  }
+
+  @Override
   public void removeDisabledWorker(RemoveDisabledWorkerPOptions options) throws IOException {
     retryRPC(() -> mClient.removeDisabledWorker(options),
             RPC_LOG, "RemoveDisabledWorker", "");

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -64,7 +64,9 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -186,6 +188,15 @@ public class FileSystemContext implements Closeable {
   private final RefreshPolicy mWorkerRefreshPolicy;
 
   private final List<InetSocketAddress> mMasterAddresses;
+
+  /**
+   * This enum class is used for specifying the type of worker list to get.
+   */
+  public enum GetWorkerListType {
+    ALL,
+    LIVE,
+    LOST
+  }
 
   /**
    * FileSystemContextFactory, it can be extended.
@@ -833,48 +844,143 @@ public class FileSystemContext implements Closeable {
   }
 
   /**
-   * Gets the cached worker information list.
+   * Gets the cached live worker information list.
    * This method is relatively cheap as the result is cached, but may not
    * be up-to-date. If up-to-date worker info list is required,
-   * use {@link #getAllWorkers()} instead.
-   *
+   * use {@link #getLiveWorkers()} ()} instead.
    * @return the info of all block workers eligible for reads and writes
    */
   public List<BlockWorkerInfo> getCachedWorkers() throws IOException {
+    return getCachedWorkers(GetWorkerListType.LIVE);
+  }
+
+  /**
+   * Gets the cached worker information list.
+   * This method is relatively cheap as the result is cached, but may not
+   * be up-to-date. If up-to-date worker info list is required,
+   * use {@link #getAllWorkers()}, {@link #getLiveWorkers()} ()}
+   * or {@link #getLostWorkers()} ()} instead.
+   *
+   * @param type get worker list type
+   * @return the info of all block workers eligible for reads and writes
+   */
+  public List<BlockWorkerInfo> getCachedWorkers(GetWorkerListType type) throws IOException {
     synchronized (mWorkerInfoList) {
       if (mWorkerInfoList.get() == null || mWorkerInfoList.get().isEmpty()
           || mWorkerRefreshPolicy.attempt()) {
-        mWorkerInfoList.set(getAllWorkers());
+        switch (type) {
+          case ALL:
+            mWorkerInfoList.set(getAllWorkers());
+            break;
+          case LIVE:
+            mWorkerInfoList.set(getLiveWorkers());
+            break;
+          case LOST:
+            mWorkerInfoList.set(getLostWorkers());
+            break;
+          default:
+        }
       }
       return mWorkerInfoList.get();
     }
   }
 
   /**
-   * Gets the worker information list.
-   * This method is more expensive than {@link #getCachedWorkers()}.
+   * Gets the live worker information list.
+   * This method is more expensive than {@link #getCachedWorkers(GetWorkerListType)}.
    * Used when more up-to-date data is needed.
    *
-   * @return the info of all block workers
+   * @return the info of live workers
    */
-  protected List<BlockWorkerInfo> getAllWorkers() throws IOException {
-    // TODO(lucy) once ConfigHashSync reinit is gotten rid of, will remove the blockReinit
-    // guard altogether
+  public List<BlockWorkerInfo> getLiveWorkers() throws IOException {
     try (ReinitBlockerResource r = blockReinit()) {
       // Use membership mgr
       if (mMembershipManager != null && !(mMembershipManager instanceof MasterMembershipManager)) {
-        return mMembershipManager.getAllMembers().stream()
-            .map(w -> new BlockWorkerInfo(w.getAddress(), w.getCapacityBytes(), w.getUsedBytes()))
-            .collect(toList());
+        return mMembershipManager.getLiveMembers().stream()
+            .map(w -> new BlockWorkerInfo(w.getAddress(), w.getCapacityBytes(), w.getUsedBytes(),
+                true)).collect(toList());
       }
     }
     // Fall back to old way
     try (CloseableResource<BlockMasterClient> masterClientResource =
              acquireBlockMasterClientResource()) {
       return masterClientResource.get().getWorkerInfoList().stream()
-          .map(w -> new BlockWorkerInfo(w.getAddress(), w.getCapacityBytes(), w.getUsedBytes()))
-          .collect(toList());
+          .map(w -> new BlockWorkerInfo(w.getAddress(), w.getCapacityBytes(), w.getUsedBytes(),
+              true)).collect(toList());
     }
+  }
+
+  /**
+   * Gets the lost worker information list.
+   * This method is more expensive than {@link #getCachedWorkers(GetWorkerListType)}.
+   * Used when more up-to-date data is needed.
+   *
+   * @return the info of lost workers
+   */
+  public List<BlockWorkerInfo> getLostWorkers() throws IOException {
+    try (ReinitBlockerResource r = blockReinit()) {
+      // Use membership mgr
+      if (mMembershipManager != null && !(mMembershipManager instanceof MasterMembershipManager)) {
+        return mMembershipManager.getFailedMembers().stream()
+            .map(w -> new BlockWorkerInfo(w.getAddress(), w.getCapacityBytes(), w.getUsedBytes(),
+                false)).collect(toList());
+      }
+    }
+    // Fall back to old way
+    try (CloseableResource<BlockMasterClient> masterClientResource =
+             acquireBlockMasterClientResource()) {
+      return masterClientResource.get().getLostWorkerInfoList().stream()
+          .map(w -> new BlockWorkerInfo(w.getAddress(), w.getCapacityBytes(), w.getUsedBytes(),
+              false)).collect(toList());
+    }
+  }
+
+  /**
+   * Gets the worker information list.
+   * This method is more expensive than {@link #getCachedWorkers(GetWorkerListType)}.
+   * Used when more up-to-date data is needed.
+   *
+   * @return the info of all workers
+   */
+  public List<BlockWorkerInfo> getAllWorkers() throws IOException {
+    // TODO(lucy) once ConfigHashSync reinit is gotten rid of, will remove the blockReinit
+    // guard altogether
+    try (ReinitBlockerResource r = blockReinit()) {
+      // Use membership mgr
+      if (mMembershipManager != null && !(mMembershipManager instanceof MasterMembershipManager)) {
+        List<BlockWorkerInfo> liveWorkers = mMembershipManager.getLiveMembers().stream()
+            .map(w -> new BlockWorkerInfo(w.getAddress(), w.getCapacityBytes(), w.getUsedBytes(),
+                true)).collect(toList());
+        List<BlockWorkerInfo> lostWorkers = mMembershipManager.getFailedMembers().stream()
+            .map(w -> new BlockWorkerInfo(w.getAddress(), w.getCapacityBytes(), w.getUsedBytes(),
+                false)).collect(toList());
+        // avoid duplicate elements in list
+        return combineAllWorkers(liveWorkers, lostWorkers);
+      }
+    }
+
+    // Fall back to old way
+    try (CloseableResource<BlockMasterClient> masterClientResource =
+             acquireBlockMasterClientResource()) {
+      List<BlockWorkerInfo> liveWorkers = masterClientResource.get().getWorkerInfoList().stream()
+          .map(w -> new BlockWorkerInfo(w.getAddress(), w.getCapacityBytes(), w.getUsedBytes(),
+              true)).collect(toList());
+      List<BlockWorkerInfo> lostWorkers = masterClientResource.get().getLostWorkerInfoList()
+          .stream().map(w -> new BlockWorkerInfo(w.getAddress(), w.getCapacityBytes(),
+              w.getUsedBytes(), false)).collect(toList());
+      // avoid duplicate elements in list
+      return combineAllWorkers(liveWorkers, lostWorkers);
+    }
+  }
+
+  private List<BlockWorkerInfo> combineAllWorkers(List<BlockWorkerInfo> liveWorkers,
+                                                  List<BlockWorkerInfo> lostWorkers) {
+    Map<WorkerNetAddress, BlockWorkerInfo> allWorkersMap = new HashMap();
+    liveWorkers.forEach(liveWorker ->
+        allWorkersMap.put(liveWorker.getNetAddress(), liveWorker));
+    lostWorkers.forEach(lostWorker ->
+        allWorkersMap.put(lostWorker.getNetAddress(), lostWorker));
+    return new ArrayList<>(allWorkersMap.values());
   }
 
   protected ConcurrentHashMap<ClientPoolKey, BlockWorkerClientPool> getBlockWorkerClientPoolMap() {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
@@ -82,6 +82,8 @@ public class DoraCacheClient {
 
   private final int mPreferredWorkerCount;
 
+  private final boolean mEnableDynamicHashRing;
+
   /**
    * Constructor.
    *
@@ -94,6 +96,8 @@ public class DoraCacheClient {
         PropertyKey.USER_STREAMING_READER_CHUNK_SIZE_BYTES);
     mNettyTransEnabled =
         context.getClusterConf().getBoolean(PropertyKey.USER_NETTY_DATA_TRANSMISSION_ENABLED);
+    mEnableDynamicHashRing =
+        context.getClusterConf().getBoolean(PropertyKey.USER_DYNAMIC_CONSISTENT_HASH_RING_ENABLED);
     int minReplicaCount = context.getClusterConf().getInt(PropertyKey.USER_FILE_REPLICATION_MIN);
     mPreferredWorkerCount = Math.max(1, minReplicaCount);
   }
@@ -262,7 +266,7 @@ public class DoraCacheClient {
   public Map<String, List<WorkerNetAddress>> checkFileLocation(String path,
       GetStatusPOptions options) throws IOException {
     Map<String, List<WorkerNetAddress>> pathDistributionMap = new HashMap<>();
-    List<BlockWorkerInfo> workers = mContext.getCachedWorkers();
+    List<BlockWorkerInfo> workers = mContext.getLiveWorkers();
     for (BlockWorkerInfo worker : workers) {
       try (CloseableResource<BlockWorkerClient> client =
                mContext.acquireBlockWorkerClient(worker.getNetAddress())) {
@@ -429,12 +433,18 @@ public class DoraCacheClient {
    */
   public WorkerNetAddress getWorkerNetAddress(String path) {
     try {
-      List<BlockWorkerInfo> workers = mContext.getCachedWorkers();
+      List<BlockWorkerInfo> workers = mEnableDynamicHashRing ? mContext.getCachedWorkers(
+          FileSystemContext.GetWorkerListType.LIVE) : mContext.getCachedWorkers(
+          FileSystemContext.GetWorkerListType.ALL);
       List<BlockWorkerInfo> preferredWorkers =
           mWorkerLocationPolicy.getPreferredWorkers(workers,
               path, mPreferredWorkerCount);
       checkState(preferredWorkers.size() > 0);
-      WorkerNetAddress workerNetAddress = choosePreferredWorker(preferredWorkers).getNetAddress();
+      BlockWorkerInfo worker = choosePreferredWorker(preferredWorkers);
+      if (!worker.isActive()) {
+        throw new RuntimeException("The preferred worker is not active.");
+      }
+      WorkerNetAddress workerNetAddress = worker.getNetAddress();
       return workerNetAddress;
     } catch (IOException e) {
       // If failed to find workers in the cluster or failed to find the specified number of

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6876,6 +6876,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.WORKER)
           .build();
 
+  public static final PropertyKey USER_DYNAMIC_CONSISTENT_HASH_RING_ENABLED =
+      booleanBuilder(Name.USER_DYNAMIC_CONSISTENT_HASH_RING_ENABLED)
+          .setDefaultValue(true)
+          .setDescription("If true, use live worker list to build consistent hash ring. Otherwise, "
+              + "use all worker list that includes lost workers to build consistent hash ring.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.CLIENT)
+          .build();
+
   public static final PropertyKey WORKER_HTTP_SERVER_ENABLED =
       booleanBuilder(Name.WORKER_HTTP_SERVER_ENABLED)
           .setDefaultValue(true)
@@ -8494,6 +8503,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_NETTY_DATA_TRANSMISSION_ENABLED =
         "alluxio.user.netty.data.transmission.enabled";
 
+    public static final String USER_DYNAMIC_CONSISTENT_HASH_RING_ENABLED =
+        "alluxio.user.dynamic.consistent.hash.ring.enabled";
     public static final String WORKER_HTTP_SERVER_ENABLED =
         "alluxio.worker.http.server.enabled";
 

--- a/dora/core/server/master/src/main/java/alluxio/master/block/BlockMasterClientServiceHandler.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/block/BlockMasterClientServiceHandler.java
@@ -143,6 +143,16 @@ public final class BlockMasterClientServiceHandler
   }
 
   @Override
+  public void getLostWorkerList(GetWorkerInfoListPOptions options,
+                                StreamObserver<GetWorkerInfoListPResponse> responseObserver) {
+    RpcUtils.call(LOG,
+        () -> GetWorkerInfoListPResponse.newBuilder()
+            .addAllWorkerInfos(mBlockMaster.getLostWorkersInfoList()
+                .stream().map(GrpcUtils::toProto).collect(Collectors.toList())).build(),
+        "GetLostWorkerList", "options=%s", responseObserver, options);
+  }
+
+  @Override
   public void removeDisabledWorker(RemoveDisabledWorkerPOptions options,
        StreamObserver<RemoveDisabledWorkerPResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {

--- a/dora/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4148,6 +4148,11 @@ public class DefaultFileSystemMaster extends CoreMaster
   }
 
   @Override
+  public List<WorkerInfo> getLostWorkerList() throws UnavailableException {
+    return mBlockMaster.getLostWorkersInfoList();
+  }
+
+  @Override
   public long getInodeCount() {
     return mInodeTree.getInodeCount();
   }

--- a/dora/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -543,6 +543,11 @@ public interface FileSystemMaster extends Master {
   List<WorkerInfo> getWorkerInfoList() throws UnavailableException;
 
   /**
+   * @return a list of {@link WorkerInfo} objects representing the lost workers in Alluxio
+   */
+  List<WorkerInfo> getLostWorkerList() throws UnavailableException;
+
+  /**
    * Get the total inode count.
    *
    * @return inode count

--- a/dora/core/server/master/src/main/java/alluxio/master/scheduler/WorkerProvider.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/scheduler/WorkerProvider.java
@@ -13,6 +13,7 @@ package alluxio.master.scheduler;
 
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.exception.runtime.AlluxioRuntimeException;
+import alluxio.exception.status.UnavailableException;
 import alluxio.resource.CloseableResource;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
@@ -36,7 +37,7 @@ public interface WorkerProvider {
    * Get live workerInfo list.
    * @return list of WorkerInfos who are alive
    */
-  List<WorkerInfo> getLiveWorkerInfos();
+  List<WorkerInfo> getLiveWorkerInfos() throws UnavailableException;
 
   /**
    * Gets a worker client.


### PR DESCRIPTION
By default, we build a dynamic consistent hash with the live worker list that comes from master or ETCD. Sometimes we want to build a static consistent hash ring to make sure we won't write data to other worker node when a worker node is offline temporarily (especially when other worker nodes are running out of disk space).

This PR provides allows us to build a static consistent hash ring by setting `alluxio.user.dynamic.consistent.hash.ring.enabled=false`. In this case, client will read from UFS if the worker where the specified file locate is down.