### PR TITLE
Refactor handling of java opts env vars in cli

### DIFF
--- a/cli/src/alluxio.org/cli/cmd/cache/format.go
+++ b/cli/src/alluxio.org/cli/cmd/cache/format.go
@@ -23,7 +23,7 @@ var Format = &FormatCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "format",
 		JavaClassName: "alluxio.cli.Format",
-		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
+		ShellJavaOpts: []string{fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console")},
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/conf/get.go
+++ b/cli/src/alluxio.org/cli/cmd/conf/get.go
@@ -26,7 +26,7 @@ var Get = &GetCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "get",
 		JavaClassName: "alluxio.cli.GetConf",
-		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioConfValidationEnabled, false),
+		ShellJavaOpts: []string{fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioConfValidationEnabled, false)},
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/exec/test_basic_io.go
+++ b/cli/src/alluxio.org/cli/cmd/exec/test_basic_io.go
@@ -23,7 +23,7 @@ var TestRun = &TestRunCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "basicIOTest",
 		JavaClassName: "alluxio.cli.TestRunner",
-		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
+		ShellJavaOpts: []string{fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console")},
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/exec/test_hdfs_mount.go
+++ b/cli/src/alluxio.org/cli/cmd/exec/test_hdfs_mount.go
@@ -23,7 +23,7 @@ var TestHdfsMount = &TestHdfsMountCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "hdfsMountTest",
 		JavaClassName: "alluxio.cli.ValidateHdfsMount",
-		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
+		ShellJavaOpts: []string{fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console")},
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/exec/test_worker.go
+++ b/cli/src/alluxio.org/cli/cmd/exec/test_worker.go
@@ -9,46 +9,45 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
- package exec
+package exec
 
- import (
-	 "fmt"
- 
-	 "github.com/spf13/cobra"
- 
-	 "alluxio.org/cli/env"
- )
- 
- var TestRunCluster = &TestClusterCommand{
-	 BaseJavaCommand: &env.BaseJavaCommand{
-		 CommandName:   "checkCluster",
-		 JavaClassName: "alluxio.cli.CheckCluster",
-		 ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
-	 },
- }
- 
- type TestClusterCommand struct {
-	 *env.BaseJavaCommand
- }
- 
- func (c *TestClusterCommand) Base() *env.BaseJavaCommand {
-	 return c.BaseJavaCommand
- }
- 
- func (c *TestClusterCommand) ToCommand() *cobra.Command {
-	 cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
-		 Use:   "checkCluster",
-		 Args:  cobra.NoArgs,
-		 Short: "Test whether the workers have already run successfully.",
-		 RunE: func(cmd *cobra.Command, args []string) error {
-			 return c.Run(args)
-		 },
-	 })
-	 return cmd
- }
- 
- func (c *TestClusterCommand) Run(args []string) error {
-	 var javaArgs []string
-	 return c.Base().Run(javaArgs)
- }
- 
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"alluxio.org/cli/env"
+)
+
+var TestRunCluster = &TestClusterCommand{
+	BaseJavaCommand: &env.BaseJavaCommand{
+		CommandName:   "checkCluster",
+		JavaClassName: "alluxio.cli.CheckCluster",
+		ShellJavaOpts: []string{fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console")},
+	},
+}
+
+type TestClusterCommand struct {
+	*env.BaseJavaCommand
+}
+
+func (c *TestClusterCommand) Base() *env.BaseJavaCommand {
+	return c.BaseJavaCommand
+}
+
+func (c *TestClusterCommand) ToCommand() *cobra.Command {
+	cmd := c.Base().InitRunJavaClassCmd(&cobra.Command{
+		Use:   "checkCluster",
+		Args:  cobra.NoArgs,
+		Short: "Test whether the workers have already run successfully.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Run(args)
+		},
+	})
+	return cmd
+}
+
+func (c *TestClusterCommand) Run(args []string) error {
+	var javaArgs []string
+	return c.Base().Run(javaArgs)
+}

--- a/cli/src/alluxio.org/cli/cmd/generate/doc_tables.go
+++ b/cli/src/alluxio.org/cli/cmd/generate/doc_tables.go
@@ -23,7 +23,7 @@ var DocTables = &DocTablesCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "doc-tables",
 		JavaClassName: "alluxio.cli.DocGenerator",
