### PR TITLE
Fix reconnect logic of servicediscoveryrecipe

### DIFF
--- a/dora/core/common/src/main/java/alluxio/membership/ServiceDiscoveryRecipe.java
+++ b/dora/core/common/src/main/java/alluxio/membership/ServiceDiscoveryRecipe.java
@@ -91,8 +91,8 @@ public class ServiceDiscoveryRecipe implements AutoCloseable {
    */
   private void newLeaseInternal(DefaultServiceEntity service, boolean force) throws IOException {
     try (LockResource lockResource = new LockResource(service.getLock())) {
-      if (!force &&
-          service.getLease() != null && !mAlluxioEtcdClient.isLeaseExpired(service.getLease())) {
+      if (!force && service.getLease() != null
+          && !mAlluxioEtcdClient.isLeaseExpired(service.getLease())) {
         LOG.info("Lease attached with service:{} is not expired, bail from here.",
             service.getServiceEntityName());
         return;
@@ -120,8 +120,7 @@ public class ServiceDiscoveryRecipe implements AutoCloseable {
             r -> kvs.addAll(r.getKvs())).collect(Collectors.toList());
         if (!txnResponse.isSucceeded()) {
           if (!kvs.isEmpty()) {
-            throw new AlreadyExistsException("Same service kv pair is there but "
-                + "attached lease is expired, this should not happen");
+            throw new AlreadyExistsException("Same service kv pair already exists.");
           }
           throw new IOException("Failed to new a lease for service:" + service.toString());
         }


### PR DESCRIPTION
### What changes are proposed in this pull request?

when etcd lease keepalive client returned with onCompleted or onError, the lease might not directly get expired at the time, therefore we always new a lease to resume keepalive without explicitly checking isleaseexpired

### Why are the changes needed?

when etcd got induced network unstableness such as pkg loss, there's race condition in our reconnection logic from ServiceDiscoveryRecipe, where we directly check isLeaseExpired when we got terminal callback from keepalive client, but at the time the lease isn't expired yet. Hence we stop trying to create new lease to keepalive.

### Does this PR introduce any user facing changes?

No
