### PR TITLE
Change logging level in NettyChannelPool

### DIFF
--- a/dora/core/common/src/main/java/alluxio/network/netty/NettyChannelPool.java
+++ b/dora/core/common/src/main/java/alluxio/network/netty/NettyChannelPool.java
@@ -74,7 +74,7 @@ public final class NettyChannelPool extends DynamicResourcePool<Channel> {
 
   @Override
   protected void closeResource(Channel channel) {
-    LOG.info("Channel closed");
+    LOG.debug("Channel closed");
     CommonUtils.closeChannel(channel);
   }
 
@@ -90,7 +90,7 @@ public final class NettyChannelPool extends DynamicResourcePool<Channel> {
     try {
       ChannelFuture channelFuture = bs.connect().sync();
       if (channelFuture.isSuccess()) {
-        LOG.info("Created netty channel with netty bootstrap {}.", mBootstrap);
+        LOG.debug("Created netty channel with netty bootstrap {}.", mBootstrap);
         return channelFuture.channel();
       } else {
         LOG.error("Failed to create netty channel with netty bootstrap {} and error {}.",


### PR DESCRIPTION
### What changes are proposed in this pull request?

Reduce unnecessary logging to help debugging

### Why are the changes needed?

Noisy logging like `2023-09-11 20:02:30,750 INFO  NettyChannelPool - Channel closed`

### Does this PR introduce any user facing changes?

N/A
