### PR TITLE
Support StressWorkerBench using consistent hash policy

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -71,8 +71,8 @@ public interface WorkerLocationPolicy {
         WorkerLocationPolicy workerLocationPolicy = CommonUtils.createNewClassInstance(
             conf.getClass(PropertyKey.USER_WORKER_SELECTION_POLICY),
             new Class[] {AlluxioConfiguration.class}, new Object[] {conf});
-        LOG.debug(String.format("Using worker location policy: %s",
-            workerLocationPolicy.getClass().getSimpleName()));
+        LOG.debug("Using worker location policy: {}",
+            workerLocationPolicy.getClass().getSimpleName());
         return workerLocationPolicy;
       } catch (ClassCastException e) {
         throw new RuntimeException(e);

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -16,7 +16,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.ResourceExhaustedException;
 import alluxio.util.CommonUtils;
-import org.apache.logging.slf4j.Log4jLogger;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +57,7 @@ public interface WorkerLocationPolicy {
    */
   class Factory {
     private static final Logger LOG = LoggerFactory.getLogger(Factory.class);
+
     private Factory() {} // prevent instantiation
 
     /**

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -16,6 +16,9 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.ResourceExhaustedException;
 import alluxio.util.CommonUtils;
+import org.apache.logging.slf4j.Log4jLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -53,6 +56,7 @@ public interface WorkerLocationPolicy {
    * The factory for the {@link WorkerLocationPolicy}.
    */
   class Factory {
+    private static final Logger LOG = LoggerFactory.getLogger(Factory.class);
     private Factory() {} // prevent instantiation
 
     /**
@@ -63,9 +67,12 @@ public interface WorkerLocationPolicy {
      */
     public static WorkerLocationPolicy create(AlluxioConfiguration conf) {
       try {
-        return CommonUtils.createNewClassInstance(
+        WorkerLocationPolicy workerLocationPolicy = CommonUtils.createNewClassInstance(
             conf.getClass(PropertyKey.USER_WORKER_SELECTION_POLICY),
             new Class[] {AlluxioConfiguration.class}, new Object[] {conf});
+        LOG.info(String.format("Using worker location policy: %s",
+            workerLocationPolicy.getClass().getSimpleName()));
+        return workerLocationPolicy;
       } catch (ClassCastException e) {
         throw new RuntimeException(e);
       }

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerLocationPolicy.java
@@ -71,7 +71,7 @@ public interface WorkerLocationPolicy {
         WorkerLocationPolicy workerLocationPolicy = CommonUtils.createNewClassInstance(
             conf.getClass(PropertyKey.USER_WORKER_SELECTION_POLICY),
             new Class[] {AlluxioConfiguration.class}, new Object[] {conf});
-        LOG.info(String.format("Using worker location policy: %s",
+        LOG.debug(String.format("Using worker location policy: %s",
             workerLocationPolicy.getClass().getSimpleName()));
         return workerLocationPolicy;
       } catch (ClassCastException e) {

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchMode.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchMode.java
@@ -1,0 +1,36 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.stress.worker;
+
+/**
+ * WorkerBenchMode, HASH or LOCAL_ONLY.
+ */
+public enum WorkerBenchMode {
+  HASH("HASH"),
+  LOCAL_ONLY("LOCAL_ONLY");
+
+  private final String mName;
+
+  /**
+   * Constructor.
+   *
+   * @param name of the client type
+   */
+  WorkerBenchMode(String name) {
+    mName = name;
+  }
+
+  @Override
+  public String toString() {
+    return mName;
+  }
+}

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
@@ -98,11 +98,12 @@ public final class WorkerBenchParameters extends FileSystemParameters {
   public String mSliceSize = "1s";
 
   @Parameter(names = {"--mode"},
-      description = "Decide which policy to use for file reads."
-          // + "Possible values are: [local-only, remote-only, hash]."
-          + "Possible values are: [local-only, hash]."
-          + "By default, the mode is 'hash'")
-  public String mMode = "hash";
+      description = "Specifies which worker the test process reads from."
+          + "Possible values are: [HASH, LOCAL_ONLY]"
+          + "HASH - alluxio.client.file.dora.ConsistentHashPolicy"
+          + "LOCAL_ONLY - alluxio.client.file.dora.LocalWorkerPolicy"
+          + "The default is HASH.")
+  public String mMode = "HASH";
 
   @DynamicParameter(names = "--conf", description = "HDFS client configuration. Can be repeated.")
   public Map<String, String> mConf = new HashMap<>();

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
@@ -100,10 +100,10 @@ public final class WorkerBenchParameters extends FileSystemParameters {
   @Parameter(names = {"--mode"},
       description = "Specifies which worker the test process reads from."
           + "Possible values are: [HASH, LOCAL_ONLY]"
-          + "HASH - alluxio.client.file.dora.ConsistentHashPolicy"
-          + "LOCAL_ONLY - alluxio.client.file.dora.LocalWorkerPolicy"
+          + "HASH -> alluxio.client.file.dora.ConsistentHashPolicy"
+          + "LOCAL_ONLY -> alluxio.client.file.dora.LocalWorkerPolicy"
           + "The default is HASH.")
-  public String mMode = "HASH";
+  public WorkerBenchMode mMode = WorkerBenchMode.HASH;
 
   @DynamicParameter(names = "--conf", description = "HDFS client configuration. Can be repeated.")
   public Map<String, String> mConf = new HashMap<>();

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
@@ -97,6 +97,13 @@ public final class WorkerBenchParameters extends FileSystemParameters {
           + "This argument sets the size of that window.")
   public String mSliceSize = "1s";
 
+  @Parameter(names = {"--mode"},
+      description = "Decide which policy to use for file reads."
+          // + "Possible values are: [local-only, remote-only, hash]."
+          + "Possible values are: [local-only, hash]."
+          + "By default, the mode is 'hash'")
+  public String mMode = "hash";
+
   @DynamicParameter(names = "--conf", description = "HDFS client configuration. Can be repeated.")
   public Map<String, String> mConf = new HashMap<>();
 }

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -26,7 +26,6 @@ import alluxio.stress.cli.AbstractStressBench;
 import alluxio.stress.common.FileSystemParameters;
 import alluxio.stress.worker.WorkerBenchCoarseDataPoint;
 import alluxio.stress.worker.WorkerBenchDataPoint;
-import alluxio.stress.worker.WorkerBenchMode;
 import alluxio.stress.worker.WorkerBenchParameters;
 import alluxio.stress.worker.WorkerBenchTaskResult;
 import alluxio.util.CommonUtils;

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -191,16 +191,18 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
         "true");
 
     // default mode value: hash, using consistent hash
-    if (Objects.equals(mParameters.mMode, "local-only")) {
+    // TODO(jiacheng): we may need a policy to only IO to remote worker
+    if (Objects.equals(mParameters.mMode, "LOCAL_ONLY")) {
       hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
           "alluxio.client.file.dora.LocalWorkerPolicy");
-    } else if (Objects.equals(mParameters.mMode, "remote-only")) {
-      // TODO(jiacheng): we may need a policy to only IO to remote worker
-      LOG.warn("Remote-only policy is not available. Switching to consistent hash policy.");
-      mParameters.mMode = "hash";
-    } else if (!Objects.equals(mParameters.mMode, "hash")) {
+    } else if (Objects.equals(mParameters.mMode, "HASH")) {
+      hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
+          "alluxio.client.file.dora.ConsistentHashPolicy");
+    } else {
       LOG.warn("Invalid mode. Switching to consistent hash policy.");
-      mParameters.mMode = "hash";
+      hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
+          "alluxio.client.file.dora.ConsistentHashPolicy");
+      mParameters.mMode = "HASH";
     }
     LOG.info("User worker selection policy: {}", mParameters.mMode);
 

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -45,7 +45,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
@@ -194,7 +198,7 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
       // TODO(jiacheng): we may need a policy to only IO to remote worker
       LOG.warn("Remote-only policy is not available. Switching to consistent hash policy.");
       mParameters.mMode = "hash";
-    } else if (!Objects.equals(mParameters.mMode, "hash")){
+    } else if (!Objects.equals(mParameters.mMode, "hash")) {
       LOG.warn("Invalid mode. Switching to consistent hash policy.");
       mParameters.mMode = "hash";
     }

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -202,10 +202,7 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
             "alluxio.client.file.dora.LocalWorkerPolicy");
         break;
       default:
-        LOG.warn("Invalid mode. Switching to consistent hash policy.");
-        hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
-            "alluxio.client.file.dora.ConsistentHashPolicy");
-        mParameters.mMode = WorkerBenchMode.HASH;
+        throw new IllegalArgumentException("Unrecognized mode" + mParameters.mMode);
     }
     LOG.info("User worker selection policy: {}", mParameters.mMode);
 

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -26,6 +26,7 @@ import alluxio.stress.cli.AbstractStressBench;
 import alluxio.stress.common.FileSystemParameters;
 import alluxio.stress.worker.WorkerBenchCoarseDataPoint;
 import alluxio.stress.worker.WorkerBenchDataPoint;
+import alluxio.stress.worker.WorkerBenchMode;
 import alluxio.stress.worker.WorkerBenchParameters;
 import alluxio.stress.worker.WorkerBenchTaskResult;
 import alluxio.util.CommonUtils;
@@ -49,7 +50,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
@@ -192,17 +192,20 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
 
     // default mode value: hash, using consistent hash
     // TODO(jiacheng): we may need a policy to only IO to remote worker
-    if (Objects.equals(mParameters.mMode, "LOCAL_ONLY")) {
-      hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
-          "alluxio.client.file.dora.LocalWorkerPolicy");
-    } else if (Objects.equals(mParameters.mMode, "HASH")) {
-      hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
-          "alluxio.client.file.dora.ConsistentHashPolicy");
-    } else {
-      LOG.warn("Invalid mode. Switching to consistent hash policy.");
-      hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
-          "alluxio.client.file.dora.ConsistentHashPolicy");
-      mParameters.mMode = "HASH";
+    switch (mParameters.mMode) {
+      case HASH:
+        hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
+            "alluxio.client.file.dora.ConsistentHashPolicy");
+        break;
+      case LOCAL_ONLY:
+        hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
+            "alluxio.client.file.dora.LocalWorkerPolicy");
+        break;
+      default:
+        LOG.warn("Invalid mode. Switching to consistent hash policy.");
+        hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
+            "alluxio.client.file.dora.ConsistentHashPolicy");
+        mParameters.mMode = WorkerBenchMode.HASH;
     }
     LOG.info("User worker selection policy: {}", mParameters.mMode);
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
This PR adds a `--mode` option for StressWorkerBench. This option allows user to choose from a range of file read policies. Possible option values are `hash`(default) and `local-only`.

If use `hash`, the config `alluxio.client.file.dora.ConsistentHashPolicy` is set to `alluxio.client.file.dora.ConsistentHashPolicy`.

If use `local-only`, that config is set to `alluxio.client.file.dora.LocalWorkerPolicy`.

The benchmark will parse this option, and choose the right policy. Also, it will print a log about the policy the user is using in both the benchmark and the policy factory.

### Why are the changes needed?
In previous versions, the default policy is `local-only`.

However, in Alluxio, the default policy is `hash`, using `alluxio.client.file.dora.ConsistentHashPolicy`.

If user wants to use the `local-only` policy, add `--mode local-only` to the end of the benchmark command.