### PR TITLE
Use linked hash set to keep sequence when picking multiple worker

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashProvider.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashProvider.java
@@ -24,7 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.HashFunction;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -110,7 +110,7 @@ public class ConsistentHashProvider {
    * @return a list of workers following the hash ring
    */
   public List<BlockWorkerInfo> getMultiple(String key, int count) {
-    Set<BlockWorkerInfo> workers = new HashSet<>();
+    Set<BlockWorkerInfo> workers = new LinkedHashSet<>(); // preserve insertion order
     int attempts = 0;
     while (workers.size() < count && attempts < mMaxAttempts) {
       attempts++;

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashPolicyTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/dora/ConsistentHashPolicyTest.java
@@ -78,7 +78,9 @@ public class ConsistentHashPolicyTest {
     List<BlockWorkerInfo> assignedWorkers = policy.getPreferredWorkers(workers, "hdfs://a/b/c", 2);
     assertEquals(2, assignedWorkers.size());
     assertTrue(assignedWorkers.stream().allMatch(w -> contains(workers, w)));
-
+    // The order of the workers should be consistent
+    assertEquals(assignedWorkers.get(0).getNetAddress().getHost(), workerAddr2.getHost());
+    assertEquals(assignedWorkers.get(1).getNetAddress().getHost(), workerAddr1.getHost());
     assertThrows(ResourceExhaustedException.class, () -> {
       // Getting 2 out of 1 worker will result in an error
       policy.getPreferredWorkers(ImmutableList.of(new BlockWorkerInfo(workerAddr1, 1024, 0)),


### PR DESCRIPTION
### What changes are proposed in this pull request?

Use linked hash set to keep sequence when picking multiple worker

### Why are the changes needed?
When loading multiple replica into Alluxio, we want deterministic sequence so we can decide which worker to load data and which worker the client can talk to.

### Does this PR introduce any user facing changes?

na
