### PR TITLE
Add remote only policy for tests

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashPolicy.java
@@ -20,7 +20,7 @@ import alluxio.exception.status.ResourceExhaustedException;
 import java.util.List;
 
 /**
- * An impl of WorkerLocationPolicy.
+ * An implementation of WorkerLocationPolicy.
  *
  * A policy where a file path is matched to worker(s) by a consistenct hashing algorithm.
  * The hash algorithm makes sure the same path maps to the same worker sequence.

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/RemoteOnlyPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/RemoteOnlyPolicy.java
@@ -15,7 +15,6 @@ import alluxio.client.block.BlockWorkerInfo;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.ResourceExhaustedException;
 import alluxio.util.network.NetworkAddressUtils;
-import alluxio.wire.WorkerNetAddress;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,53 +22,29 @@ import java.util.List;
 /**
  * An implementation of WorkerLocationPolicy, where a client will ONLY talk to a local worker.
  *
- * This policy can probably only be used in testing. If client on node A reads path /a,
- * it will only talk to the worker on node A and produce a cache there. If a client on
- * node B reads the same path /a, it will not see the cache on node A.
- *
- * A use case for this policy is a test like StressWorkerBench, where we create clients
- * (with job service) and simulate I/O workload to workers.
- * If all clients talk to their local worker, the test creates balanced stress on each worker
- * and we measure local read performance.
+ * Policy description.
  */
