### PR TITLE
Add getStatus RESTful API

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
@@ -132,6 +132,8 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
         return doGetPage(httpRequest, httpRequestUri);
       case "files":
         return doListFiles(httpRequest, httpRequestUri);
+      case "info":
+        return doGetFileStatus(httpRequest, httpRequestUri);
       case "load":
         return doLoad(httpRequest, httpRequestUri);
       default:
@@ -170,6 +172,33 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
             uriStatus.getLength());
         responseFileInfoList.add(responseFileInfo);
       }
+      // convert to JSON string
+      String responseJson = new Gson().toJson(responseFileInfoList);
+      // create HTTP response
+      FullHttpResponse response = new DefaultFullHttpResponse(httpRequest.protocolVersion(), OK,
+          Unpooled.wrappedBuffer(responseJson.getBytes()));
+      response.headers()
+          .set(CONTENT_TYPE, APPLICATION_JSON)
+          .setInt(CONTENT_LENGTH, response.content().readableBytes());
+      return new HttpResponseContext(response, null);
+    } catch (IOException | AlluxioException e) {
+      LOG.error("Failed to list files of path {}", path, e);
+      return null;
+    }
+  }
+
+  private HttpResponseContext doGetFileStatus(
+      HttpRequest httpRequest, HttpRequestUri httpRequestUri) {
+    String path = httpRequestUri.getParameters().get("path");
+    path = handleReservedCharacters(path);
+    try {
+      URIStatus uriStatus = mFileSystem.getStatus(new AlluxioURI(path));
+      List<ResponseFileInfo> responseFileInfoList = new ArrayList<>();
+      String type = uriStatus.isFolder() ? "directory" : "file";
+      ResponseFileInfo responseFileInfo = new ResponseFileInfo(type, uriStatus.getName(),
+          uriStatus.getPath(), uriStatus.getUfsPath(), uriStatus.getLastModificationTimeMs(),
+          uriStatus.getLength());
+      responseFileInfoList.add(responseFileInfo);
       // convert to JSON string
       String responseJson = new Gson().toJson(responseFileInfoList);
       // create HTTP response


### PR DESCRIPTION
Add getStatus RESTful API.

**Example:**
Get the specified directory/file information by the following request:
`curl -X GET http://localhost:28080/v1/info?path=/tpcds-data`

The response JSON looks like:
`[
  {
    "mType": "directory",
    "mName": "tpcds-data",
    "mPath": "/tpcds-data",
    "mUfsPath": "s3a://jiamingmai-test/tpcds-data",
    "mLastModificationTimeMs": 0,
    "mLength": 0,
    "mHumanReadableFileSize": "0B"
  }
]`

<img width="597" alt="image" src="https://github.com/Alluxio/alluxio/assets/6129818/b38d644b-11da-4206-937b-6d61fd6b3a6c">
