### PR TITLE
Load ufs path directly

### DIFF
--- a/dora/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
+++ b/dora/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
@@ -15,8 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.annotation.PublicApi;
 import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
-import alluxio.conf.Configuration;
-import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.JobProgressReportFormat;
@@ -150,8 +148,7 @@ public final class LoadCommand extends AbstractFileSystemCommand {
   @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
     String[] args = cl.getArgs();
-    AlluxioURI path =
-        new AlluxioURI(Configuration.getString(PropertyKey.DORA_CLIENT_UFS_ROOT)).join(args[0]);
+    AlluxioURI path = new AlluxioURI(args[0]);
     if (path.containsWildcard()) {
       throw new UnsupportedOperationException("Load does not support wildcard path");
     }

--- a/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraLoadCommandIntegrationTest.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraLoadCommandIntegrationTest.java
@@ -44,7 +44,7 @@ public class DoraLoadCommandIntegrationTest extends AbstractDoraFileSystemShellT
   public void testCommand() throws Exception {
     File testRoot = mTestFolder.newFolder("testRoot");
     mTestFolder.newFolder("testRoot/testDirectory");
-
+    String path = testRoot.getAbsolutePath();
     createByteFileInUfs("/testRoot/testFileA", Constants.MB);
     createByteFileInUfs("/testRoot/testFileB", Constants.MB);
     createByteFileInUfs("/testRoot/testDirectory/testFileC", Constants.MB);
@@ -56,10 +56,10 @@ public class DoraLoadCommandIntegrationTest extends AbstractDoraFileSystemShellT
     assertEquals(0, mFileSystem.getStatus(uriA).getInAlluxioPercentage());
     assertEquals(0, mFileSystem.getStatus(uriB).getInAlluxioPercentage());
     assertEquals(0, mFileSystem.getStatus(uriC).getInAlluxioPercentage());
-
     // Testing loading of a directory
-    assertEquals(0, mFsShell.run("load", "/testRoot", "--submit", "--verify"));
-    assertEquals(0, mFsShell.run("load", "/testRoot", "--progress"));
+
+    assertEquals(0, mFsShell.run("load", path, "--submit", "--verify"));
+    assertEquals(0, mFsShell.run("load", path, "--progress"));
 
     FileSystemUtils.waitForAlluxioPercentage(mFileSystem, uriA, 100);
     FileSystemUtils.waitForAlluxioPercentage(mFileSystem, uriB, 100);
@@ -69,18 +69,18 @@ public class DoraLoadCommandIntegrationTest extends AbstractDoraFileSystemShellT
     fileInStream.positionedRead(0, buffer, 0, Constants.MB);
     assertTrue(BufferUtils.equalIncreasingByteArray(Constants.MB, buffer));
     while (!mOutput.toString().contains("SUCCEEDED")) {
-      assertEquals(0, mFsShell.run("load", "/testRoot", "--progress"));
+      assertEquals(0, mFsShell.run("load", path, "--progress"));
       Thread.sleep(1000);
     }
     assertTrue(mOutput.toString().contains("Inodes Processed: 4"));
     assertTrue(mOutput.toString().contains("Bytes Loaded: 3072.00KB out of 3072.00KB"));
     assertTrue(mOutput.toString().contains("Files Failed: 0"));
-    assertEquals(0, mFsShell.run("load", "/testRoot", "--stop"));
+    assertEquals(0, mFsShell.run("load", path, "--stop"));
     assertEquals(-2, mFsShell.run("load", "/testRootNotExists", "--progress"));
     assertTrue(mOutput.toString().contains("cannot be found."));
-    mFsShell.run("load", "/testRoot", "--progress", "--format", "JSON");
+    mFsShell.run("load", path, "--progress", "--format", "JSON");
     assertTrue(mOutput.toString().contains("\"mJobState\":\"SUCCEEDED\""));
-    mFsShell.run("load", "/testRoot", "--progress", "--format", "JSON", "--verbose");
+    mFsShell.run("load", path, "--progress", "--format", "JSON", "--verbose");
     assertTrue(mOutput.toString().contains("\"mVerbose\":true"));
   }
 }

--- a/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraLoadCommandWithVirtualBlockIntegrationTest.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraLoadCommandWithVirtualBlockIntegrationTest.java
@@ -45,6 +45,7 @@ public class DoraLoadCommandWithVirtualBlockIntegrationTest
   @Test
   public void testCommand() throws Exception {
     File testRoot = mTestFolder.newFolder("testRoot");
+    String path = testRoot.getAbsolutePath();
     mTestFolder.newFolder("testRoot/testDirectory");
 
     int lengthA = 16 * Constants.MB;
@@ -63,8 +64,8 @@ public class DoraLoadCommandWithVirtualBlockIntegrationTest
     assertEquals(0, mFileSystem.getStatus(uriC).getInAlluxioPercentage());
 
     // Testing loading of a directory
-    assertEquals(0, mFsShell.run("load", "/testRoot", "--submit", "--verify"));
-    assertEquals(0, mFsShell.run("load", "/testRoot", "--progress"));
+    assertEquals(0, mFsShell.run("load", path, "--submit", "--verify"));
+    assertEquals(0, mFsShell.run("load", path, "--progress"));
 
     FileSystemUtils.waitForAlluxioPercentage(mFileSystem, uriA, 100);
     FileSystemUtils.waitForAlluxioPercentage(mFileSystem, uriB, 100);
@@ -82,7 +83,7 @@ public class DoraLoadCommandWithVirtualBlockIntegrationTest
     fileInStream.positionedRead(0, buffer, 0, lengthC);
     assertTrue(BufferUtils.equalIncreasingByteArray(lengthC, buffer));
     while (!mOutput.toString().contains("SUCCEEDED")) {
-      assertEquals(0, mFsShell.run("load", "/testRoot", "--progress"));
+      assertEquals(0, mFsShell.run("load", path, "--progress"));
       Thread.sleep(1000);
     }
     assertTrue(mOutput.toString().contains("Inodes Processed: 4"));
@@ -90,12 +91,12 @@ public class DoraLoadCommandWithVirtualBlockIntegrationTest
     assertTrue(mOutput.toString().contains(
         String.format("Bytes Loaded: %s.00MB out of %s.00MB", bytes, bytes)));
     assertTrue(mOutput.toString().contains("Files Failed: 0"));
-    assertEquals(0, mFsShell.run("load", "/testRoot", "--stop"));
+    assertEquals(0, mFsShell.run("load", path, "--stop"));
     assertEquals(-2, mFsShell.run("load", "/testRootNotExists", "--progress"));
     assertTrue(mOutput.toString().contains("cannot be found."));
-    mFsShell.run("load", "/testRoot", "--progress", "--format", "JSON");
+    mFsShell.run("load", path, "--progress", "--format", "JSON");
     assertTrue(mOutput.toString().contains("\"mJobState\":\"SUCCEEDED\""));
-    mFsShell.run("load", "/testRoot", "--progress", "--format", "JSON", "--verbose");
+    mFsShell.run("load", path, "--progress", "--format", "JSON", "--verbose");
     assertTrue(mOutput.toString().contains("\"mVerbose\":true"));
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Load ufs path directly

### Why are the changes needed?
Previously we concatenate root with relative path, now we directly pass ufs path So we can have multiple ufs support

### Does this PR introduce any user facing changes?
load have to input full ufs path
