### PR TITLE
Fix read position in PagedDoraWorker

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
@@ -147,7 +147,7 @@ public class PagedFileReader extends BlockReader implements PositionReader {
 
     // cap length to the remaining of block, as the caller may pass in a longer length than what
     // is left in the block, but expect as many bytes as there is
-    length = Math.min(length, mPos - offset);
+    length = Math.min(length, mFileSize - offset);
     ensureReadable(offset, length);
 
     // must not use pooled buffer, see interface implementation note
@@ -163,7 +163,6 @@ public class PagedFileReader extends BlockReader implements PositionReader {
     }
     buffer.position(0);
     buffer.limit(bytesRead);
-    mPos += bytesRead;
     return buffer;
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. The length of the read is incorrectly calculated. Should not have anything to do with the position of the reader.
2. `mPos` should not be updated for the `read` method, as it's a positioned read operation (has an `offset` argument).

### Why are the changes needed?

bug fix

### Does this PR introduce any user facing changes?
No.
