### PR TITLE
Fix cosn ufs cannot find class

### DIFF
--- a/underfs/cosn/pom.xml
+++ b/underfs/cosn/pom.xml
@@ -86,8 +86,6 @@
                       <exclude>META-INF/*.SF</exclude>
                       <exclude>META-INF/*.DSA</exclude>
                       <exclude>META-INF/*.RSA</exclude>
-                      <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
-                      <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
                     </excludes>
                   </filter>
                   <filter>


### PR DESCRIPTION
Fix bug involved by https://github.com/Alluxio/alluxio/pull/17024

After https://github.com/Alluxio/alluxio/pull/18143, `HdfsUnderFileSystemFactory` is no longer included in COSN jar therefore no need to exclude.