### PR TITLE
Make size of dynamic buffering shrink slower

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
@@ -153,6 +153,11 @@ public interface BlockWorkerClient extends Closeable {
    */
   void cache(CacheRequest request);
 
+  /**
+   * Cache data.
+   *
+   * @param request
+   */
   void cacheData(CacheDataRequest request);
 
   /**

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
@@ -176,8 +176,10 @@ public class PositionReadFileInStream extends FileInStream {
 
   /**
    * Constructor.
+   *
    * @param reader
-   * @param length
+   * @param uriStatus
+   * @param client
    */
   public PositionReadFileInStream(
       PositionReader reader,

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
@@ -21,7 +21,6 @@ import alluxio.network.protocol.databuffer.PooledDirectNioByteBuf;
 import com.amazonaws.annotation.NotThreadSafe;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.EvictingQueue;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
@@ -53,35 +52,23 @@ public class PositionReadFileInStream extends FileInStream {
 
   private class PrefetchCache implements AutoCloseable {
     private final long mFileLength;
-    private final EvictingQueue<CallTrace> mCallHistory;
+    private final int mMaxPrefetchSize;
     private int mPrefetchSize = 0;
 
     private ByteBuf mCache = Unpooled.wrappedBuffer(new byte[0]);
     private long mCacheStartPos = 0;
+    private long mLastCallEndPos = -1;
 
-    PrefetchCache(int prefetchMultiplier, long fileLength) {
-      mCallHistory = EvictingQueue.create(prefetchMultiplier);
+    PrefetchCache(int maxPrefetchSize, long fileLength) {
       mFileLength = fileLength;
-    }
-
-    private void update() {
-      int consecutiveReadLength = 0;
-      long lastReadEnd = -1;
-      for (CallTrace trace : mCallHistory) {
-        if (trace.mPosition == lastReadEnd) {
-          lastReadEnd += trace.mLength;
-          consecutiveReadLength += trace.mLength;
-        } else {
-          lastReadEnd = trace.mPosition + trace.mLength;
-          consecutiveReadLength = trace.mLength;
-        }
-      }
-      mPrefetchSize = consecutiveReadLength;
+      mMaxPrefetchSize = maxPrefetchSize;
     }
 
     private void addTrace(long pos, int size) {
-      mCallHistory.add(new CallTrace(pos, size));
-      update();
+      if (pos == mLastCallEndPos) {
+        mPrefetchSize = Math.min(mMaxPrefetchSize, mPrefetchSize + size);
+      }
+      mLastCallEndPos = pos + size;
     }
 
     /**
@@ -103,11 +90,21 @@ public class PositionReadFileInStream extends FileInStream {
           outBuffer.position(outBuffer.position() + size);
           return size;
         } else {
-          // the position is beyond the cache end position
+          if (targetStartPos > mCacheStartPos + mCache.readableBytes()) {
+            // the target position is beyond the end position of the cache,
+            // meaning it's not a sequential read
+            // halve the prefetch size to be conservative
+            mPrefetchSize /= 2;
+          }
+          // else, the target position is the same as the end of the cache, meaning the cache is
+          // exhausted normally so the read remains sequential.
+          // no need to adjust the prefetch size at this point
           return 0;
         }
       } else {
-        // the position is behind the cache start position
+        // the position is behind the cache start position, this is a rewind
+        // halve the prefetch size
+        mPrefetchSize /= 2;
         return 0;
       }
     }
@@ -190,8 +187,10 @@ public class PositionReadFileInStream extends FileInStream {
     mURIStatus = uriStatus;
     mPositionReader = reader;
     mLength = uriStatus.getLength();
-    mCache = new PrefetchCache(
-        Configuration.getInt(PropertyKey.USER_POSITION_READER_STREAMING_MULTIPLIER), mLength);
+    long size =
+        Configuration.getBytes(PropertyKey.USER_POSITION_READER_STREAMING_PREFETCH_MAX_SIZE);
+    Preconditions.checkArgument(size > 0 && size < Integer.MAX_VALUE, "size");
+    mCache = new PrefetchCache((int) size, mLength);
     mClient = client;
   }
 

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
@@ -137,7 +137,11 @@ public class PositionReadFileInStream extends FileInStream {
 
       if (mCache.capacity() < prefetchSize) {
         mCache.release();
-        mCache = PooledDirectNioByteBuf.allocate(prefetchSize);
+        try {
+          mCache = PooledDirectNioByteBuf.allocate(prefetchSize);
+        } catch (OutOfMemoryError oom) {
+          mCache = Unpooled.wrappedBuffer(new byte[0]);
+        }
         mCacheStartPos = 0;
       }
       mCache.clear();

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -343,6 +343,12 @@ public interface CacheManager extends AutoCloseable, CacheStatus {
    */
   State state();
 
+  /**
+   * Check if a page is being stored.
+   *
+   * @param pageId
+   * @return whether the cache has stored the page
+   */
   default boolean hasPageUnsafe(PageId pageId) {
     throw new UnsupportedOperationException();
   }

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
@@ -428,6 +428,13 @@ public class DoraCacheClient {
     }
   }
 
+  /**
+   * Load data.
+   *
+   * @param ufsPath
+   * @param pos
+   * @param length
+   */
   public void loadDataAsync(String ufsPath, long pos, long length) {
     try (CloseableResource<BlockWorkerClient> client =
              mContext.acquireBlockWorkerClient(getWorkerNetAddress(ufsPath))) {

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5774,6 +5774,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setIsHidden(true)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .build();
+  public static final PropertyKey USER_POSITION_READER_STREAMING_PREFETCH_MAX_SIZE =
+      dataSizeBuilder(Name.USER_POSITION_READER_STREAMING_PREFETCH_MAX_SIZE)
+          .setScope(Scope.CLIENT)
+          .setDefaultValue("16MB")
+          .setDescription("The max size of the prefetch of dynamic buffering")
+          .setIsHidden(true)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .build();
   public static final PropertyKey USER_POSITION_READER_PRELOAD_DATA_ENABLED =
       booleanBuilder("user.position.reader.preload.data.enabled")
           .setScope(Scope.CLIENT)
@@ -8293,6 +8301,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_APP_ID = "alluxio.user.app.id";
     public static final String USER_POSITION_READER_STREAMING_MULTIPLIER =
         "alluxio.user.position.reader.streaming.multiplier";
+    public static final String USER_POSITION_READER_STREAMING_PREFETCH_MAX_SIZE =
+        "alluxio.user.position.reader.streaming.prefetch.max.size";
     public static final String USER_NETWORK_DATA_TIMEOUT =
         "alluxio.user.network.data.timeout";
     public static final String USER_NETWORK_READER_BUFFER_SIZE_MESSAGES =


### PR DESCRIPTION
### What changes are proposed in this pull request?

Halve the prefetch size when cache miss, instead of resetting it to zero.

### Why are the changes needed?
Slower shrinking of buffer size can improve performance in case of sequential read.

### Does this PR introduce any user facing changes?
No.