### PR TITLE
Disable UFS fallback in DoraFileSystemIntegrationTest

### DIFF
--- a/dora/tests/integration/src/test/java/alluxio/client/fs/DoraFileSystemIntegrationTest.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/fs/DoraFileSystemIntegrationTest.java
@@ -81,6 +81,7 @@ public final class DoraFileSystemIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.WORKER_HTTP_SERVER_ENABLED, false)
           .setProperty(PropertyKey.S3A_ACCESS_KEY, mS3Proxy.getAccessKey())
           .setProperty(PropertyKey.S3A_SECRET_KEY, mS3Proxy.getSecretKey())
+          .setProperty(PropertyKey.DORA_CLIENT_UFS_FALLBACK_ENABLED, false)
           .setNumWorkers(2)
           .setStartCluster(false);
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Set PropertyKey.DORA_CLIENT_UFS_FALLBACK_ENABLED to false.

### Why are the changes needed?

As we mentioned in [here](https://github.com/Alluxio/alluxio/pull/18213).
When we want to test the DoraFileSystem, we have to disable the Ufs Fallback, otherwise the methods like `createFile`  `getStatus` will fall back to Ufs, while we want to test DoraFileSystem.

**This is a important change, so it is necessary to open a new PR for it.**

### Does this PR introduce any user facing changes?

No.
