### PR TITLE
Check load meta option at worker

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -46,6 +46,7 @@ import alluxio.grpc.GrpcUtils;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.LoadFileFailure;
 import alluxio.grpc.LoadFileResponse;
+import alluxio.grpc.LoadMetadataPType;
 import alluxio.grpc.RenamePOptions;
 import alluxio.grpc.Route;
 import alluxio.grpc.RouteFailure;
@@ -363,6 +364,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
     boolean isRecursive = options.getRecursive();
     final Optional<ListStatusResult> resultFromCache = mMetaManager.listCached(path, isRecursive);
     if (resultFromCache.isPresent()
+        && options.getLoadMetadataType() != LoadMetadataPType.ALWAYS
         && (syncIntervalMs < 0
         || System.nanoTime() - resultFromCache.get().mTimeStamp
         <= syncIntervalMs * Constants.MS_NANO)) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Check the `-f, --load-metadata` option at the worker side.

### Why are the changes needed?

The [doc](https://docs.alluxio.io/os/user/edge/en/operation/User-CLI.html#fs-ls) has

![2023-10-03_12-03-58](https://github.com/Alluxio/alluxio/assets/7149512/e839b2e5-ef2a-4834-b421-b414353572f4)

and the "fs ls" command has the following option

```
 -f, --load-metadata       Force load metadata for immediate children in a directory
```

But this option is only set at the client side and is not checked at the worker side. So setting it has no use. Please check the following example

```
$ ./bin/alluxio fs ls /
-rw-rw-r--  test test              1366                 10-02-2023 17:39:54:284 FILE /file.01
-rw-rw-r--  test test              1366                 10-02-2023 17:41:37:496 FILE /file.02
-rw-rw-r--  test test              1366                 10-03-2023 11:04:18:177 FILE /file.03

$ ./bin/alluxio fs ls -f /
-rw-rw-r--   test test             1366                 10-02-2023 17:39:54:284 FILE /file.01
-rw-rw-r--   test test             1366                 10-02-2023 17:41:37:496 FILE /file.02
-rw-rw-r--   test test             1366                 10-03-2023 11:04:18:177 FILE /file.03

$ ./bin/alluxio fs ls -Dalluxio.user.file.metadata.sync.interval=0 /
-rw-rw-r--   test test             1366                 10-02-2023 17:39:54:284 FILE /file.01
-rw-rw-r--   test test             1366                 10-02-2023 17:41:37:496 FILE /file.02
-rw-rw-r--   test test             1366                 10-03-2023 11:04:18:177 FILE /file.03
-rw-rw-r--   test test             1366                 10-03-2023 11:09:33:642 FILE /file.04
-rw-rw-r--   test test             1366                 10-03-2023 11:12:57:668 FILE /file.05
```

This PR checks it at the worker side and makes it matches the doc.

### Does this PR introduce any user facing changes?

NO
