### PR TITLE
Close Etcd client when process exits

### DIFF
--- a/dora/core/common/src/main/java/alluxio/membership/AlluxioEtcdClient.java
+++ b/dora/core/common/src/main/java/alluxio/membership/AlluxioEtcdClient.java
@@ -140,12 +140,14 @@ public class AlluxioEtcdClient {
 
   private <V> V retryInternal(String description, RetryPolicy retryPolicy,
                               EtcdUtilCallable<V> etcdCallable) {
+    LOG.debug("retry = {} desc= {}", retryPolicy, description);
     Exception ex = null;
     // TODO(lucy) Currently retry on all sorts of exception and report the last exception,
     // As jetcd exception often hides underneath CompletableFuture.get(), find
     // more info later on distinguishing different possible exceptions.
     while (retryPolicy.attempt()) {
       try {
+        LOG.debug("AlluxioEtcdClient calling. AttemptCount = {}", retryPolicy.getAttemptCount());
         return etcdCallable.call();
       } catch (Exception e) {
         // TODO(lucy) check in future if io.etcd.jetcd.common.exception.EtcdException
@@ -536,5 +538,12 @@ public class AlluxioEtcdClient {
    */
   public Client getEtcdClient() {
     return mClient;
+  }
+
+  public static void destroy() {
+    LOG.debug("Destroying {}", sAlluxioEtcdClient);
+    sAlluxioEtcdClient.mServiceDiscovery.close();
+    sAlluxioEtcdClient.getEtcdClient().close();
+    sAlluxioEtcdClient = null;
   }
 }

--- a/dora/core/common/src/main/java/alluxio/membership/AlluxioEtcdClient.java
+++ b/dora/core/common/src/main/java/alluxio/membership/AlluxioEtcdClient.java
@@ -547,6 +547,14 @@ public class AlluxioEtcdClient {
     return mClient;
   }
 
+  /**
+   * Destroys the client and corresponding resources.
+   *
+   * We don't implement {@link AutoCloseable} because the client is used by client
+   * FileSystemContext. FileSystemContext has reinit() logic which may close and recreate
+   * all resources. We don't want the life cycle of one FileSystemContext to close the global
+   * singleton ETCD client.
+   */
   public static void destroy() {
     LOG.debug("Destroying ETCD client {}", sAlluxioEtcdClient);
     try (LockResource lockResource = new LockResource(INSTANCE_LOCK)) {

--- a/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
@@ -206,5 +206,6 @@ public class EtcdMembershipManager implements MembershipManager {
   @Override
   public void close() throws Exception {
     // NOTHING TO CLOSE
+    // The EtcdClient is a singleton so its life cycle is managed by the class itself
   }
 }

--- a/dora/core/common/src/main/java/alluxio/membership/ServiceDiscoveryRecipe.java
+++ b/dora/core/common/src/main/java/alluxio/membership/ServiceDiscoveryRecipe.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
  * ServiceDiscoveryRecipe for etcd, to track health status
  * of all registered services.
  */
-public class ServiceDiscoveryRecipe {
+public class ServiceDiscoveryRecipe implements AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(ServiceDiscoveryRecipe.class);
   final AlluxioEtcdClient mAlluxioEtcdClient;
   private final ScheduledExecutorService mExecutor;
@@ -332,6 +332,7 @@ public class ServiceDiscoveryRecipe {
    * to renew the lease with new keepalive client.
    */
   private void checkAllForReconnect() {
+    LOG.debug("Start Checking all for reconnect ...@{}", this);
     // No need for lock over all services, just individual DefaultServiceEntity is enough
     for (Map.Entry<String, DefaultServiceEntity> entry : mRegisteredServices.entrySet()) {
       DefaultServiceEntity entity = entry.getValue();
@@ -348,5 +349,9 @@ public class ServiceDiscoveryRecipe {
         }
       }
     }
+  }
+
+  public void close() {
+    mExecutor.shutdown();
   }
 }

--- a/dora/core/common/src/main/java/alluxio/membership/ServiceDiscoveryRecipe.java
+++ b/dora/core/common/src/main/java/alluxio/membership/ServiceDiscoveryRecipe.java
@@ -70,7 +70,7 @@ public class ServiceDiscoveryRecipe implements AutoCloseable {
     mAlluxioEtcdClient = client;
     mRegisterPathPrefix = pathPrefix;
     mExecutor = Executors.newSingleThreadScheduledExecutor(
-        ThreadFactoryUtils.build("service-discovery-checker", false));
+        ThreadFactoryUtils.build("service-discovery-checker", true));
     mExecutor.scheduleWithFixedDelay(this::checkAllForReconnect,
         AlluxioEtcdClient.DEFAULT_LEASE_TTL_IN_SEC, AlluxioEtcdClient.DEFAULT_LEASE_TTL_IN_SEC,
         TimeUnit.SECONDS);


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Since EtcdClient is a singleton, close it in the jvm shutdownHook
2. Close related resources within EtcdClient
