### PR TITLE
Fix getActiveWorkers() in Scheduler

### DIFF
--- a/dora/core/server/master/src/main/java/alluxio/master/scheduler/Scheduler.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/scheduler/Scheduler.java
@@ -276,6 +276,7 @@ public final class Scheduler {
    */
   @VisibleForTesting
   public Set<WorkerInfo> getActiveWorkers() {
+    updateWorkers();
     return mWorkerInfoHub.mActiveWorkers.keySet().stream()
         .map(x -> x.mWorkerInfo).collect(Collectors.toSet());
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

When I call the Scheduler.getActiveWorkers(), it returns wrong result. This PR calls updateWorkers() when calls  getActiveWorkers(). Please review its correctness. 

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
