### PR TITLE
Add ser/de support for JSON or WorkerIdentity

### DIFF
--- a/dora/core/common/src/main/java/alluxio/wire/WorkerIdentity.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerIdentity.java
@@ -140,7 +140,6 @@ public final class WorkerIdentity implements Serializable {
     }
   }
 
-
   /**
    * Parsers for worker identity.
    */
@@ -417,7 +416,6 @@ public final class WorkerIdentity implements Serializable {
       return getVersionSpecificRepresentation0(identity);
     }
   }
-
 
   /**
    * Utility for ser/de with Gson.

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerIdentity.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerIdentity.java
@@ -11,15 +11,40 @@
 
 package alluxio.wire;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.util.StdConverter;
+import com.google.common.hash.Funnel;
+import com.google.common.hash.PrimitiveSink;
 import com.google.common.primitives.Longs;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.UnsafeByteOperations;
+import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.Serializable;
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.UUID;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -28,15 +53,19 @@ import javax.annotation.concurrent.Immutable;
  * representation and an instance of this class.
  */
 @Immutable
-public final class WorkerIdentity {
+@JsonAdapter(WorkerIdentity.GsonSerde.class)
+@JsonDeserialize(converter = WorkerIdentity.JacksonDeserializeConverter.class)
+@JsonSerialize(using = WorkerIdentity.JacksonSerializer.class)
+public final class WorkerIdentity implements Serializable {
+  private static final long serialVersionUID = -3241509286694514179L;
+
   private final byte[] mId;
   private final int mVersion;
-  private final int mHashcode;
+  private transient int mHashcode;
 
   WorkerIdentity(byte[] id, int version) {
     mId = id;
     mVersion = version;
-    mHashcode = Arrays.hashCode(mId) * 31 + mVersion;
   }
 
   /**
@@ -75,7 +104,12 @@ public final class WorkerIdentity {
 
   @Override
   public int hashCode() {
-    return mHashcode;
+    int hashCode = mHashcode;
+    if (hashCode == 0) {
+      hashCode = Arrays.hashCode(mId) * 31 + mVersion;
+      mHashcode = hashCode;
+    }
+    return hashCode;
   }
 
   @Override
@@ -83,6 +117,29 @@ public final class WorkerIdentity {
     return String.format("Worker (%s)",
         Parsers.getParserOfVersion(mVersion).getVersionSpecificRepresentation(this));
   }
+
+  private void writeObject(java.io.ObjectOutputStream out)
+      throws IOException {
+    out.defaultWriteObject();
+  }
+
+  private void readObject(java.io.ObjectInputStream in)
+      throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    final Parser parser;
+    try {
+      parser = Parsers.getParserOfVersion(mVersion);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidObjectException("Unrecognized identity version: " + mVersion);
+    }
+    try {
+      parser.fromProto(parser.toProto(this));
+    } catch (ProtoParsingException e) {
+      throw new InvalidObjectException("Validation after deserialization failed: "
+          + "data corruption during serialization and/or transmission of the object: " + e);
+    }
+  }
+
 
   /**
    * Parsers for worker identity.
@@ -358,6 +415,213 @@ public final class WorkerIdentity {
     public UUID toUUID(WorkerIdentity identity) throws IllegalArgumentException {
       ensureVersionMatch(identity);
       return getVersionSpecificRepresentation0(identity);
+    }
+  }
+
+
+  /**
+   * Utility for ser/de with Gson.
+   * <p>
+   * The version field is encoded as a JSON number, and the identity field
+   * is encoded as a hexadecimal string.
+   */
+  public enum GsonSerde
+      implements JsonSerializer<WorkerIdentity>, JsonDeserializer<WorkerIdentity> {
+    INSTANCE;
+
+    static final String FIELD_VERSION = "version";
+    static final String FIELD_IDENTIFIER = "identifier";
+
+    /**
+     * @return serializer
+     */
+    public JsonSerializer<WorkerIdentity> getSerializer() {
+      return WorkerIdentitySerializer.INSTANCE;
+    }
+
+    /**
+     * @return deserializer
+     */
+    public JsonDeserializer<WorkerIdentity> getDeserializer() {
+      return WorkerIdentityDeserializer.INSTANCE;
+    }
+
+    @Override
+    public WorkerIdentity deserialize(JsonElement json, Type typeOfT,
+        JsonDeserializationContext context) throws JsonParseException {
+      return getDeserializer().deserialize(json, typeOfT, context);
+    }
+
+    @Override
+    public JsonElement serialize(WorkerIdentity src, Type typeOfSrc,
+        JsonSerializationContext context) {
+      return getSerializer().serialize(src, typeOfSrc, context);
+    }
+  }
+
+  private enum WorkerIdentitySerializer implements JsonSerializer<WorkerIdentity> {
+    INSTANCE;
+
+    @Override
+    public JsonElement serialize(WorkerIdentity src, Type typeOfSrc,
+        JsonSerializationContext context) {
+      JsonObject json = new JsonObject();
+      json.addProperty(GsonSerde.FIELD_VERSION, src.mVersion);
+      json.addProperty(GsonSerde.FIELD_IDENTIFIER, Hex.encodeHexString(src.mId));
+      return json;
+    }
+  }
+
+  private enum WorkerIdentityDeserializer implements JsonDeserializer<WorkerIdentity> {
+    INSTANCE;
+
+    @Override
+    public WorkerIdentity deserialize(JsonElement json, Type typeOfT,
+        JsonDeserializationContext context)
+        throws JsonParseException {
+      if (typeOfT != WorkerIdentity.class) {
+        throw new JsonParseException("Wrong type for deserialization, "
+            + "expecting " + WorkerIdentity.class.getSimpleName() + ", got " + typeOfT);
+      }
+      if (!json.isJsonObject()) {
+        throw new JsonParseException(
+            String.format("Expecting worker identity to be an object, got %s",
+                json.getClass().getSimpleName()));
+      }
+      JsonObject object = json.getAsJsonObject();
+      alluxio.grpc.WorkerIdentity.Builder protoBuilder = alluxio.grpc.WorkerIdentity.newBuilder();
+      JsonElement versionElement = object.get(GsonSerde.FIELD_VERSION);
+      if (versionElement != null) {
+        int version = parseVersion(versionElement);
+        protoBuilder.setVersion(version);
+      }
+
+      JsonElement identifierElement = object.get(GsonSerde.FIELD_IDENTIFIER);
+      if (identifierElement != null) {
+        byte[] identifier = parseIdentifier(identifierElement);
+        protoBuilder.setIdentifier(UnsafeByteOperations.unsafeWrap(identifier));
+      }
+
+      alluxio.grpc.WorkerIdentity proto = protoBuilder.build();
+      try {
+        return WorkerIdentity.fromProto(proto);
+      } catch (ProtoParsingException e) {
+        throw new JsonParseException("Invalid worker identity: " + proto, e);
+      }
+    }
+
+    private int parseVersion(JsonElement versionElement) throws JsonParseException {
+      if (versionElement.isJsonPrimitive()) {
+        JsonPrimitive versionPrimitive = versionElement.getAsJsonPrimitive();
+        if (versionPrimitive.isNumber()) {
+          return versionPrimitive.getAsInt();
+        }
+      }
+      throw new JsonParseException(
+          "Expected field " + GsonSerde.FIELD_VERSION + " to be integer, got " + versionElement);
+    }
+
+    private byte[] parseIdentifier(JsonElement identifierElement) throws JsonParseException {
+      if (identifierElement.isJsonPrimitive()) {
+        JsonPrimitive identifierPrimitive = identifierElement.getAsJsonPrimitive();
+        if (identifierPrimitive.isString()) {
+          try {
+            return Hex.decodeHex(identifierPrimitive.getAsString());
+          } catch (DecoderException e) {
+            throw new JsonParseException(String.format(
+                "Invalid hex representation of identifier bytes: %s",
+                identifierPrimitive.getAsString()), e);
+          }
+        }
+      }
+      throw new JsonParseException("Expected field " + GsonSerde.FIELD_IDENTIFIER
+          + " to be string, got " + identifierElement);
+    }
+  }
+
+  /**
+   * JSON serializer for Jackson.
+   */
+  public static class JacksonSerializer
+      extends com.fasterxml.jackson.databind.JsonSerializer<WorkerIdentity> {
+    public static final JacksonSerializer INSTANCE = new JacksonSerializer();
+
+    private JacksonSerializer() {
+      // prevent instantiation
+    }
+
+    @Override
+    public void serialize(WorkerIdentity value, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      gen.writeStartObject();
+      gen.writeNumberField(GsonSerde.FIELD_VERSION, value.mVersion);
+      gen.writeStringField(GsonSerde.FIELD_IDENTIFIER, Hex.encodeHexString(value.mId));
+      gen.writeEndObject();
+    }
+  }
+
+  private static class JacksonDeserializeIntermediate {
+    @JsonProperty(GsonSerde.FIELD_VERSION)
+    @Nullable
+    private final String mIdHexEncoded;
+    @JsonProperty(GsonSerde.FIELD_IDENTIFIER)
+    @Nullable
+    private final Integer mVersion;
+
+    @JsonCreator
+    public JacksonDeserializeIntermediate(
+        @Nullable @JsonProperty(GsonSerde.FIELD_VERSION) Integer version,
+        @Nullable @JsonProperty(GsonSerde.FIELD_IDENTIFIER) String hexEncodedIdentifier) {
+      mVersion = version;
+      mIdHexEncoded = hexEncodedIdentifier;
+    }
+  }
+
+  /**
+   * Deserializer for Jackson.
+   */
+  public static class JacksonDeserializeConverter
+      extends StdConverter<JacksonDeserializeIntermediate, WorkerIdentity> {
+    @Override
+    public WorkerIdentity convert(JacksonDeserializeIntermediate value) {
+      alluxio.grpc.WorkerIdentity.Builder protoBuilder = alluxio.grpc.WorkerIdentity.newBuilder();
+      if (value.mIdHexEncoded != null) {
+        final byte[] identifier;
+        try {
+          identifier = Hex.decodeHex(value.mIdHexEncoded);
+          protoBuilder
+              .setIdentifier(UnsafeByteOperations.unsafeWrap(identifier));
+        } catch (DecoderException e) {
+          throw new IllegalArgumentException(
+              "Malformed hex encoded identifier: " + value.mIdHexEncoded, e);
+        }
+      }
+      if (value.mVersion != null) {
+        protoBuilder.setVersion(value.mVersion);
+      }
+      alluxio.grpc.WorkerIdentity proto = protoBuilder.build();
+      try {
+        return WorkerIdentity.fromProto(proto);
+      } catch (ProtoParsingException e) {
+        throw new IllegalArgumentException(
+            "Invalid worker identity: " + proto, e);
+      }
+    }
+  }
+
+  /**
+   * Funnel to serialize an instance of {@link WorkerIdentity} for hashing.
+   */
+  @SuppressWarnings("UnstableApiUsage")
+  public enum HashFunnel implements Funnel<WorkerIdentity> {
+    INSTANCE;
+
+    @Override
+    // @Nonnull annotation is needed to work around a bug in spotbugs
+    // see https://github.com/spotbugs/spotbugs/pull/2502
+    public void funnel(@Nonnull WorkerIdentity from, PrimitiveSink into) {
+      into.putBytes(from.mId)
+          .putInt(from.mVersion);
     }
   }
 }

--- a/dora/core/common/src/test/java/alluxio/wire/WorkerIdentityTest.java
+++ b/dora/core/common/src/test/java/alluxio/wire/WorkerIdentityTest.java
@@ -1,0 +1,314 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.wire;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.util.io.BufferUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.Longs;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.google.protobuf.ByteString;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+public class WorkerIdentityTest {
+  @Test
+  public void legacyIdConvertToLong() {
+    WorkerIdentity identity = new WorkerIdentity(Longs.toByteArray(1L), 0);
+    assertEquals(1L, WorkerIdentity.ParserV0.INSTANCE.toLong(identity));
+    assertEquals(1L, WorkerIdentity.ParserV0.INSTANCE.getVersionSpecificRepresentation(identity));
+  }
+
+  @Test
+  public void legacyIdConvertFromLong() {
+    WorkerIdentity identity = WorkerIdentity.ParserV0.INSTANCE.fromLong(1L);
+    assertEquals(new WorkerIdentity(Longs.toByteArray(1L), 0), identity);
+  }
+
+  @Test
+  public void legacyConvertToProto() throws Exception {
+    WorkerIdentity identity = new WorkerIdentity(Longs.toByteArray(1L), 0);
+    alluxio.grpc.WorkerIdentity identityProto = identity.toProto();
+    assertEquals(alluxio.grpc.WorkerIdentity.newBuilder()
+            .setVersion(0)
+            .setIdentifier(ByteString.copyFrom(Longs.toByteArray(1L)))
+            .build(),
+        identityProto);
+  }
+
+  @Test
+  public void legacyConvertFromProto() throws Exception {
+    alluxio.grpc.WorkerIdentity identityProto = alluxio.grpc.WorkerIdentity.newBuilder()
+        .setVersion(0)
+        .setIdentifier(ByteString.copyFrom(Longs.toByteArray(2L)))
+        .build();
+    WorkerIdentity identity = new WorkerIdentity(Longs.toByteArray(2L), 0);
+    assertEquals(identity, WorkerIdentity.fromProto(identityProto));
+  }
+
+  @Test
+  public void legacyVersionMismatch() {
+    alluxio.grpc.WorkerIdentity identityProto = alluxio.grpc.WorkerIdentity.newBuilder()
+        .setVersion(1)
+        .setIdentifier(ByteString.copyFrom(Longs.toByteArray(2L)))
+        .build();
+    assertThrows(InvalidVersionParsingException.class,
+        () -> WorkerIdentity.ParserV0.INSTANCE.fromProto(identityProto));
+  }
+
+  @Test
+  public void legacyInvalidIdentifier() {
+    alluxio.grpc.WorkerIdentity identityProto = alluxio.grpc.WorkerIdentity.newBuilder()
+        .setVersion(0)
+        .setIdentifier(ByteString.copyFrom("a byte string longer than 8 bytes".getBytes()))
+        .build();
+    assertThrows(ProtoParsingException.class,
+        () -> WorkerIdentity.ParserV0.INSTANCE.fromProto(identityProto));
+  }
+
+  @Test
+  public void legacyMissingFields() {
+    alluxio.grpc.WorkerIdentity missingId = alluxio.grpc.WorkerIdentity.newBuilder()
+        .setVersion(1)
+        .build();
+    assertThrows(MissingRequiredFieldsParsingException.class,
+        () -> WorkerIdentity.ParserV1.INSTANCE.fromProto(missingId));
+
+    alluxio.grpc.WorkerIdentity missingVersion = alluxio.grpc.WorkerIdentity.newBuilder()
+        .setIdentifier(ByteString.copyFrom("id", Charset.defaultCharset()))
+        .build();
+    assertThrows(MissingRequiredFieldsParsingException.class,
+        () -> WorkerIdentity.ParserV0.INSTANCE.fromProto(missingVersion));
+  }
+
+  @Test
+  public void v1ConvertFromUuid() {
+    UUID uuid = UUID.randomUUID();
+    WorkerIdentity identity = WorkerIdentity.ParserV1.INSTANCE.fromUUID(uuid);
+    alluxio.grpc.WorkerIdentity proto = identity.toProto();
+    ByteBuffer uuidBytes = proto.getIdentifier().asReadOnlyByteBuffer();
+    assertEquals(uuid, new UUID(uuidBytes.getLong(), uuidBytes.getLong()));
+
+    identity = WorkerIdentity.ParserV1.INSTANCE.fromUUID(uuid.toString());
+    proto = identity.toProto();
+    uuidBytes = proto.getIdentifier().asReadOnlyByteBuffer();
+    assertEquals(uuid, new UUID(uuidBytes.getLong(), uuidBytes.getLong()));
+  }
+
+  @Test
+  public void v1ConvertToUuid() {
+    byte[] uuidBytes = BufferUtils.getIncreasingByteArray(16);
+    ByteBuffer buffer = ByteBuffer.wrap(uuidBytes);
+    UUID uuid = new UUID(buffer.getLong(), buffer.getLong());
+    WorkerIdentity identity = new WorkerIdentity(uuidBytes, 1);
+    assertEquals(uuid, WorkerIdentity.ParserV1.INSTANCE.toUUID(identity));
+  }
+
+  @Test
+  public void v1InvalidIdentifier() {
+    alluxio.grpc.WorkerIdentity identityProto = alluxio.grpc.WorkerIdentity.newBuilder()
+        .setVersion(1)
+        .setIdentifier(ByteString.copyFrom("non-uuid".getBytes(StandardCharsets.UTF_8)))
+        .build();
+    assertThrows(ProtoParsingException.class,
+        () -> WorkerIdentity.ParserV1.INSTANCE.fromProto(identityProto));
+  }
+
+  @Test
+  public void parserFromProto() throws Exception {
+    WorkerIdentity identity = WorkerIdentity.Parsers.fromProto(
+        alluxio.grpc.WorkerIdentity.newBuilder()
+            .setVersion(0)
+            .setIdentifier(ByteString.copyFrom(Longs.toByteArray(1L)))
+            .build());
+    assertEquals(new WorkerIdentity(Longs.toByteArray(1L), 0), identity);
+  }
+
+  @Test
+  public void parserToProto() throws Exception {
+    byte[] idBytes = BufferUtils.getIncreasingByteArray(16);
+    WorkerIdentity identity = new WorkerIdentity(idBytes, 1);
+    alluxio.grpc.WorkerIdentity proto = WorkerIdentity.Parsers.toProto(identity);
+    assertEquals(1, proto.getVersion());
+    assertArrayEquals(idBytes, proto.getIdentifier().toByteArray());
+  }
+
+  @Test
+  public void parserInvalidVersion() throws Exception {
+    alluxio.grpc.WorkerIdentity proto = alluxio.grpc.WorkerIdentity.newBuilder()
+        .setVersion(-1)
+        .setIdentifier(ByteString.copyFrom(Longs.toByteArray(1L)))
+        .build();
+    assertThrows(InvalidVersionParsingException.class,
+        () -> WorkerIdentity.Parsers.fromProto(proto));
+  }
+
+  @Test
+  public void testEquals() {
+    WorkerIdentity identity1 = new WorkerIdentity(new byte[]{0x1}, 2);
+    WorkerIdentity identity2 = new WorkerIdentity(new byte[]{0x1}, 2);
+    assertEquals(identity1, identity2);
+  }
+
+  @Test
+  public void gsonSerialization() {
+    long id = RandomUtils.nextLong();
+    byte[] idBytes = Longs.toByteArray(id);
+    WorkerIdentity identity = new WorkerIdentity(idBytes, 0);
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapter(WorkerIdentity.class, WorkerIdentity.GsonSerde.INSTANCE)
+        .create();
+    assertEquals("{\"version\":0,\"identifier\":\"" + Hex.encodeHexString(idBytes) + "\"}",
+        gson.toJson(identity));
+  }
+
+  @Test
+  public void gsonDeserialization() {
+    byte[] uuidBytes = BufferUtils.getIncreasingByteArray(16);
+    String jsonString = "{\"version\":1,\"identifier\":\"" + Hex.encodeHexString(uuidBytes) + "\"}";
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapter(WorkerIdentity.class, WorkerIdentity.GsonSerde.INSTANCE)
+        .create();
+    WorkerIdentity identity = gson.fromJson(jsonString, WorkerIdentity.class);
+
+    assertEquals(new WorkerIdentity(uuidBytes, 1), identity);
+  }
+
+  @Test
+  public void gsonDeserializationWithFieldsMissing() {
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapter(WorkerIdentity.class, WorkerIdentity.GsonSerde.INSTANCE)
+        .create();
+    String missingId = "{\"version\":1}";
+    Throwable jsonParseException =
+        assertThrows(JsonParseException.class,
+            () -> gson.fromJson(missingId, WorkerIdentity.class));
+    assertTrue(jsonParseException.getCause() instanceof MissingRequiredFieldsParsingException);
+
+    String missingVersion = "{\"identifier\":\"0badbeef\"}";
+    jsonParseException =
+        assertThrows(JsonParseException.class,
+            () -> gson.fromJson(missingVersion, WorkerIdentity.class));
+    assertTrue(jsonParseException.getCause() instanceof MissingRequiredFieldsParsingException);
+  }
+
+  @Test
+  public void jacksonSerialization() throws Exception {
+    long id = RandomUtils.nextLong();
+    byte[] idBytes = Longs.toByteArray(id);
+    WorkerIdentity identity = new WorkerIdentity(idBytes, 0);
+    ObjectMapper objectMapper = new ObjectMapper();
+    assertEquals("{\"version\":0,\"identifier\":\"" + Hex.encodeHexString(idBytes) + "\"}",
+        objectMapper.writeValueAsString(identity));
+  }
+
+  @Test
+  public void jacksonDeserialization() throws Exception {
+    byte[] uuidBytes = BufferUtils.getIncreasingByteArray(16);
+    String jsonString = "{\"version\":1,\"identifier\":\"" + Hex.encodeHexString(uuidBytes) + "\"}";
+    ObjectMapper objectMapper = new ObjectMapper();
+    WorkerIdentity identity = objectMapper.readValue(jsonString, WorkerIdentity.class);
+
+    assertEquals(new WorkerIdentity(uuidBytes, 1), identity);
+  }
+
+  @Test
+  public void jacksonDeserializationWithFieldsMissing() {
+    ObjectMapper mapper = new ObjectMapper();
+    String missingId = "{\"version\":1}";
+    Throwable jsonParseException =
+        assertThrows(IllegalArgumentException.class,
+            () -> mapper.readValue(missingId, WorkerIdentity.class));
+    assertTrue(jsonParseException.getCause() instanceof MissingRequiredFieldsParsingException);
+
+    String missingVersion = "{\"identifier\":\"0badbeef\"}";
+    jsonParseException =
+        assertThrows(IllegalArgumentException.class,
+            () -> mapper.readValue(missingVersion, WorkerIdentity.class));
+    assertTrue(jsonParseException.getCause() instanceof MissingRequiredFieldsParsingException);
+  }
+
+  @Test
+  public void javaSerde() throws Exception {
+    UUID uuid = UUID.nameUUIDFromBytes("uuid".getBytes(StandardCharsets.UTF_8));
+    WorkerIdentity identity = WorkerIdentity.ParserV1.INSTANCE.fromUUID(uuid);
+    final byte[] buffer;
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(identity);
+    }
+    buffer = bos.toByteArray();
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(buffer);
+         ObjectInputStream ois = new ObjectInputStream(bis)) {
+      Object obj = ois.readObject();
+      assertTrue(obj instanceof WorkerIdentity);
+      WorkerIdentity idDeserialized = (WorkerIdentity) obj;
+      assertEquals(identity, idDeserialized);
+    }
+  }
+
+  @Test
+  public void javaSerdeInvalidVersion() throws Exception {
+    int invalidVersion = -1;
+    byte[] data = new byte[]{0x1, 0x2, 0x3, 0x4};
+    WorkerIdentity identity = new WorkerIdentity(data, invalidVersion);
+    final byte[] buffer;
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(identity);
+    }
+    buffer = bos.toByteArray();
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(buffer);
+         ObjectInputStream ois = new ObjectInputStream(bis)) {
+      InvalidObjectException t = assertThrows(InvalidObjectException.class,
+          ois::readObject);
+      t.printStackTrace();
+    }
+  }
+
+  @Test
+  public void javaSerdeInvalidData() throws Exception {
+    int version0 = 0;
+    byte[] invalidIdForVersion0 = new byte[]{0x1, 0x2, 0x3, 0x4};
+    WorkerIdentity identity = new WorkerIdentity(invalidIdForVersion0, version0);
+    final byte[] buffer;
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(identity);
+    }
+    buffer = bos.toByteArray();
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(buffer);
+         ObjectInputStream ois = new ObjectInputStream(bis)) {
+      InvalidObjectException t = assertThrows(InvalidObjectException.class,
+          ois::readObject);
+      t.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Allow `WorkerIdentity` to be de/serialized to JSON and Java serialization format.

### Why are the changes needed?

To be able to be embedded in `WorkerInfo` and other data objects that need to be de/serialized to JSON.

### Does this PR introduce any user facing changes?

No.
