### PR TITLE
Avoid creating FileSystem instance many times in HttpServerHandler

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
@@ -61,12 +61,20 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
 
   private final PagedService mPagedService;
 
+  private final FileSystemContext mFileSystemContext;
+
+  private final FileSystem mFileSystem;
+
   /**
    * {@link HttpServerHandler} deals with HTTP requests received from Netty Channel.
    * @param pagedService the {@link PagedService} object provides page related RESTful API
+   * @param fsContextFactory the factory for creating file system context
    */
-  public HttpServerHandler(PagedService pagedService) {
+  public HttpServerHandler(PagedService pagedService,
+                           FileSystemContext.FileSystemContextFactory fsContextFactory) {
     mPagedService = pagedService;
+    mFileSystemContext = fsContextFactory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create(mFileSystemContext);
   }
 
   @Override
@@ -146,12 +154,7 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
     ListStatusPOptions options = FileSystemOptionsUtils.listStatusDefaults(
         Configuration.global()).toBuilder().build();
     try {
-      FileSystemContext.FileSystemContextFactory factory =
-          new FileSystemContext.FileSystemContextFactory();
-      FileSystemContext fileSystemContext = factory.create(Configuration.global());
-      FileSystem fileSystem = FileSystem.Factory.create(fileSystemContext);
-
-      List<URIStatus> uriStatuses = fileSystem.listStatus(new AlluxioURI(path), options);
+      List<URIStatus> uriStatuses = mFileSystem.listStatus(new AlluxioURI(path), options);
       List<ResponseFileInfo> responseFileInfoList = new ArrayList<>();
       for (URIStatus uriStatus : uriStatuses) {
         String type = uriStatus.isFolder() ? "directory" : "file";
@@ -185,5 +188,12 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
     cause.printStackTrace();
     ctx.close();
+  }
+
+  @Override
+  public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+    super.handlerRemoved(ctx);
+    mFileSystem.close();
+    mFileSystemContext.close();
   }
 }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerInitializer.java
@@ -11,6 +11,8 @@
 
 package alluxio.worker.http;
 
+import alluxio.client.file.FileSystemContext;
+
 import com.google.inject.Inject;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
@@ -26,13 +28,18 @@ public class HttpServerInitializer extends ChannelInitializer<SocketChannel> {
 
   private final PagedService mPagedService;
 
+  private final FileSystemContext.FileSystemContextFactory mFsContextFactory;
+
   /**
    * {@link HttpServerInitializer} is used for initializing the Netty pipeline of HTTP Server.
    * @param pagedService the {@link PagedService} object provides page related RESTful API
+   * @param fsContextFactory the file system context factory
    */
   @Inject
-  public HttpServerInitializer(PagedService pagedService) {
+  public HttpServerInitializer(PagedService pagedService,
+                               FileSystemContext.FileSystemContextFactory fsContextFactory) {
     mPagedService = pagedService;
+    mFsContextFactory = fsContextFactory;
   }
 
   @Override
@@ -41,6 +48,6 @@ public class HttpServerInitializer extends ChannelInitializer<SocketChannel> {
     p.addLast(new HttpServerCodec());
     p.addLast(new HttpObjectAggregator(1024 * 10));
     p.addLast(new HttpServerExpectContinueHandler());
-    p.addLast(new HttpServerHandler(mPagedService));
+    p.addLast(new HttpServerHandler(mPagedService, mFsContextFactory));
   }
 }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/modules/DoraWorkerModule.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/modules/DoraWorkerModule.java
@@ -12,6 +12,7 @@
 package alluxio.worker.modules;
 
 import alluxio.ClientContext;
+import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.cache.CacheManager;
 import alluxio.client.file.cache.CacheManagerOptions;
 import alluxio.client.file.cache.PageMetaStore;
@@ -84,6 +85,7 @@ public class DoraWorkerModule extends AbstractModule {
     }
 
     // HTTP Server
+    bind(FileSystemContext.FileSystemContextFactory.class).in(Scopes.SINGLETON);
     bind(PagedService.class).in(Scopes.SINGLETON);
     bind(HttpServerInitializer.class).in(Scopes.SINGLETON);
     bind(HttpServer.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
Avoid creating `FileSystem` instance many times in `HttpServerHandler`, and call the `close()` method when the handler is removed.