### PR TITLE
Implement HDFS list status iterator

### DIFF
--- a/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUfsStatusIterator.java
+++ b/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUfsStatusIterator.java
@@ -1,0 +1,120 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.hdfs;
+
+import alluxio.AlluxioURI;
+import alluxio.collections.Pair;
+import alluxio.underfs.UfsDirectoryStatus;
+import alluxio.underfs.UfsFileStatus;
+import alluxio.underfs.UfsStatus;
+import alluxio.util.UnderFileSystemUtils;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
+
+/**
+ * HDFS under file system status iterator.
+ */
+public class HdfsUfsStatusIterator implements Iterator<UfsStatus> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HdfsUfsStatusIterator.class);
+
+  private final FileSystem mFs;
+
+  /**
+   * Each element is a pair of (full path, UfsStatus).
+   */
+  private LinkedList<Pair<String, UfsStatus>> mDirPathsToProcess = new LinkedList<>();
+
+  private RemoteIterator<FileStatus> mHdfsRemoteIterator;
+
+  /**
+   * HDFS under file system status iterator.
+   * @param path the path for listing
+   * @param fs the hdfs file system
+   */
+  public HdfsUfsStatusIterator(String path, FileSystem fs) {
+    mFs = fs;
+    initQueue(path);
+  }
+
+  private void initQueue(String path) {
+    try {
+      Path thePath = new Path(path);
+      mHdfsRemoteIterator = mFs.listStatusIterator(thePath);
+    } catch (IOException e) {
+      LOG.error("Failed to list the path {}", path, e);
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    try {
+      if (mHdfsRemoteIterator.hasNext()) {
+        return true;
+      }
+      if (mDirPathsToProcess.isEmpty()) {
+        return false;
+      }
+      while (!mDirPathsToProcess.isEmpty()) {
+        Pair<String, UfsStatus> dir = mDirPathsToProcess.removeFirst();
+        String path = dir.getFirst();
+        mHdfsRemoteIterator = mFs.listStatusIterator(new Path(path));
+        if (mHdfsRemoteIterator.hasNext()) {
+          return true;
+        }
+      }
+      return false;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public UfsStatus next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    try {
+      FileStatus fileStatus = mHdfsRemoteIterator.next();
+      UfsStatus ufsStatus;
+      Path path = fileStatus.getPath();
+      AlluxioURI alluxioUri = new AlluxioURI(path.toString());
+      if (fileStatus.isDirectory()) {
+        ufsStatus = new UfsDirectoryStatus(path.getName(), fileStatus.getOwner(),
+            fileStatus.getGroup(), fileStatus.getPermission().toShort(),
+            fileStatus.getModificationTime());
+        mDirPathsToProcess.addLast(new Pair<>(path.toString(), ufsStatus));
+      } else {
+        String contentHash =
+            UnderFileSystemUtils.approximateContentHash(
+                fileStatus.getLen(), fileStatus.getModificationTime());
+        ufsStatus = new UfsFileStatus(path.getName(), contentHash, fileStatus.getLen(),
+            fileStatus.getModificationTime(), fileStatus.getOwner(), fileStatus.getGroup(),
+            fileStatus.getPermission().toShort(), fileStatus.getBlockSize());
+      }
+      ufsStatus.setUfsFullPath(alluxioUri);
+      return ufsStatus;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -34,6 +34,7 @@ import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.FileLocationOptions;
 import alluxio.underfs.options.GetStatusOptions;
+import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
 import alluxio.util.CommonUtils;
@@ -69,6 +70,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -507,6 +509,14 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
   public boolean isFile(String path) throws IOException {
     FileSystem hdfs = getFs();
     return hdfs.isFile(new Path(path));
+  }
+
+  @Nullable
+  @Override
+  public Iterator<UfsStatus> listStatusIterable(String path, ListOptions options, String startAfter,
+                                                int batchSize) throws IOException {
+    FileSystem hdfs = getFs();
+    return new HdfsUfsStatusIterator(path, hdfs);
   }
 
   @Override

--- a/dora/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/hdfs3/HdfsUnderFileSystemIntegrationTestBase.java
+++ b/dora/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/hdfs3/HdfsUnderFileSystemIntegrationTestBase.java
@@ -103,6 +103,10 @@ public class HdfsUnderFileSystemIntegrationTestBase {
         mUfs.getFs().getFileBlockLocations(status, 0, status.getLen()).length);
   }
 
+  protected void createDirectoryTest(String dirPath) throws IOException {
+    mUfs.mkdirs(dirPath);
+  }
+
   protected void writeEmptyFileTest() throws IOException {
     String testFilePath = "/empty_file";
     OutputStream os = mUfs.create(testFilePath, getCreateOption());


### PR DESCRIPTION
When there are a lot of files in HDFS, it takes a large amount of time and memory to complete a `listStatus` request. Moreover, sometimes OOM occurs. This PR provides an iterator for the HDFS under file system to list files.