### PR TITLE
Fix the bug of using a terminated executor in S3 UFS

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
@@ -68,7 +68,7 @@ public class PagedFileReader extends BlockReader implements PositionReader {
                                        UnderFileSystem ufs, String fileId,
                                        String ufsPath, long fileSize, long startPosition) {
     FileId fileIdField = FileId.of(fileId);
-    return new PagedFileReader(ufs, LocalCachePositionReader.create(cacheManager,
+    return new PagedFileReader(LocalCachePositionReader.create(cacheManager,
         new CloseableSupplier<>(() -> ufs.openPositionRead(ufsPath, fileSize)),
         fileIdField, fileSize, conf.getBytes(PropertyKey.WORKER_PAGE_STORE_PAGE_SIZE),
         CacheContext.defaults()), fileSize, startPosition);
@@ -77,13 +77,11 @@ public class PagedFileReader extends BlockReader implements PositionReader {
   /**
    * Constructor.
    *
-   * @param ufs
    * @param localCachePositionReader
    * @param fileSize
    * @param startPosition
    */
-  public PagedFileReader(UnderFileSystem ufs,
-                         LocalCachePositionReader localCachePositionReader,
+  public PagedFileReader(LocalCachePositionReader localCachePositionReader,
                          long fileSize, long startPosition) {
     mPositionReader = Preconditions.checkNotNull(localCachePositionReader);
     mFileSize = fileSize;

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
@@ -220,7 +220,6 @@ public class PagedFileReader extends BlockReader implements PositionReader {
     }
     mClosed = true;
     mPositionReader.close();
-    mUfs.close();
     super.close();
   }
 

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
@@ -49,7 +49,6 @@ public class PagedFileReader extends BlockReader implements PositionReader {
   private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0);
   private final long mFileSize;
   private final LocalCachePositionReader mPositionReader;
-  private final UnderFileSystem mUfs;
   private long mPos;
   private volatile boolean mClosed = false;
 
@@ -86,7 +85,6 @@ public class PagedFileReader extends BlockReader implements PositionReader {
   public PagedFileReader(UnderFileSystem ufs,
                          LocalCachePositionReader localCachePositionReader,
                          long fileSize, long startPosition) {
-    mUfs = Preconditions.checkNotNull(ufs);
     mPositionReader = Preconditions.checkNotNull(localCachePositionReader);
     mFileSize = fileSize;
     mPos = startPosition;


### PR DESCRIPTION
### What changes are proposed in this pull request?
Don't call the ufs.close() in PageFileReader.close()

### Why are the changes needed?
1. we should not close the ufs instance, because we always try to reuse it for the same ufs mount point. unless we don't reuse the instance of the ufs instance.
2. S3UnderFileSystem.close() will just shut down the executor held by the instance. when other threads reuse the executor, it will cause issues.

### Does this PR introduce any user facing changes?
no
