### PR TITLE
Add manual exit at the end of FUSE life cycle

### DIFF
--- a/dora/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/dora/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -154,6 +154,11 @@ public class AlluxioFuse {
       startCommon(conf, fuseOptions, fsContext); // This will be blocked until quitting
 
       stopCommon();
+      // Explicitly exit() so non daemon threads will be terminated
+      System.exit(0);
+    } catch (Throwable t) {
+      LOG.error("Failed running FUSE", t);
+      System.exit(-1);
     }
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Added a manual double-safety `System.exit()` at the end of FUSE lifecycle, to be absolutely sure we exit the JVM and terminate all non-daemon & daemon threads.

Before this change, after we `alluxio-fuse umount` or `kill (not -9)`, the FUSE process may fail to quit. One reason is a non-daemon thread dangling around:
```
# This is a non daemon thread in AlluxioEtcdClient
"vert.x-eventloop-thread-0" #21 prio=5 os_prio=31 cpu=482.23ms elapsed=722.11s tid=0x00007fde79251800 nid=0x8c03 runnable  [0x00007000102ae000]
   java.lang.Thread.State: RUNNABLE
   at sun.nio.ch.KQueue.poll(java.base@11.0.11/Native Method)
   at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.11/KQueueSelectorImpl.java:122)
   at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.11/SelectorImpl.java:124)
   - locked <0x00000007c0603938> (a io.netty.channel.nio.SelectedSelectionKeySet)
   - locked <0x00000007c06038d8> (a sun.nio.ch.KQueueSelectorImpl)
   at sun.nio.ch.SelectorImpl.select(java.base@11.0.11/SelectorImpl.java:136)
   at io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:62)
   at io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:883)
   at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:526)
   at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
   at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
   at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
   at java.lang.Thread.run(java.base@11.0.11/Thread.java:829)
```

The JVM shutdownHook executes after the LAST non-daemon thread dies or when `System.exit()` triggers. So if some libraries we use or some thread pools of ours accidentally introduce non-daemon threads, `System.exit()` is our last resort to trigger shutdownHook.

FUSE does handle signals and exit, but there are some corner cases which don't seem to trigger that successfully. So this PR serves as the last resort.
https://github.com/Alluxio/alluxio/blob/527ffe8105568757e05dc81dff1e28a8078e9a9e/dora/integration/fuse/src/main/java/alluxio/fuse/FuseSignalHandler.java#L52

### Why are the changes needed?

See above

### Does this PR introduce any user facing changes?

No
