### PR TITLE
Remove restriction in overwriting worker info within join logic

### DIFF
--- a/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
@@ -13,7 +13,6 @@ package alluxio.membership;
 
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.exception.status.AlreadyExistsException;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerInfo;
 
@@ -97,8 +96,9 @@ public class EtcdMembershipManager implements MembershipManager {
       if (!Arrays.equals(existingEntityBytes, serializedEntity)) {
         // In k8s this might be bcos worker pod restarting with the same worker identity
         // but certain fields such as hostname has been changed. Register to ring path anyway.
-        LOG.warn("Same worker entity found bearing same workerid, maybe benign if pod restart in k8s env or "
-            + " same worker scheduled to restart on another machine in baremetal env.");
+        LOG.warn("Same worker entity found bearing same workerid,"
+            + "maybe benign if pod restart in k8s env or same worker"
+            + " scheduled to restart on another machine in baremetal env.");
         mAlluxioEtcdClient.createForPath(pathOnRing, Optional.of(serializedEntity));
       }
       // It's me, go ahead to start heartbeating.

--- a/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
@@ -96,9 +96,13 @@ public class EtcdMembershipManager implements MembershipManager {
       if (!Arrays.equals(existingEntityBytes, serializedEntity)) {
         // In k8s this might be bcos worker pod restarting with the same worker identity
         // but certain fields such as hostname has been changed. Register to ring path anyway.
-        LOG.warn("Same worker entity found bearing same workerid,"
+        WorkerServiceEntity existingEntity = new WorkerServiceEntity();
+        existingEntity.deserialize(existingEntityBytes);
+        LOG.warn("Same worker entity found bearing same workerid:{},"
+            + "existing WorkerServiceEntity to be overwritten:{},"
             + "maybe benign if pod restart in k8s env or same worker"
-            + " scheduled to restart on another machine in baremetal env.");
+            + " scheduled to restart on another machine in baremetal env.",
+            workerInfo.getIdentity().toString(), existingEntity);
         mAlluxioEtcdClient.createForPath(pathOnRing, Optional.of(serializedEntity));
       }
       // It's me, go ahead to start heartbeating.

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -288,13 +288,13 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
             mConf.get(PropertyKey.WORKER_MEMBERSHIP_MANAGER_TYPE));
         mMembershipManager.join(new WorkerInfo().setIdentity(mWorkerId.get()).setAddress(mAddress));
         break;
-      } catch (UnavailableRuntimeException ioe) {
-        /* We should only expect such exception when situation such as
-         * etcd hasn't started up yet when alluxio components and etcd
-         * are starting up at same time. In such case we keep retrying.
+      } catch (IOException | UnavailableRuntimeException e) {
+        /* Retry everything it might have coming from membership, as now a different worker
+         * instance might assume same worker id in k8s pod restart situation. There might
+         * be gaps in updating etcd states in the interim of transition.
          */
         if (!retry.attempt()) {
-          throw ioe;
+          throw e;
         }
       }
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Now with worker id can be assumed from a different worker instance whether on a different pod in k8s or a different host machine for baremetal. The creation onto the persisted ring path : /DHT/DefaultAlluxioCluster/AUTHORIZED/ should not bail if a different value is seen.

### Why are the changes needed?

to enable rejoin of a worker bearing same worker id but with different host or other WorkerInfo fileds.

### Does this PR introduce any user facing changes?

No