-		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
+		ShellJavaOpts: []string{fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console")},
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/initiate/validate.go
+++ b/cli/src/alluxio.org/cli/cmd/initiate/validate.go
@@ -23,7 +23,7 @@ import (
 var Validate = &ValidateCommand{
 	BaseJavaCommand: &env.BaseJavaCommand{
 		CommandName:   "validate",
-		ShellJavaOpts: fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
+		ShellJavaOpts: []string{fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console")},
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/journal/format.go
+++ b/cli/src/alluxio.org/cli/cmd/journal/format.go
@@ -28,7 +28,7 @@ var Format = &FormatCommand{
 		JavaClassName:      "alluxio.cli.Format",
 		Parameters:         []string{"master"},
 		UseServerClasspath: true,
-		ShellJavaOpts:      fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
+		ShellJavaOpts:      []string{fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console")},
 	},
 }
 

--- a/cli/src/alluxio.org/cli/cmd/journal/read.go
+++ b/cli/src/alluxio.org/cli/cmd/journal/read.go
@@ -26,7 +26,7 @@ var Read = &ReadCommand{
 		CommandName:        "read",
 		JavaClassName:      "alluxio.master.journal.tool.JournalTool",
 		UseServerClasspath: true,
-		ShellJavaOpts:      fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console"),
+		ShellJavaOpts:      []string{fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, "Console")},
 	},
 }
 

--- a/cli/src/alluxio.org/cli/env/command.go
+++ b/cli/src/alluxio.org/cli/env/command.go
@@ -40,7 +40,7 @@ type BaseJavaCommand struct {
 
 	UseServerClasspath bool     // defaults to ALLUXIO_CLIENT_CLASSPATH, use ALLUXIO_SERVER_CLASSPATH if true
 	InlineJavaOpts     []string // java opts provided by the user as part of the inline command
-	ShellJavaOpts      string   // default java opts encoded as part of the specific command
+	ShellJavaOpts      []string // default java opts encoded as part of the specific command
 }
 
 const (
@@ -77,8 +77,8 @@ func (c *BaseJavaCommand) RunJavaClassCmd(args []string) *exec.Cmd {
 	if opts := Env.EnvVar.GetString(ConfAlluxioUserJavaOpts.EnvVar); opts != "" {
 		cmdArgs = append(cmdArgs, strings.Split(opts, " ")...)
 	}
-	if opts := c.ShellJavaOpts; opts != "" {
-		cmdArgs = append(cmdArgs, strings.Split(opts, " ")...)
+	if len(c.ShellJavaOpts) > 0 {
+		cmdArgs = append(cmdArgs, c.ShellJavaOpts...)
 	}
 	for _, o := range c.InlineJavaOpts {
 		if opts := strings.TrimSpace(o); opts != "" {

--- a/cli/src/alluxio.org/cli/env/command.go
+++ b/cli/src/alluxio.org/cli/env/command.go
@@ -77,7 +77,7 @@ func (c *BaseJavaCommand) RunJavaClassCmd(args []string) *exec.Cmd {
 	if opts := Env.EnvVar.GetString(ConfAlluxioUserJavaOpts.EnvVar); opts != "" {
 		cmdArgs = append(cmdArgs, strings.Split(opts, " ")...)
 	}
-	if opts := strings.TrimSpace(c.ShellJavaOpts); opts != "" {
+	if opts := c.ShellJavaOpts; opts != "" {
 		cmdArgs = append(cmdArgs, strings.Split(opts, " ")...)
 	}
 	for _, o := range c.InlineJavaOpts {

--- a/cli/src/alluxio.org/cli/env/env.go
+++ b/cli/src/alluxio.org/cli/env/env.go
@@ -153,7 +153,7 @@ func InitAlluxioEnv(rootPath string, jarEnvVars map[string]string, appendClasspa
 		ConfAlluxioLogsDir,
 		confAlluxioUserLogsDir,
 	} {
-		alluxioJavaOpts += c.ToJavaOpt(envVar, true) // mandatory java opts
+		alluxioJavaOpts += " " + c.ToJavaOpt(envVar, true) // mandatory java opts
 	}
 
 	for _, c := range []*AlluxioConfigEnvVar{
@@ -163,13 +163,14 @@ func InitAlluxioEnv(rootPath string, jarEnvVars map[string]string, appendClasspa
 		ConfAlluxioMasterJournalType,
 		confAlluxioWorkerRamdiskSize,
 	} {
-		alluxioJavaOpts += c.ToJavaOpt(envVar, false) // optional user provided java opts
+		alluxioJavaOpts += " " + c.ToJavaOpt(envVar, false) // optional user provided java opts
 	}
-
-	alluxioJavaOpts += fmt.Sprintf(JavaOptFormat, "log4j.configuration", "file:"+filepath.Join(envVar.GetString(ConfAlluxioConfDir.EnvVar), "log4j.properties"))
-	alluxioJavaOpts += fmt.Sprintf(JavaOptFormat, "org.apache.jasper.compiler.disablejsr199", true)
-	alluxioJavaOpts += fmt.Sprintf(JavaOptFormat, "java.net.preferIPv4Stack", true)
-	alluxioJavaOpts += fmt.Sprintf(JavaOptFormat, "org.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads", false)
+	alluxioJavaOpts += " " + strings.Join([]string{
+		fmt.Sprintf(JavaOptFormat, "log4j.configuration", "file:"+filepath.Join(envVar.GetString(ConfAlluxioConfDir.EnvVar), "log4j.properties")),
+		fmt.Sprintf(JavaOptFormat, "org.apache.jasper.compiler.disablejsr199", true),
+		fmt.Sprintf(JavaOptFormat, "java.net.preferIPv4Stack", true),
+		fmt.Sprintf(JavaOptFormat, "org.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads", false),
+	}, " ")
 
 	envVar.Set(ConfAlluxioJavaOpts.EnvVar, alluxioJavaOpts)
 

--- a/cli/src/alluxio.org/cli/env/env.go
+++ b/cli/src/alluxio.org/cli/env/env.go
@@ -69,20 +69,7 @@ func InitAlluxioEnv(rootPath string, jarEnvVars map[string]string, appendClasspa
 		envVar.Set(envVersion, ver)
 	}
 
-	// set default values
-	for k, v := range map[string]string{
-		ConfAlluxioHome.EnvVar:        rootPath,
-		ConfAlluxioConfDir.EnvVar:     filepath.Join(rootPath, "conf"),
-		ConfAlluxioLogsDir.EnvVar:     filepath.Join(rootPath, "logs"),
-		confAlluxioUserLogsDir.EnvVar: filepath.Join(rootPath, "logs", "user"),
-	} {
-		envVar.SetDefault(k, v)
-	}
-
-	// set jar env vars
-	for envVarName, jarPathFormat := range jarEnvVars {
-		envVar.SetDefault(envVarName, filepath.Join(rootPath, fmt.Sprintf(jarPathFormat, ver)))
-	}
+	setEnvDefaults(envVar, ver, rootPath, jarEnvVars)
 
 	// set user-specified environment variable values from alluxio-env.sh
 	{
@@ -108,17 +95,7 @@ func InitAlluxioEnv(rootPath string, jarEnvVars map[string]string, appendClasspa
 		}
 	}
 
-	// set classpath variables which are dependent on user configurable values
-	envVar.Set(EnvAlluxioClientClasspath, strings.Join([]string{
-		envVar.GetString(ConfAlluxioConfDir.EnvVar) + "/",
-		envVar.GetString(confAlluxioClasspath.EnvVar),
-		envVar.GetString(EnvAlluxioAssemblyClientJar),
-	}, ":"))
-	envVar.Set(EnvAlluxioServerClasspath, strings.Join([]string{
-		envVar.GetString(ConfAlluxioConfDir.EnvVar) + "/",
-		envVar.GetString(confAlluxioClasspath.EnvVar),
-		envVar.GetString(EnvAlluxioAssemblyServerJar),
-	}, ":"))
+	setClasspathVariables(envVar)
 
 	for envVarName, envF := range appendClasspathJars {
 		envVar.Set(envVarName, envF(envVar, ver))
@@ -132,58 +109,7 @@ func InitAlluxioEnv(rootPath string, jarEnvVars map[string]string, appendClasspa
 		return stacktrace.Propagate(err, "error checking java version compatibility")
 	}
 
-	// append default opts to ALLUXIO_JAVA_OPTS
-	alluxioJavaOpts := ConfAlluxioJavaOpts.JavaOptsToArgs(envVar)
-	if opts := strings.Join(alluxioJavaOpts, " "); opts != "" {
-		// warn about setting configuration through java opts that should be set through environment variables instead
-		for _, c := range []*AlluxioConfigEnvVar{
-			ConfAlluxioConfDir,
-			ConfAlluxioLogsDir,
-			confAlluxioUserLogsDir,
-		} {
-			if strings.Contains(opts, c.configKey) {
-				log.Logger.Warnf("Setting %v through %v will be ignored. Use environment variable %v instead.", c.configKey, ConfAlluxioJavaOpts.EnvVar, c.EnvVar)
-			}
-		}
-	}
-
-	for _, c := range []*AlluxioConfigEnvVar{
-		ConfAlluxioHome,
-		ConfAlluxioConfDir,
-		ConfAlluxioLogsDir,
-		confAlluxioUserLogsDir,
-	} {
-		alluxioJavaOpts = append(alluxioJavaOpts, c.ConfigToJavaOpts(envVar, true)...) // mandatory java opts
-	}
-
-	for _, c := range []*AlluxioConfigEnvVar{
-		confAlluxioRamFolder,
-		confAlluxioMasterHostname,
-		ConfAlluxioMasterMountTableRootUfs,
-		ConfAlluxioMasterJournalType,
-		confAlluxioWorkerRamdiskSize,
-	} {
-		alluxioJavaOpts = append(alluxioJavaOpts, c.ConfigToJavaOpts(envVar, false)...) // optional user provided java opts
-	}
-	alluxioJavaOpts = append(alluxioJavaOpts,
-		fmt.Sprintf(JavaOptFormat, "log4j.configuration", "file:"+filepath.Join(envVar.GetString(ConfAlluxioConfDir.EnvVar), "log4j.properties")),
-		fmt.Sprintf(JavaOptFormat, "org.apache.jasper.compiler.disablejsr199", true),
-		fmt.Sprintf(JavaOptFormat, "java.net.preferIPv4Stack", true),
-		fmt.Sprintf(JavaOptFormat, "org.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads", false),
-	)
-
-	envVar.Set(ConfAlluxioJavaOpts.EnvVar, strings.Join(alluxioJavaOpts, " "))
-
-	for _, p := range ProcessRegistry {
-		p.SetEnvVars(envVar)
-	}
-
-	// also set user environment variables, as they are not associated with a particular process
-	// ALLUXIO_USER_JAVA_OPTS = {default logger opts} ${ALLUXIO_JAVA_OPTS} {user provided opts}
-	userJavaOpts := []string{fmt.Sprintf(JavaOptFormat, ConfAlluxioLoggerType, userLoggerType)}
-	userJavaOpts = append(userJavaOpts, ConfAlluxioJavaOpts.JavaOptsToArgs(envVar)...)
-	userJavaOpts = append(userJavaOpts, ConfAlluxioUserJavaOpts.JavaOptsToArgs(envVar)...)
-	envVar.Set(ConfAlluxioUserJavaOpts.EnvVar, strings.Join(userJavaOpts, " "))
+	setJavaOpts(envVar)
 
 	if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
 		keys := envVar.AllKeys()
@@ -254,4 +180,119 @@ func checkJavaVersion(javaPath string) error {
 		return stacktrace.NewError("Error: Alluxio requires Java 1.8 or 11.0, currently Java %v found.", matches[1])
 	}
 	return nil
+}
+
+func InitEnvForTesting(alluxioEnv map[string]string) {
+	envVar := viper.New()
+	ver := "300-testing"
+	envVar.Set(envVersion, ver)
+
+	rootPath := "/opt/alluxio"
+	setEnvDefaults(envVar, ver, rootPath, map[string]string{
+		EnvAlluxioAssemblyClientJar: filepath.Join("assembly", "client", "target", "alluxio-assembly-client-%v-jar-with-dependencies.jar"),
+		EnvAlluxioAssemblyServerJar: filepath.Join("assembly", "server", "target", "alluxio-assembly-server-%v-jar-with-dependencies.jar"),
+	})
+
+	// set test specified env
+	for k, v := range alluxioEnv {
+		envVar.Set(k, v)
+	}
+
+	setClasspathVariables(envVar)
+
+	// set dummy java
+	envVar.Set(ConfJava.EnvVar, "/usr/lib/java")
+
+	setJavaOpts(envVar)
+
+	Env = &AlluxioEnv{
+		RootPath: rootPath,
+		Version:  ver,
+		EnvVar:   envVar,
+	}
+}
+
+func setEnvDefaults(envVar *viper.Viper, ver, rootPath string, jarEnvVars map[string]string) {
+	// set default values
+	for k, v := range map[string]string{
+		ConfAlluxioHome.EnvVar:        rootPath,
+		ConfAlluxioConfDir.EnvVar:     filepath.Join(rootPath, "conf"),
+		ConfAlluxioLogsDir.EnvVar:     filepath.Join(rootPath, "logs"),
+		confAlluxioUserLogsDir.EnvVar: filepath.Join(rootPath, "logs", "user"),
+	} {
+		envVar.SetDefault(k, v)
+	}
+	// set jar env vars
+	for envVarName, jarPathFormat := range jarEnvVars {
+		envVar.SetDefault(envVarName, filepath.Join(rootPath, fmt.Sprintf(jarPathFormat, ver)))
+	}
+}
+
+func setClasspathVariables(envVar *viper.Viper) {
+	// set classpath variables which are dependent on user configurable values
+	envVar.Set(EnvAlluxioClientClasspath, strings.Join([]string{
+		envVar.GetString(ConfAlluxioConfDir.EnvVar) + "/",
+		envVar.GetString(confAlluxioClasspath.EnvVar),
+		envVar.GetString(EnvAlluxioAssemblyClientJar),
+	}, ":"))
+	envVar.Set(EnvAlluxioServerClasspath, strings.Join([]string{
+		envVar.GetString(ConfAlluxioConfDir.EnvVar) + "/",
+		envVar.GetString(confAlluxioClasspath.EnvVar),
+		envVar.GetString(EnvAlluxioAssemblyServerJar),
+	}, ":"))
+}
+
+func setJavaOpts(envVar *viper.Viper) {
+	// append default opts to ALLUXIO_JAVA_OPTS
+	alluxioJavaOpts := ConfAlluxioJavaOpts.JavaOptsToArgs(envVar)
+	if opts := strings.Join(alluxioJavaOpts, " "); opts != "" {
+		// warn about setting configuration through java opts that should be set through environment variables instead
+		for _, c := range []*AlluxioConfigEnvVar{
+			ConfAlluxioConfDir,
+			ConfAlluxioLogsDir,
+			confAlluxioUserLogsDir,
+		} {
+			if strings.Contains(opts, c.configKey) {
+				log.Logger.Warnf("Setting %v through %v will be ignored. Use environment variable %v instead.", c.configKey, ConfAlluxioJavaOpts.EnvVar, c.EnvVar)
+			}
+		}
+	}
+
+	for _, c := range []*AlluxioConfigEnvVar{
+		ConfAlluxioHome,
+		ConfAlluxioConfDir,
+		ConfAlluxioLogsDir,
+		confAlluxioUserLogsDir,
+	} {
+		alluxioJavaOpts = append(alluxioJavaOpts, c.ConfigToJavaOpts(envVar, true)...) // mandatory java opts
+	}
+
+	for _, c := range []*AlluxioConfigEnvVar{
+		confAlluxioRamFolder,
+		confAlluxioMasterHostname,
+		ConfAlluxioMasterMountTableRootUfs,
+		ConfAlluxioMasterJournalType,
+		confAlluxioWorkerRamdiskSize,
+	} {
+		alluxioJavaOpts = append(alluxioJavaOpts, c.ConfigToJavaOpts(envVar, false)...) // optional user provided java opts
+	}
+	alluxioJavaOpts = append(alluxioJavaOpts,
+		fmt.Sprintf(JavaOptFormat, "log4j.configuration", "file:"+filepath.Join(envVar.GetString(ConfAlluxioConfDir.EnvVar), "log4j.properties")),
+		fmt.Sprintf(JavaOptFormat, "org.apache.jasper.compiler.disablejsr199", true),
+		fmt.Sprintf(JavaOptFormat, "java.net.preferIPv4Stack", true),
+		fmt.Sprintf(JavaOptFormat, "org.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads", false),
+	)
+
+	envVar.Set(ConfAlluxioJavaOpts.EnvVar, strings.Join(alluxioJavaOpts, " "))
+
+	for _, p := range ProcessRegistry {
+		p.SetEnvVars(envVar)
+	}
+
+	// also set user environment variables, as they are not associated with a particular process
+	// ALLUXIO_USER_JAVA_OPTS = {default logger opts} ${ALLUXIO_JAVA_OPTS} {user provided opts}
+	userJavaOpts := []string{fmt.Sprintf(JavaOptFormat, ConfAlluxioLoggerType, userLoggerType)}
+	userJavaOpts = append(userJavaOpts, ConfAlluxioJavaOpts.JavaOptsToArgs(envVar)...)
+	userJavaOpts = append(userJavaOpts, ConfAlluxioUserJavaOpts.JavaOptsToArgs(envVar)...)
+	envVar.Set(ConfAlluxioUserJavaOpts.EnvVar, strings.Join(userJavaOpts, " "))
 }

--- a/cli/src/alluxio.org/cli/env/env_vars.go
+++ b/cli/src/alluxio.org/cli/env/env_vars.go
@@ -13,6 +13,7 @@ package env
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -135,4 +136,12 @@ func (a *AlluxioConfigEnvVar) ConfigToJavaOpts(env *viper.Viper, required bool) 
 		ret = append(ret, fmt.Sprintf(JavaOptFormat, k2, v2))
 	}
 	return ret
+}
+
+func (a *AlluxioConfigEnvVar) JavaOptsToArgs(env *viper.Viper) []string {
+	v := env.GetString(a.EnvVar)
+	if v == "" {
+		return nil
+	}
+	return strings.Split(v, " ")
 }

--- a/cli/src/alluxio.org/cli/env/env_vars.go
+++ b/cli/src/alluxio.org/cli/env/env_vars.go
@@ -122,17 +122,17 @@ var (
 	}
 )
 
-func (a *AlluxioConfigEnvVar) ToJavaOpt(env *viper.Viper, required bool) string {
+func (a *AlluxioConfigEnvVar) ConfigToJavaOpts(env *viper.Viper, required bool) []string {
 	v := env.Get(a.EnvVar)
 	if v == nil {
 		if required {
 			panic("No value set for required environment variable: " + a.EnvVar)
 		}
-		return ""
+		return nil
 	}
-	ret := fmt.Sprintf(JavaOptFormat, a.configKey, v)
+	ret := []string{fmt.Sprintf(JavaOptFormat, a.configKey, v)}
 	for k2, v2 := range a.additionalAlluxioJavaOpts {
-		ret += " " + fmt.Sprintf(JavaOptFormat, k2, v2)
+		ret = append(ret, fmt.Sprintf(JavaOptFormat, k2, v2))
 	}
 	return ret
 }

--- a/cli/src/alluxio.org/cli/env/env_vars.go
+++ b/cli/src/alluxio.org/cli/env/env_vars.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	JavaOptFormat = " -D%v=%v"
+	JavaOptFormat = "-D%v=%v"
 )
 
 // alluxioEnvVarsTemplate lists the environment variables to include in conf/alluxio-env.sh.template
@@ -128,7 +128,7 @@ func (a *AlluxioConfigEnvVar) ToJavaOpt(env *viper.Viper, required bool) string 
 	}
 	ret := fmt.Sprintf(JavaOptFormat, a.configKey, v)
 	for k2, v2 := range a.additionalAlluxioJavaOpts {
-		ret += fmt.Sprintf(JavaOptFormat, k2, v2)
+		ret += " " + fmt.Sprintf(JavaOptFormat, k2, v2)
 	}
 	return ret
 }

--- a/cli/src/alluxio.org/cli/env/env_vars.go
+++ b/cli/src/alluxio.org/cli/env/env_vars.go
@@ -139,6 +139,9 @@ func (a *AlluxioConfigEnvVar) ConfigToJavaOpts(env *viper.Viper, required bool) 
 }
 
 func (a *AlluxioConfigEnvVar) JavaOptsToArgs(env *viper.Viper) []string {
+	if !a.IsJavaOpts {
+		panic(fmt.Sprintf("cannot convert to args because %v is not declared to be a JAVA_OPT environment variable", a.EnvVar))
+	}
 	v := strings.TrimSpace(env.GetString(a.EnvVar))
 	if v == "" {
 		return nil

--- a/cli/src/alluxio.org/cli/env/env_vars.go
+++ b/cli/src/alluxio.org/cli/env/env_vars.go
@@ -139,7 +139,7 @@ func (a *AlluxioConfigEnvVar) ConfigToJavaOpts(env *viper.Viper, required bool) 
 }
 
 func (a *AlluxioConfigEnvVar) JavaOptsToArgs(env *viper.Viper) []string {
-	v := env.GetString(a.EnvVar)
+	v := strings.TrimSpace(env.GetString(a.EnvVar))
 	if v == "" {
 		return nil
 	}

--- a/cli/src/alluxio.org/cli/env/env_vars.go
+++ b/cli/src/alluxio.org/cli/env/env_vars.go
@@ -29,6 +29,7 @@ type AlluxioConfigEnvVar struct {
 	description string // describes the environment variable in conf/alluxio-env.sh.template file
 
 	// optional
+	IsJavaOpts                bool              // true if environment variable's value is a java opts string
 	configKey                 string            // corresponding property key as defined in java
 	additionalAlluxioJavaOpts map[string]string // additional java opts to append if non-empty java opt is added
 }
@@ -78,16 +79,19 @@ var (
 		EnvVar:    "ALLUXIO_USER_LOGS_DIR",
 	})
 	ConfAlluxioJavaOpts = RegisterTemplateEnvVar(&AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_JAVA_OPTS",
+		EnvVar:     "ALLUXIO_JAVA_OPTS",
+		IsJavaOpts: true,
 	})
 	confAlluxioClasspath = RegisterTemplateEnvVar(&AlluxioConfigEnvVar{
 		EnvVar: "ALLUXIO_CLASSPATH",
 	})
 	ConfAlluxioUserJavaOpts = RegisterTemplateEnvVar(&AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_USER_JAVA_OPTS",
+		EnvVar:     "ALLUXIO_USER_JAVA_OPTS",
+		IsJavaOpts: true,
 	})
 	ConfAlluxioUserAttachOpts = RegisterTemplateEnvVar(&AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_USER_ATTACH_OPTS",
+		EnvVar:     "ALLUXIO_USER_ATTACH_OPTS",
+		IsJavaOpts: true,
 	})
 )
 

--- a/cli/src/alluxio.org/cli/env/process.go
+++ b/cli/src/alluxio.org/cli/env/process.go
@@ -55,9 +55,9 @@ type Process interface {
 }
 
 type BaseProcess struct {
-	Name              string
-	JavaClassName     string
-	JavaOptsEnvVarKey string
+	Name          string
+	JavaClassName string
+	JavaOpts      *AlluxioConfigEnvVar
 
 	// start
 	ProcessOutFile string
@@ -115,7 +115,7 @@ var debugOptsToRemove = []*regexp.Regexp{
 func (p *BaseProcess) Monitor() error {
 	cmdArgs := []string{"-cp", Env.EnvVar.GetString(EnvAlluxioClientClasspath)}
 
-	javaOpts := strings.TrimSpace(Env.EnvVar.GetString(p.JavaOptsEnvVarKey))
+	javaOpts := strings.TrimSpace(Env.EnvVar.GetString(p.JavaOpts.EnvVar))
 	// remove debugging options from java opts for monitor process
 	for _, re := range debugOptsToRemove {
 		javaOpts = re.ReplaceAllString(javaOpts, "")

--- a/cli/src/alluxio.org/cli/processes/common.go
+++ b/cli/src/alluxio.org/cli/processes/common.go
@@ -255,3 +255,14 @@ func getSigner() (ssh.Signer, error) {
 	}
 	return parsedPrivateKey, nil
 }
+
+func argsContainsOpt(args []string, optPrefixes ...string) bool {
+	for _, arg := range args {
+		for _, prefix := range optPrefixes {
+			if strings.HasPrefix(arg, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/cli/src/alluxio.org/cli/processes/job_master.go
+++ b/cli/src/alluxio.org/cli/processes/job_master.go
@@ -13,8 +13,6 @@ package processes
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -79,14 +77,9 @@ func (p *JobMasterProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *JobMasterProcess) Start(cmd *env.StartProcessCommand) error {
 	cmdArgs := []string{env.Env.EnvVar.GetString(env.ConfJava.EnvVar)}
-	if attachOpts := env.Env.EnvVar.GetString(confAlluxioJobMasterAttachOpts.EnvVar); attachOpts != "" {
-		cmdArgs = append(cmdArgs, strings.Split(attachOpts, " ")...)
-	}
+	cmdArgs = append(cmdArgs, confAlluxioJobMasterAttachOpts.JavaOptsToArgs(env.Env.EnvVar)...)
 	cmdArgs = append(cmdArgs, "-cp", env.Env.EnvVar.GetString(env.EnvAlluxioServerClasspath))
-
-	jobMasterJavaOpts := env.Env.EnvVar.GetString(p.JavaOpts.EnvVar)
-	cmdArgs = append(cmdArgs, strings.Split(jobMasterJavaOpts, " ")...)
-
+	cmdArgs = append(cmdArgs, p.JavaOpts.JavaOptsToArgs(env.Env.EnvVar)...)
 	cmdArgs = append(cmdArgs, p.JavaClassName)
 
 	if err := p.Launch(cmd, cmdArgs); err != nil {

--- a/cli/src/alluxio.org/cli/processes/job_master.go
+++ b/cli/src/alluxio.org/cli/processes/job_master.go
@@ -62,12 +62,12 @@ func (p *JobMasterProcess) SetEnvVars(envVar *viper.Viper) {
 	envVar.SetDefault(envAlluxioJobMasterLogger, jobMasterLoggerType)
 	jobMasterJavaOpts := fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, envVar.Get(envAlluxioJobMasterLogger))
 	envVar.SetDefault(envAlluxioAuditJobMasterLogger, jobMasterAuditLoggerType)
-	jobMasterJavaOpts += fmt.Sprintf(env.JavaOptFormat, confAlluxioJobMasterAuditLoggerType, envVar.Get(envAlluxioAuditJobMasterLogger))
+	jobMasterJavaOpts += " " + fmt.Sprintf(env.JavaOptFormat, confAlluxioJobMasterAuditLoggerType, envVar.Get(envAlluxioAuditJobMasterLogger))
 
 	jobMasterJavaOpts += envVar.GetString(env.ConfAlluxioJavaOpts.EnvVar)
 	jobMasterJavaOpts += envVar.GetString(p.JavaOpts.EnvVar)
 
-	envVar.Set(p.JavaOpts.EnvVar, strings.TrimSpace(jobMasterJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
+	envVar.Set(p.JavaOpts.EnvVar, jobMasterJavaOpts)
 }
 
 func (p *JobMasterProcess) StartCmd(cmd *cobra.Command) *cobra.Command {

--- a/cli/src/alluxio.org/cli/processes/job_master.go
+++ b/cli/src/alluxio.org/cli/processes/job_master.go
@@ -42,10 +42,12 @@ const (
 
 var (
 	ConfAlluxioJobMasterJavaOpts = env.RegisterTemplateEnvVar(&env.AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_JOB_MASTER_JAVA_OPTS",
+		EnvVar:     "ALLUXIO_JOB_MASTER_JAVA_OPTS",
+		IsJavaOpts: true,
 	})
 	confAlluxioJobMasterAttachOpts = env.RegisterTemplateEnvVar(&env.AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_JOB_MASTER_ATTACH_OPTS",
+		EnvVar:     "ALLUXIO_JOB_MASTER_ATTACH_OPTS",
+		IsJavaOpts: true,
 	})
 )
 

--- a/cli/src/alluxio.org/cli/processes/job_master.go
+++ b/cli/src/alluxio.org/cli/processes/job_master.go
@@ -26,7 +26,7 @@ var JobMaster = &JobMasterProcess{
 	BaseProcess: &env.BaseProcess{
 		Name:                 "job_master",
 		JavaClassName:        "alluxio.master.AlluxioJobMaster",
-		JavaOptsEnvVarKey:    ConfAlluxioJobMasterJavaOpts.EnvVar,
+		JavaOpts:             ConfAlluxioJobMasterJavaOpts,
 		ProcessOutFile:       "job_master.out",
 		MonitorJavaClassName: "alluxio.master.job.AlluxioJobMasterMonitor",
 	},
@@ -65,9 +65,9 @@ func (p *JobMasterProcess) SetEnvVars(envVar *viper.Viper) {
 	jobMasterJavaOpts += fmt.Sprintf(env.JavaOptFormat, confAlluxioJobMasterAuditLoggerType, envVar.Get(envAlluxioAuditJobMasterLogger))
 
 	jobMasterJavaOpts += envVar.GetString(env.ConfAlluxioJavaOpts.EnvVar)
-	jobMasterJavaOpts += envVar.GetString(p.JavaOptsEnvVarKey)
+	jobMasterJavaOpts += envVar.GetString(p.JavaOpts.EnvVar)
 
-	envVar.Set(p.JavaOptsEnvVarKey, strings.TrimSpace(jobMasterJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
+	envVar.Set(p.JavaOpts.EnvVar, strings.TrimSpace(jobMasterJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
 }
 
 func (p *JobMasterProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
@@ -82,7 +82,7 @@ func (p *JobMasterProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 	cmdArgs = append(cmdArgs, "-cp", env.Env.EnvVar.GetString(env.EnvAlluxioServerClasspath))
 
-	jobMasterJavaOpts := env.Env.EnvVar.GetString(p.JavaOptsEnvVarKey)
+	jobMasterJavaOpts := env.Env.EnvVar.GetString(p.JavaOpts.EnvVar)
 	cmdArgs = append(cmdArgs, strings.Split(jobMasterJavaOpts, " ")...)
 
 	cmdArgs = append(cmdArgs, p.JavaClassName)

--- a/cli/src/alluxio.org/cli/processes/job_worker.go
+++ b/cli/src/alluxio.org/cli/processes/job_worker.go
@@ -74,14 +74,9 @@ func (p *JobWorkerProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *JobWorkerProcess) Start(cmd *env.StartProcessCommand) error {
 	cmdArgs := []string{env.Env.EnvVar.GetString(env.ConfJava.EnvVar)}
-	if attachOpts := env.Env.EnvVar.GetString(confAlluxioJobWorkerAttachOpts.EnvVar); attachOpts != "" {
-		cmdArgs = append(cmdArgs, strings.Split(attachOpts, " ")...)
-	}
+	cmdArgs = append(cmdArgs, confAlluxioJobWorkerAttachOpts.JavaOptsToArgs(env.Env.EnvVar)...)
 	cmdArgs = append(cmdArgs, "-cp", env.Env.EnvVar.GetString(env.EnvAlluxioServerClasspath))
-
-	jobWorkerJavaOpts := env.Env.EnvVar.GetString(p.JavaOpts.EnvVar)
-	cmdArgs = append(cmdArgs, strings.Split(jobWorkerJavaOpts, " ")...)
-
+	cmdArgs = append(cmdArgs, p.JavaOpts.JavaOptsToArgs(env.Env.EnvVar)...)
 	cmdArgs = append(cmdArgs, p.JavaClassName)
 
 	if err := p.Launch(cmd, cmdArgs); err != nil {

--- a/cli/src/alluxio.org/cli/processes/job_worker.go
+++ b/cli/src/alluxio.org/cli/processes/job_worker.go
@@ -26,7 +26,7 @@ var JobWorker = &WorkerProcess{
 	BaseProcess: &env.BaseProcess{
 		Name:                 "job_worker",
 		JavaClassName:        "alluxio.worker.AlluxioJobWorker",
-		JavaOptsEnvVarKey:    ConfAlluxioJobWorkerJavaOpts.EnvVar,
+		JavaOpts:             ConfAlluxioJobWorkerJavaOpts,
 		ProcessOutFile:       "job_worker.out",
 		MonitorJavaClassName: "alluxio.worker.job.AlluxioJobWorkerMonitor",
 	},
@@ -60,9 +60,9 @@ func (p *JobWorkerProcess) SetEnvVars(envVar *viper.Viper) {
 	jobWorkerJavaOpts := fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, envVar.Get(envAlluxioJobWorkerLogger))
 
 	jobWorkerJavaOpts += envVar.GetString(env.ConfAlluxioJavaOpts.EnvVar)
-	jobWorkerJavaOpts += envVar.GetString(p.JavaOptsEnvVarKey)
+	jobWorkerJavaOpts += envVar.GetString(p.JavaOpts.EnvVar)
 
-	envVar.Set(p.JavaOptsEnvVarKey, strings.TrimSpace(jobWorkerJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
+	envVar.Set(p.JavaOpts.EnvVar, strings.TrimSpace(jobWorkerJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
 }
 
 func (p *JobWorkerProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
@@ -77,7 +77,7 @@ func (p *JobWorkerProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 	cmdArgs = append(cmdArgs, "-cp", env.Env.EnvVar.GetString(env.EnvAlluxioServerClasspath))
 
-	jobWorkerJavaOpts := env.Env.EnvVar.GetString(p.JavaOptsEnvVarKey)
+	jobWorkerJavaOpts := env.Env.EnvVar.GetString(p.JavaOpts.EnvVar)
 	cmdArgs = append(cmdArgs, strings.Split(jobWorkerJavaOpts, " ")...)
 
 	cmdArgs = append(cmdArgs, p.JavaClassName)

--- a/cli/src/alluxio.org/cli/processes/job_worker.go
+++ b/cli/src/alluxio.org/cli/processes/job_worker.go
@@ -39,10 +39,12 @@ const (
 
 var (
 	ConfAlluxioJobWorkerJavaOpts = env.RegisterTemplateEnvVar(&env.AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_JOB_WORKER_JAVA_OPTS",
+		EnvVar:     "ALLUXIO_JOB_WORKER_JAVA_OPTS",
+		IsJavaOpts: true,
 	})
 	confAlluxioJobWorkerAttachOpts = env.RegisterTemplateEnvVar(&env.AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_JOB_WORKER_ATTACH_OPTS",
+		EnvVar:     "ALLUXIO_JOB_WORKER_ATTACH_OPTS",
+		IsJavaOpts: true,
 	})
 )
 

--- a/cli/src/alluxio.org/cli/processes/job_worker.go
+++ b/cli/src/alluxio.org/cli/processes/job_worker.go
@@ -57,14 +57,14 @@ func (p *JobWorkerProcess) Base() *env.BaseProcess {
 }
 
 func (p *JobWorkerProcess) SetEnvVars(envVar *viper.Viper) {
-	// ALLUXIO_JOB_WORKER_JAVA_OPTS = {default logger opts} ${ALLUXIO_JAVA_OPTS} ${ALLUXIO_WORKER_JAVA_OPTS}
 	envVar.SetDefault(envAlluxioJobWorkerLogger, jobWorkerLoggerType)
-	jobWorkerJavaOpts := fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, envVar.Get(envAlluxioJobWorkerLogger))
-
-	jobWorkerJavaOpts += envVar.GetString(env.ConfAlluxioJavaOpts.EnvVar)
-	jobWorkerJavaOpts += envVar.GetString(p.JavaOpts.EnvVar)
-
-	envVar.Set(p.JavaOpts.EnvVar, strings.TrimSpace(jobWorkerJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
+	// ALLUXIO_JOB_WORKER_JAVA_OPTS = {default logger opts} ${ALLUXIO_JAVA_OPTS} ${ALLUXIO_WORKER_JAVA_OPTS}
+	javaOpts := []string{
+		fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, envVar.Get(envAlluxioJobWorkerLogger)),
+	}
+	javaOpts = append(javaOpts, env.ConfAlluxioJavaOpts.JavaOptsToArgs(envVar)...)
+	javaOpts = append(javaOpts, p.JavaOpts.JavaOptsToArgs(envVar)...)
+	envVar.Set(p.JavaOpts.EnvVar, strings.Join(javaOpts, " "))
 }
 
 func (p *JobWorkerProcess) StartCmd(cmd *cobra.Command) *cobra.Command {

--- a/cli/src/alluxio.org/cli/processes/master.go
+++ b/cli/src/alluxio.org/cli/processes/master.go
@@ -68,12 +68,12 @@ func (p *MasterProcess) SetEnvVars(envVar *viper.Viper) {
 	envVar.SetDefault(envAlluxioMasterLogger, masterLoggerType)
 	masterJavaOpts := fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, envVar.Get(envAlluxioMasterLogger))
 	envVar.SetDefault(envAlluxioAuditMasterLogger, masterAuditLoggerType)
-	masterJavaOpts += fmt.Sprintf(env.JavaOptFormat, confAlluxioMasterAuditLoggerType, envVar.Get(envAlluxioAuditMasterLogger))
+	masterJavaOpts += " " + fmt.Sprintf(env.JavaOptFormat, confAlluxioMasterAuditLoggerType, envVar.Get(envAlluxioAuditMasterLogger))
 
 	masterJavaOpts += envVar.GetString(env.ConfAlluxioJavaOpts.EnvVar)
 	masterJavaOpts += envVar.GetString(p.JavaOpts.EnvVar)
 
-	envVar.Set(p.JavaOpts.EnvVar, strings.TrimSpace(masterJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
+	envVar.Set(p.JavaOpts.EnvVar, masterJavaOpts)
 }
 
 func (p *MasterProcess) StartCmd(cmd *cobra.Command) *cobra.Command {

--- a/cli/src/alluxio.org/cli/processes/master.go
+++ b/cli/src/alluxio.org/cli/processes/master.go
@@ -48,10 +48,12 @@ const (
 
 var (
 	ConfAlluxioMasterJavaOpts = env.RegisterTemplateEnvVar(&env.AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_MASTER_JAVA_OPTS",
+		EnvVar:     "ALLUXIO_MASTER_JAVA_OPTS",
+		IsJavaOpts: true,
 	})
 	confAlluxioMasterAttachOpts = env.RegisterTemplateEnvVar(&env.AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_MASTER_ATTACH_OPTS",
+		EnvVar:     "ALLUXIO_MASTER_ATTACH_OPTS",
+		IsJavaOpts: true,
 	})
 )
 

--- a/cli/src/alluxio.org/cli/processes/master.go
+++ b/cli/src/alluxio.org/cli/processes/master.go
@@ -13,12 +13,10 @@ package processes
 
 import (
 	"fmt"
-	"os"
-	"strings"
-
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"os"
 
 	"alluxio.org/cli/cmd/conf"
 	"alluxio.org/cli/cmd/journal"
@@ -89,22 +87,18 @@ func (p *MasterProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 
 	cmdArgs := []string{env.Env.EnvVar.GetString(env.ConfJava.EnvVar)}
-	if attachOpts := env.Env.EnvVar.GetString(confAlluxioMasterAttachOpts.EnvVar); attachOpts != "" {
-		cmdArgs = append(cmdArgs, strings.Split(attachOpts, " ")...)
-	}
+	cmdArgs = append(cmdArgs, confAlluxioMasterAttachOpts.JavaOptsToArgs(env.Env.EnvVar)...)
 	cmdArgs = append(cmdArgs, "-cp", env.Env.EnvVar.GetString(env.EnvAlluxioServerClasspath))
-
-	masterJavaOpts := env.Env.EnvVar.GetString(p.JavaOpts.EnvVar)
-	cmdArgs = append(cmdArgs, strings.Split(masterJavaOpts, " ")...)
+	cmdArgs = append(cmdArgs, p.JavaOpts.JavaOptsToArgs(env.Env.EnvVar)...)
 
 	// specify a default of -Xmx8g if no memory setting is specified
 	const xmxOpt = "-Xmx"
-	if !strings.Contains(masterJavaOpts, xmxOpt) && !strings.Contains(masterJavaOpts, "MaxRAMPercentage") {
+	if !argsContainsOpt(cmdArgs, xmxOpt, "MaxRAMPercentage") {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("%v8g", xmxOpt))
 	}
 	// specify a default of -XX:MetaspaceSize=256M if not set
 	const metaspaceSizeOpt = "-XX:MetaspaceSize"
-	if !strings.Contains(masterJavaOpts, metaspaceSizeOpt) {
+	if !argsContainsOpt(cmdArgs, metaspaceSizeOpt) {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("%v=256M", metaspaceSizeOpt))
 	}
 

--- a/cli/src/alluxio.org/cli/processes/master.go
+++ b/cli/src/alluxio.org/cli/processes/master.go
@@ -30,7 +30,7 @@ var Master = &MasterProcess{
 	BaseProcess: &env.BaseProcess{
 		Name:                 "master",
 		JavaClassName:        "alluxio.master.AlluxioMaster",
-		JavaOptsEnvVarKey:    ConfAlluxioMasterJavaOpts.EnvVar,
+		JavaOpts:             ConfAlluxioMasterJavaOpts,
 		ProcessOutFile:       "master.out",
 		MonitorJavaClassName: "alluxio.master.AlluxioMasterMonitor",
 	},
@@ -71,9 +71,9 @@ func (p *MasterProcess) SetEnvVars(envVar *viper.Viper) {
 	masterJavaOpts += fmt.Sprintf(env.JavaOptFormat, confAlluxioMasterAuditLoggerType, envVar.Get(envAlluxioAuditMasterLogger))
 
 	masterJavaOpts += envVar.GetString(env.ConfAlluxioJavaOpts.EnvVar)
-	masterJavaOpts += envVar.GetString(p.JavaOptsEnvVarKey)
+	masterJavaOpts += envVar.GetString(p.JavaOpts.EnvVar)
 
-	envVar.Set(p.JavaOptsEnvVarKey, strings.TrimSpace(masterJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
+	envVar.Set(p.JavaOpts.EnvVar, strings.TrimSpace(masterJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
 }
 
 func (p *MasterProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
@@ -92,7 +92,7 @@ func (p *MasterProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 	cmdArgs = append(cmdArgs, "-cp", env.Env.EnvVar.GetString(env.EnvAlluxioServerClasspath))
 
-	masterJavaOpts := env.Env.EnvVar.GetString(p.JavaOptsEnvVarKey)
+	masterJavaOpts := env.Env.EnvVar.GetString(p.JavaOpts.EnvVar)
 	cmdArgs = append(cmdArgs, strings.Split(masterJavaOpts, " ")...)
 
 	// specify a default of -Xmx8g if no memory setting is specified

--- a/cli/src/alluxio.org/cli/processes/proxy.go
+++ b/cli/src/alluxio.org/cli/processes/proxy.go
@@ -42,10 +42,12 @@ const (
 
 var (
 	ConfAlluxioProxyJavaOpts = env.RegisterTemplateEnvVar(&env.AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_PROXY_JAVA_OPTS",
+		EnvVar:     "ALLUXIO_PROXY_JAVA_OPTS",
+		IsJavaOpts: true,
 	})
 	confAlluxioProxyAttachOpts = env.RegisterTemplateEnvVar(&env.AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_PROXY_ATTACH_OPTS",
+		EnvVar:     "ALLUXIO_PROXY_ATTACH_OPTS",
+		IsJavaOpts: true,
 	})
 )
 

--- a/cli/src/alluxio.org/cli/processes/proxy.go
+++ b/cli/src/alluxio.org/cli/processes/proxy.go
@@ -26,7 +26,7 @@ var Proxy = &ProxyProcess{
 	BaseProcess: &env.BaseProcess{
 		Name:                 "proxy",
 		JavaClassName:        "alluxio.proxy.AlluxioProxy",
-		JavaOptsEnvVarKey:    ConfAlluxioProxyJavaOpts.EnvVar,
+		JavaOpts:             ConfAlluxioProxyJavaOpts,
 		ProcessOutFile:       "proxy.out",
 		MonitorJavaClassName: "alluxio.proxy.AlluxioProxyMonitor",
 	},
@@ -65,9 +65,9 @@ func (p *ProxyProcess) SetEnvVars(envVar *viper.Viper) {
 	proxyJavaOpts += fmt.Sprintf(env.JavaOptFormat, confAlluxioProxyAuditLoggerType, envVar.Get(envAlluxioAuditProxyLogger))
 
 	proxyJavaOpts += envVar.GetString(env.ConfAlluxioJavaOpts.EnvVar)
-	proxyJavaOpts += envVar.GetString(p.JavaOptsEnvVarKey)
+	proxyJavaOpts += envVar.GetString(p.JavaOpts.EnvVar)
 
-	envVar.Set(p.JavaOptsEnvVarKey, strings.TrimSpace(proxyJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
+	envVar.Set(p.JavaOpts.EnvVar, strings.TrimSpace(proxyJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
 }
 
 func (p *ProxyProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
@@ -82,7 +82,7 @@ func (p *ProxyProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 	cmdArgs = append(cmdArgs, "-cp", env.Env.EnvVar.GetString(env.EnvAlluxioServerClasspath))
 
-	proxyJavaOpts := env.Env.EnvVar.GetString(p.JavaOptsEnvVarKey)
+	proxyJavaOpts := env.Env.EnvVar.GetString(p.JavaOpts.EnvVar)
 	cmdArgs = append(cmdArgs, strings.Split(proxyJavaOpts, " ")...)
 
 	cmdArgs = append(cmdArgs, p.JavaClassName)

--- a/cli/src/alluxio.org/cli/processes/proxy.go
+++ b/cli/src/alluxio.org/cli/processes/proxy.go
@@ -13,8 +13,6 @@ package processes
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/palantir/stacktrace"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -79,14 +77,9 @@ func (p *ProxyProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *ProxyProcess) Start(cmd *env.StartProcessCommand) error {
 	cmdArgs := []string{env.Env.EnvVar.GetString(env.ConfJava.EnvVar)}
-	if attachOpts := env.Env.EnvVar.GetString(confAlluxioProxyAttachOpts.EnvVar); attachOpts != "" {
-		cmdArgs = append(cmdArgs, strings.Split(attachOpts, " ")...)
-	}
+	cmdArgs = append(cmdArgs, confAlluxioProxyAttachOpts.JavaOptsToArgs(env.Env.EnvVar)...)
 	cmdArgs = append(cmdArgs, "-cp", env.Env.EnvVar.GetString(env.EnvAlluxioServerClasspath))
-
-	proxyJavaOpts := env.Env.EnvVar.GetString(p.JavaOpts.EnvVar)
-	cmdArgs = append(cmdArgs, strings.Split(proxyJavaOpts, " ")...)
-
+	cmdArgs = append(cmdArgs, p.JavaOpts.JavaOptsToArgs(env.Env.EnvVar)...)
 	cmdArgs = append(cmdArgs, p.JavaClassName)
 
 	if err := p.Launch(cmd, cmdArgs); err != nil {

--- a/cli/src/alluxio.org/cli/processes/proxy.go
+++ b/cli/src/alluxio.org/cli/processes/proxy.go
@@ -62,12 +62,12 @@ func (p *ProxyProcess) SetEnvVars(envVar *viper.Viper) {
 	envVar.SetDefault(envAlluxioProxyLogger, proxyLoggerType)
 	proxyJavaOpts := fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, envVar.Get(envAlluxioProxyLogger))
 	envVar.SetDefault(envAlluxioAuditProxyLogger, proxyAuditLoggerType)
-	proxyJavaOpts += fmt.Sprintf(env.JavaOptFormat, confAlluxioProxyAuditLoggerType, envVar.Get(envAlluxioAuditProxyLogger))
+	proxyJavaOpts += " " + fmt.Sprintf(env.JavaOptFormat, confAlluxioProxyAuditLoggerType, envVar.Get(envAlluxioAuditProxyLogger))
 
 	proxyJavaOpts += envVar.GetString(env.ConfAlluxioJavaOpts.EnvVar)
 	proxyJavaOpts += envVar.GetString(p.JavaOpts.EnvVar)
 
-	envVar.Set(p.JavaOpts.EnvVar, strings.TrimSpace(proxyJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
+	envVar.Set(p.JavaOpts.EnvVar, proxyJavaOpts)
 }
 
 func (p *ProxyProcess) StartCmd(cmd *cobra.Command) *cobra.Command {

--- a/cli/src/alluxio.org/cli/processes/worker.go
+++ b/cli/src/alluxio.org/cli/processes/worker.go
@@ -39,10 +39,12 @@ const (
 
 var (
 	ConfAlluxioWorkerJavaOpts = env.RegisterTemplateEnvVar(&env.AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_WORKER_JAVA_OPTS",
+		EnvVar:     "ALLUXIO_WORKER_JAVA_OPTS",
+		IsJavaOpts: true,
 	})
 	confAlluxioWorkerAttachOpts = env.RegisterTemplateEnvVar(&env.AlluxioConfigEnvVar{
-		EnvVar: "ALLUXIO_WORKER_ATTACH_OPTS",
+		EnvVar:     "ALLUXIO_WORKER_ATTACH_OPTS",
+		IsJavaOpts: true,
 	})
 )
 

--- a/cli/src/alluxio.org/cli/processes/worker.go
+++ b/cli/src/alluxio.org/cli/processes/worker.go
@@ -26,7 +26,7 @@ var Worker = &WorkerProcess{
 	BaseProcess: &env.BaseProcess{
 		Name:                 "worker",
 		JavaClassName:        "alluxio.worker.AlluxioWorker",
-		JavaOptsEnvVarKey:    ConfAlluxioWorkerJavaOpts.EnvVar,
+		JavaOpts:             ConfAlluxioWorkerJavaOpts,
 		ProcessOutFile:       "worker.out",
 		MonitorJavaClassName: "alluxio.worker.AlluxioWorkerMonitor",
 	},
@@ -60,9 +60,9 @@ func (p *WorkerProcess) SetEnvVars(envVar *viper.Viper) {
 	workerJavaOpts := fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, envVar.Get(envAlluxioWorkerLogger))
 
 	workerJavaOpts += envVar.GetString(env.ConfAlluxioJavaOpts.EnvVar)
-	workerJavaOpts += envVar.GetString(p.JavaOptsEnvVarKey)
+	workerJavaOpts += envVar.GetString(p.JavaOpts.EnvVar)
 
-	envVar.Set(p.JavaOptsEnvVarKey, strings.TrimSpace(workerJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
+	envVar.Set(p.JavaOpts.EnvVar, strings.TrimSpace(workerJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
 }
 
 func (p *WorkerProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
@@ -77,7 +77,7 @@ func (p *WorkerProcess) Start(cmd *env.StartProcessCommand) error {
 	}
 	cmdArgs = append(cmdArgs, "-cp", env.Env.EnvVar.GetString(env.EnvAlluxioServerClasspath))
 
-	workerJavaOpts := env.Env.EnvVar.GetString(p.JavaOptsEnvVarKey)
+	workerJavaOpts := env.Env.EnvVar.GetString(p.JavaOpts.EnvVar)
 	cmdArgs = append(cmdArgs, strings.Split(workerJavaOpts, " ")...)
 
 	// specify a default of -Xmx4g if no memory setting is specified

--- a/cli/src/alluxio.org/cli/processes/worker.go
+++ b/cli/src/alluxio.org/cli/processes/worker.go
@@ -57,14 +57,14 @@ func (p *WorkerProcess) Base() *env.BaseProcess {
 }
 
 func (p *WorkerProcess) SetEnvVars(envVar *viper.Viper) {
-	// ALLUXIO_WORKER_JAVA_OPTS = {default logger opts} ${ALLUXIO_JAVA_OPTS} ${ALLUXIO_WORKER_JAVA_OPTS}
 	envVar.SetDefault(envAlluxioWorkerLogger, workerLoggerType)
-	workerJavaOpts := fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, envVar.Get(envAlluxioWorkerLogger))
-
-	workerJavaOpts += envVar.GetString(env.ConfAlluxioJavaOpts.EnvVar)
-	workerJavaOpts += envVar.GetString(p.JavaOpts.EnvVar)
-
-	envVar.Set(p.JavaOpts.EnvVar, strings.TrimSpace(workerJavaOpts)) // leading spaces need to be trimmed as a exec.Command argument
+	// ALLUXIO_WORKER_JAVA_OPTS = {default logger opts} ${ALLUXIO_JAVA_OPTS} ${ALLUXIO_WORKER_JAVA_OPTS}
+	javaOpts := []string{
+		fmt.Sprintf(env.JavaOptFormat, env.ConfAlluxioLoggerType, envVar.Get(envAlluxioWorkerLogger)),
+	}
+	javaOpts = append(javaOpts, env.ConfAlluxioJavaOpts.JavaOptsToArgs(envVar)...)
+	javaOpts = append(javaOpts, p.JavaOpts.JavaOptsToArgs(envVar)...)
+	envVar.Set(p.JavaOpts.EnvVar, strings.Join(javaOpts, " "))
 }
 
 func (p *WorkerProcess) StartCmd(cmd *cobra.Command) *cobra.Command {

--- a/cli/src/alluxio.org/cli/processes/worker.go
+++ b/cli/src/alluxio.org/cli/processes/worker.go
@@ -74,22 +74,18 @@ func (p *WorkerProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
 
 func (p *WorkerProcess) Start(cmd *env.StartProcessCommand) error {
 	cmdArgs := []string{env.Env.EnvVar.GetString(env.ConfJava.EnvVar)}
-	if attachOpts := env.Env.EnvVar.GetString(confAlluxioWorkerAttachOpts.EnvVar); attachOpts != "" {
-		cmdArgs = append(cmdArgs, strings.Split(attachOpts, " ")...)
-	}
+	cmdArgs = append(cmdArgs, confAlluxioWorkerAttachOpts.JavaOptsToArgs(env.Env.EnvVar)...)
 	cmdArgs = append(cmdArgs, "-cp", env.Env.EnvVar.GetString(env.EnvAlluxioServerClasspath))
-
-	workerJavaOpts := env.Env.EnvVar.GetString(p.JavaOpts.EnvVar)
-	cmdArgs = append(cmdArgs, strings.Split(workerJavaOpts, " ")...)
+	cmdArgs = append(cmdArgs, p.JavaOpts.JavaOptsToArgs(env.Env.EnvVar)...)
 
 	// specify a default of -Xmx4g if no memory setting is specified
 	const xmxOpt = "-Xmx"
-	if !strings.Contains(workerJavaOpts, xmxOpt) && !strings.Contains(workerJavaOpts, "MaxRAMPercentage") {
+	if !argsContainsOpt(cmdArgs, xmxOpt, "MaxRAMPercentage") {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("%v4g", xmxOpt))
 	}
 	// specify a default of -XX:MaxDirectMemorySize=4g if not set
 	const maxDirectMemorySize = "-XX:MaxDirectMemorySize"
-	if !strings.Contains(workerJavaOpts, maxDirectMemorySize) {
+	if !argsContainsOpt(cmdArgs, maxDirectMemorySize) {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("%v=4g", maxDirectMemorySize))
 	}
 

--- a/cli/src/alluxio.org/cli/processes/worker.go
+++ b/cli/src/alluxio.org/cli/processes/worker.go
@@ -72,7 +72,7 @@ func (p *WorkerProcess) StartCmd(cmd *cobra.Command) *cobra.Command {
 	return cmd
 }
 
-func (p *WorkerProcess) Start(cmd *env.StartProcessCommand) error {
+func (p *WorkerProcess) startCmdArgs() []string {
 	cmdArgs := []string{env.Env.EnvVar.GetString(env.ConfJava.EnvVar)}
 	cmdArgs = append(cmdArgs, confAlluxioWorkerAttachOpts.JavaOptsToArgs(env.Env.EnvVar)...)
 	cmdArgs = append(cmdArgs, "-cp", env.Env.EnvVar.GetString(env.EnvAlluxioServerClasspath))
@@ -88,10 +88,11 @@ func (p *WorkerProcess) Start(cmd *env.StartProcessCommand) error {
 	if !argsContainsOpt(cmdArgs, maxDirectMemorySize) {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("%v=4g", maxDirectMemorySize))
 	}
+	return append(cmdArgs, p.JavaClassName)
+}
 
-	cmdArgs = append(cmdArgs, p.JavaClassName)
-
-	if err := p.Launch(cmd, cmdArgs); err != nil {
+func (p *WorkerProcess) Start(cmd *env.StartProcessCommand) error {
+	if err := p.Launch(cmd, p.startCmdArgs()); err != nil {
 		return stacktrace.Propagate(err, "error launching process")
 	}
 	return nil

--- a/cli/src/alluxio.org/cli/processes/worker_test.go
+++ b/cli/src/alluxio.org/cli/processes/worker_test.go
@@ -1,0 +1,86 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package processes
+
+import (
+	"strings"
+	"testing"
+
+	"alluxio.org/cli/env"
+)
+
+func TestWorkerProcess_startCmdArgs(t *testing.T) {
+	env.RegisterProcess(Worker)
+	for name, tc := range map[string]struct {
+		alluxioEnv    map[string]string
+		expectNumArgs int
+	}{
+		"none": {
+			expectNumArgs: 15,
+		},
+		"2 alluxio java opts": {
+			alluxioEnv: map[string]string{
+				env.ConfAlluxioJavaOpts.EnvVar: "-DalluxioJava1=opts1 -DalluxioJava2=opts2",
+			},
+			expectNumArgs: 17,
+		},
+		"2 alluxio java opts with spaces": {
+			alluxioEnv: map[string]string{
+				env.ConfAlluxioJavaOpts.EnvVar: " -DalluxioJava1=opts1 -DalluxioJava2=opts2 ",
+			},
+			expectNumArgs: 17,
+		},
+		"2 worker java opts with spaces": {
+			alluxioEnv: map[string]string{
+				ConfAlluxioWorkerJavaOpts.EnvVar: " -DaworkerJava1=opts1 -DworkerJava2=opts2 ",
+			},
+			expectNumArgs: 17,
+		},
+		"2 worker attach java opts with spaces": {
+			alluxioEnv: map[string]string{
+				confAlluxioWorkerAttachOpts.EnvVar: " -DaworkerAttach1=opts1 -DworkerAttach2=opts2 ",
+			},
+			expectNumArgs: 17,
+		},
+		"1 each of alluxio java, worker java, worker attach": {
+			alluxioEnv: map[string]string{
+				env.ConfAlluxioJavaOpts.EnvVar:     "-DalluxioJava1=opts1",
+				ConfAlluxioWorkerJavaOpts.EnvVar:   "-DaworkerJava1=opts1",
+				confAlluxioWorkerAttachOpts.EnvVar: "-DaworkerAttach1=opts1",
+			},
+			expectNumArgs: 18,
+		},
+		"1 each of alluxio java, worker java, worker attach with spaces": {
+			alluxioEnv: map[string]string{
+				env.ConfAlluxioJavaOpts.EnvVar:     " -DalluxioJava1=opts1 ",
+				ConfAlluxioWorkerJavaOpts.EnvVar:   " -DaworkerJava1=opts1 ",
+				confAlluxioWorkerAttachOpts.EnvVar: " -DaworkerAttach1=opts1 ",
+			},
+			expectNumArgs: 18,
+		},
+	} {
+		env.InitEnvForTesting(tc.alluxioEnv)
+		args := Worker.startCmdArgs()
+		if len(args) != tc.expectNumArgs {
+			t.Errorf("case %v: expected %v args but got %v:\n%v",
+				name, tc.expectNumArgs, len(args), strings.Join(args, "\n"))
+		}
+		for i, arg := range args {
+			if arg == "" {
+				t.Errorf("case %v: %dth argument is empty", name, i)
+			}
+			if arg != strings.TrimSpace(arg) {
+				t.Errorf("case %v: %dth argument has leading or trailing spaces:\n%v", name, i, arg)
+			}
+		}
+	}
+}


### PR DESCRIPTION
address https://github.com/Alluxio/alluxio/issues/18249

refactor how java opt env vars are handled. previously they were treating as strings and then using a split operation to separate the single string into cmd line arguments. now they are handled as `[]string` immediately after parsing from env to properly handle any leading or trailing whitespaces.