-public class LocalWorkerPolicy implements WorkerLocationPolicy {
+public class RemoteOnlyPolicy implements WorkerLocationPolicy {
   private final AlluxioConfiguration mConf;
 
   /**
-   * Constructs a new {@link LocalWorkerPolicy}.
+   * Constructs a new {@link RemoteOnlyPolicy}.
    *
    * @param conf the configuration used by the policy
    */
-  public LocalWorkerPolicy(AlluxioConfiguration conf) {
+  public RemoteOnlyPolicy(AlluxioConfiguration conf) {
     mConf = conf;
   }
 
   /**
-   * Finds a local worker from the available workers, matching by hostname.
-   * If there are multiple workers matching the client hostname, return the 1st one following
-   * the input order.
+   * Finds a remote worker from the available workers, matching by hostname.
    */
   @Override
   public List<BlockWorkerInfo> getPreferredWorkers(List<BlockWorkerInfo> blockWorkerInfos,
       String fileId, int count) throws ResourceExhaustedException {
     String userHostname = NetworkAddressUtils.getClientHostName(mConf);
-    // TODO(jiacheng): domain socket is not considered here
-    // Find the worker matching in hostname
     List<BlockWorkerInfo> results = new ArrayList<>();
-    for (BlockWorkerInfo worker : blockWorkerInfos) {
-      WorkerNetAddress workerAddr = worker.getNetAddress();
-      if (workerAddr == null) {
-        continue;
-      }
-      // Only a plain string match is performed on hostname
-      // If one is IP and the other is hostname, a false negative will be returned
-      if (userHostname.equals(workerAddr.getHost())) {
-        results.add(worker);
-        if (results.size() >= count) {
-          break;
-        }
-      }
-    }
+    // TODO(tongyu): get result
     if (results.size() < count) {
       throw new ResourceExhaustedException(String.format(
           "Failed to find a local worker for client hostname %s", userHostname));

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/RemoteOnlyPolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/RemoteOnlyPolicy.java
@@ -37,46 +37,22 @@ public class RemoteOnlyPolicy implements WorkerLocationPolicy {
     mConf = conf;
   }
 
-  enum WorkerInfoListSingleton {
-    WORKER_INFO_LIST;
-
-    private List<BlockWorkerInfo> mWorkerInfoList;
-    WorkerInfoListSingleton() {
-      mWorkerInfoList = new ArrayList<>();
-    }
-    public boolean isEmpty() {
-      return mWorkerInfoList.isEmpty();
-    }
-    public void initialize(List<BlockWorkerInfo> workerInfoList) {
-      mWorkerInfoList = workerInfoList;
-    }
-    public List<BlockWorkerInfo> getWorkerInfoList() {
-      return mWorkerInfoList;
-    }
-    public void roulette() {
-      if (!mWorkerInfoList.isEmpty()) {
-        BlockWorkerInfo firstWorker = mWorkerInfoList.remove(0);
-        mWorkerInfoList.add(firstWorker);
-      }
-    }
-  }
-
   /**
    * Finds a remote worker from the available workers, matching by hostname.
    */
   @Override
   public List<BlockWorkerInfo> getPreferredWorkers(List<BlockWorkerInfo> blockWorkerInfos,
-                                                   String fileId, int count) throws ResourceExhaustedException {
-    if (WorkerInfoListSingleton.WORKER_INFO_LIST.isEmpty()) {
-      WorkerInfoListSingleton.WORKER_INFO_LIST.initialize(blockWorkerInfos);
+      String fileId, int count) throws ResourceExhaustedException {
+    WorkerInfoListSingleton workerInfoListSingleton = WorkerInfoListSingleton.getInstance();
+    if (workerInfoListSingleton.isEmpty()) {
+      workerInfoListSingleton.initWorkerList(blockWorkerInfos);
     } else {
-      //TODO(tongyu): check if workers changed
-      WorkerInfoListSingleton.WORKER_INFO_LIST.roulette();
+      workerInfoListSingleton.roulette();
     }
     String userHostname = NetworkAddressUtils.getClientHostName(mConf);
     // Find the worker matching in hostname
     List<BlockWorkerInfo> results = new ArrayList<>();
-    for (BlockWorkerInfo worker : WorkerInfoListSingleton.WORKER_INFO_LIST.getWorkerInfoList()) {
+    for (BlockWorkerInfo worker : workerInfoListSingleton.getWorkerList()) {
       WorkerNetAddress workerAddr = worker.getNetAddress();
       if (workerAddr == null) {
         continue;

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerInfoListSingleton.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/WorkerInfoListSingleton.java
@@ -1,0 +1,37 @@
+package alluxio.client.file.dora;
+
+import alluxio.client.block.BlockWorkerInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WorkerInfoListSingleton {
+  private static WorkerInfoListSingleton instance;
+  private List<BlockWorkerInfo> mWorkerInfoList;
+  private WorkerInfoListSingleton() {
+    mWorkerInfoList = new ArrayList<>();
+  }
+  public static synchronized WorkerInfoListSingleton getInstance() {
+    if (instance == null) {
+      instance = new WorkerInfoListSingleton();
+    }
+    return instance;
+  }
+  public boolean isEmpty() {
+    return mWorkerInfoList.isEmpty();
+  }
+
+  public synchronized void initWorkerList(List<BlockWorkerInfo> workerList) {
+    mWorkerInfoList = workerList;
+  }
+  public List<BlockWorkerInfo> getWorkerList() {
+    return mWorkerInfoList;
+  }
+
+  public synchronized void roulette() {
+    if (!mWorkerInfoList.isEmpty()) {
+      BlockWorkerInfo firstWorker = mWorkerInfoList.remove(0);
+      mWorkerInfoList.add(firstWorker);
+    }
+  }
+}

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchMode.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchMode.java
@@ -16,7 +16,8 @@ package alluxio.stress.worker;
  */
 public enum WorkerBenchMode {
   HASH("HASH"),
-  LOCAL_ONLY("LOCAL_ONLY");
+  LOCAL_ONLY("LOCAL_ONLY"),
+  REMOTE_ONLY("REMOTE_ONLY");
 
   private final String mName;
 

--- a/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
@@ -99,9 +99,10 @@ public final class WorkerBenchParameters extends FileSystemParameters {
 
   @Parameter(names = {"--mode"},
       description = "Specifies which worker the test process reads from."
-          + "Possible values are: [HASH, LOCAL_ONLY]"
+          + "Possible values are: [HASH, LOCAL_ONLY, REMOTE_ONLY]"
           + "HASH -> alluxio.client.file.dora.ConsistentHashPolicy"
           + "LOCAL_ONLY -> alluxio.client.file.dora.LocalWorkerPolicy"
+          + "REMOTE_ONLY -> alluxio.client.file.dora.RemoteOnlyPolicy"
           + "The default is HASH.")
   public WorkerBenchMode mMode = WorkerBenchMode.HASH;
 

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -200,6 +200,10 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
         hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
             "alluxio.client.file.dora.LocalWorkerPolicy");
         break;
+      case REMOTE_ONLY:
+        hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
+            "alluxio.client.file.dora.RemoteOnlyPolicy");
+        break;
       default:
         throw new IllegalArgumentException("Unrecognized mode" + mParameters.mMode);
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add one `RemoteOnlyPolicy` implementation for testing. This is usable for reading all files from remote nodes, rather than the local node itself.

Generally, this policy keeps a thread-safe list including all workers. When one thread reads, the round-robin list returns all available workers after a roulette (putting the first element in the list to the end) , and choose the first remote worker to read from.

We also added available options of `--mode` in StressWorkerBench to use the new remote only policy.

### Why are the changes needed?

The new policy is for internal testing where all test clients find the remote worker for IO. This policy should not be used in real deployments because if all clients find remote worker, overall throughput can be quite low due to bandwidth restrictions.

### Does this PR introduce any user facing changes?

No, RemoteOnlyPolicy should only be used in internal testing