### PR TITLE
Support Mkdir/CreateFile with configured default umask in HDFS API

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -50,7 +50,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
-import org.apache.hadoop.fs.permission.FsCreateModes;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Progressable;

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -168,10 +168,9 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
   public FSDataOutputStream create(Path path, boolean overwrite, int bufferSize, short replication,
                                    long blockSize, Progressable progress) throws IOException {
     String confUmask = mAlluxioConf.getString(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_UMASK);
-    Mode mode = ModeUtils.applyDirectoryUMask(Mode.defaults(), confUmask);
-    return this.create(path, FsCreateModes.applyUMask(
-            FsPermission.getFileDefault(), new FsPermission(mode.toShort())),
-        overwrite, bufferSize, replication, blockSize, progress);
+    Mode mode = ModeUtils.applyFileUMask(Mode.defaults(), confUmask);
+    return this.create(path, new FsPermission(mode.toShort()), overwrite, bufferSize, replication,
+        blockSize, progress);
   }
 
   /**

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -52,6 +52,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsCreateModes;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.After;
 import org.junit.Before;
@@ -726,7 +728,9 @@ public class AbstractFileSystemTest {
             ExceptionMessage.CANNOT_OVERWRITE_FILE_WITHOUT_OVERWRITE.getMessage(path.toString())));
 
     try (FileSystem alluxioHadoopFs = new FileSystem(alluxioFs)) {
-      alluxioHadoopFs.create(path, false, 100, (short) 1, 1000);
+      alluxioHadoopFs.create(path,
+          FsCreateModes.applyUMask(FsPermission.getFileDefault(), FsPermission.getUMask(getConf())),
+          false, 100, (short) 1, 1000, null);
       fail("create() of existing file is expected to fail");
     } catch (IOException e) {
       assertEquals("alluxio.exception.FileAlreadyExistsException: "

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemAclIntegrationTest.java
@@ -108,6 +108,12 @@ public final class FileSystemAclIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void createFileWithPermission() throws Exception {
+    Path defaultFile = new Path("/createfile-default");
+    FSDataOutputStream stream = sTFS.create(defaultFile, false /* ignored */, 10 /* ignored */,
+        (short) 1 /* ignored */, 512 /* ignored */, null /* ignored */);
+    stream.close();
+    FileStatus fileStatus = sTFS.getFileStatus(defaultFile);
+    Assert.assertEquals((short) 0644, fileStatus.getPermission().toShort());
     List<Integer> permissionValues =
         Lists.newArrayList(0111, 0222, 0333, 0444, 0555, 0666, 0777, 0755, 0733, 0644, 0533, 0511);
     for (int value : permissionValues) {
@@ -124,6 +130,10 @@ public final class FileSystemAclIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void mkdirsWithPermission() throws Exception {
+    Path defaultDir = new Path("/createDir-default");
+    sTFS.mkdirs(defaultDir);
+    FileStatus fileStatus = sTFS.getFileStatus(defaultDir);
+    Assert.assertEquals((short) 0755, fileStatus.getPermission().toShort());
     List<Integer> permissionValues =
         Lists.newArrayList(0111, 0222, 0333, 0444, 0555, 0666, 0777, 0755, 0733, 0644, 0533, 0511);
     for (int value : permissionValues) {


### PR DESCRIPTION
### What changes are proposed in this pull request?
Support creating directories and files with default permissions based on configuration propertykey in HDFS API.

### Why are the changes needed?
Alluxio Hdfs api hasn't the corresponding implementation of Mkdir without permission parameter. If it does not carry permission, the umask property in the configuration item shall prevail.

### Does this PR introduce any user facing changes?

