### PR TITLE
Add prefetch cache policy

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/AdaptivePrefetchCachePolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/AdaptivePrefetchCachePolicy.java
@@ -1,0 +1,49 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file;
+
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+
+/**
+ * An improved implementation of the prefetch cache policy that only halves the prefetch size,
+ * on cache miss.
+ */
+public class AdaptivePrefetchCachePolicy implements PrefetchCachePolicy {
+  private long mPrefetchSize = 0;
+  private long mLastCallEndPos = -1;
+  private final long mMaxPrefetchSize =
+      Configuration.getBytes(PropertyKey.USER_POSITION_READER_STREAMING_PREFETCH_MAX_SIZE);
+
+  @Override
+  public void addTrace(long pos, int size) {
+    if (pos == mLastCallEndPos) {
+      mPrefetchSize = Math.min(mMaxPrefetchSize, mPrefetchSize + size);
+    }
+    mLastCallEndPos = pos + size;
+  }
+
+  @Override
+  public void onCacheHitRead() {
+    // Noop
+  }
+
+  @Override
+  public void onCacheMissRead() {
+    mPrefetchSize /= 2;
+  }
+
+  @Override
+  public long getPrefetchSize() {
+    return mPrefetchSize;
+  }
+}

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/BasePrefetchCachePolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/BasePrefetchCachePolicy.java
@@ -21,7 +21,7 @@ import com.google.common.collect.EvictingQueue;
  * contiguous and reduce the window down to the read size if it is not.
  */
 public class BasePrefetchCachePolicy implements PrefetchCachePolicy {
-  private long mPrefetchSize = 0;
+  private int mPrefetchSize = 0;
   private final EvictingQueue<CallTrace> mCallHistory = EvictingQueue.create(
       Configuration.getInt(PropertyKey.USER_POSITION_READER_STREAMING_MULTIPLIER));
 
@@ -53,7 +53,7 @@ public class BasePrefetchCachePolicy implements PrefetchCachePolicy {
   }
 
   @Override
-  public long getPrefetchSize() {
+  public int getPrefetchSize() {
     return mPrefetchSize;
   }
 

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/BasePrefetchCachePolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/BasePrefetchCachePolicy.java
@@ -1,0 +1,69 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file;
+
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+
+import com.google.common.collect.EvictingQueue;
+
+/**
+ * A base prefetch cache policy that increases the prefetch window if the read pattern is
+ * contiguous and reduce the window down to the read size if it is not.
+ */
+public class BasePrefetchCachePolicy implements PrefetchCachePolicy {
+  private long mPrefetchSize = 0;
+  private final EvictingQueue<CallTrace> mCallHistory = EvictingQueue.create(
+      Configuration.getInt(PropertyKey.USER_POSITION_READER_STREAMING_MULTIPLIER));
+
+  @Override
+  public void addTrace(long pos, int size) {
+    mCallHistory.add(new CallTrace(pos, size));
+    int consecutiveReadLength = 0;
+    long lastReadEnd = -1;
+    for (CallTrace trace : mCallHistory) {
+      if (trace.mPosition == lastReadEnd) {
+        lastReadEnd += trace.mLength;
+        consecutiveReadLength += trace.mLength;
+      } else {
+        lastReadEnd = trace.mPosition + trace.mLength;
+        consecutiveReadLength = trace.mLength;
+      }
+    }
+    mPrefetchSize = consecutiveReadLength;
+  }
+
+  @Override
+  public void onCacheHitRead() {
+    // Noop
+  }
+
+  @Override
+  public void onCacheMissRead() {
+    // Noop
+  }
+
+  @Override
+  public long getPrefetchSize() {
+    return mPrefetchSize;
+  }
+
+  private static class CallTrace {
+    final long mPosition;
+    final int mLength;
+
+    private CallTrace(long pos, int length) {
+      mPosition = pos;
+      mLength = length;
+    }
+  }
+}

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
@@ -135,7 +135,11 @@ public class PositionReadFileInStream extends FileInStream {
 
       if (mCache.capacity() < prefetchSize) {
         mCache.release();
-        mCache = PooledDirectNioByteBuf.allocate(prefetchSize);
+        try {
+          mCache = PooledDirectNioByteBuf.allocate(prefetchSize);
+        } catch (OutOfMemoryError oom) {
+          mCache = Unpooled.wrappedBuffer(new byte[0]);
+        }
         mCacheStartPos = 0;
       }
       mCache.clear();

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
@@ -191,7 +191,7 @@ public class PositionReadFileInStream extends FileInStream {
   }
 
   @VisibleForTesting
-  long getPrefetchSize() {
+  int getPrefetchSize() {
     return mCache.mPolicy.getPrefetchSize();
   }
 

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/PrefetchCachePolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/PrefetchCachePolicy.java
@@ -1,0 +1,58 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file;
+
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+
+/**
+ * The prefetch cache policy to determine the prefetch size.
+ */
+public interface PrefetchCachePolicy {
+  /**
+   * Adds the trace of a read request.
+   * @param pos the position
+   * @param size the size
+   */
+  void addTrace(long pos, int size);
+
+  /**
+   * Called when a read hits the cache.
+   */
+  void onCacheHitRead();
+
+  /**
+   * Called when a read does not hit the cache.
+   */
+  void onCacheMissRead();
+
+  /**
+   * @return the expected prefetch size
+   */
+  long getPrefetchSize();
+
+  /**
+   * The factory class.
+   */
+  class Factory {
+    /**
+     * @return a prefetch cache policy
+     */
+    public static PrefetchCachePolicy create() {
+      if (Configuration.getBoolean(
+          PropertyKey.USER_POSITION_READER_STREAMING_ADAPTIVE_POLICY_ENABLED)) {
+        return new AdaptivePrefetchCachePolicy();
+      }
+      return new BasePrefetchCachePolicy();
+    }
+  }
+}

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/PrefetchCachePolicy.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/PrefetchCachePolicy.java
@@ -14,9 +14,12 @@ package alluxio.client.file;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 
+import com.amazonaws.annotation.NotThreadSafe;
+
 /**
  * The prefetch cache policy to determine the prefetch size.
  */
+@NotThreadSafe
 public interface PrefetchCachePolicy {
   /**
    * Adds the trace of a read request.
@@ -38,7 +41,7 @@ public interface PrefetchCachePolicy {
   /**
    * @return the expected prefetch size
    */
-  long getPrefetchSize();
+  int getPrefetchSize();
 
   /**
    * The factory class.

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5794,6 +5794,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.CLIENT)
           .setDefaultValue(false)
           .setDescription("If uses adaptive policy to adjust the prefetch window size")
+          .setIsHidden(true)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .build();
   public static final PropertyKey USER_POSITION_READER_STREAMING_PREFETCH_MAX_SIZE =

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5789,6 +5789,21 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setIsHidden(true)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .build();
+  public static final PropertyKey USER_POSITION_READER_STREAMING_ADAPTIVE_POLICY_ENABLED =
+      booleanBuilder(Name.USER_POSITION_READER_STREAMING_ADAPTIVE_POLICY_ENABLED)
+          .setScope(Scope.CLIENT)
+          .setDefaultValue(false)
+          .setDescription("If uses adaptive policy to adjust the prefetch window size")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .build();
+  public static final PropertyKey USER_POSITION_READER_STREAMING_PREFETCH_MAX_SIZE =
+      dataSizeBuilder(Name.USER_POSITION_READER_STREAMING_PREFETCH_MAX_SIZE)
+          .setScope(Scope.CLIENT)
+          .setDefaultValue("16MB")
+          .setDescription("The max size of the prefetch of dynamic buffering")
+          .setIsHidden(true)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .build();
   public static final PropertyKey USER_POSITION_READER_PRELOAD_DATA_ENABLED =
       booleanBuilder(Name.USER_POSITION_READER_PRELOAD_DATA_ENABLED)
           .setScope(Scope.CLIENT)
@@ -8331,6 +8346,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_APP_ID = "alluxio.user.app.id";
     public static final String USER_POSITION_READER_STREAMING_MULTIPLIER =
         "alluxio.user.position.reader.streaming.multiplier";
+    public static final String USER_POSITION_READER_STREAMING_ADAPTIVE_POLICY_ENABLED =
+        "alluxio.user.position.reader.streaming.adaptive.policy.enabled";
+    public static final String USER_POSITION_READER_STREAMING_PREFETCH_MAX_SIZE =
+        "alluxio.user.position.reader.streaming.prefetch.max.size";
     public static final String USER_POSITION_READER_PRELOAD_DATA_ENABLED =
         "alluxio.user.position.reader.preload.data.enabled";
     public static final String USER_POSITION_READER_PRELOAD_DATA_FILE_SIZE_THRESHOLD =


### PR DESCRIPTION
Origin @dbw9580 

### What changes are proposed in this pull request?

Add an prefetch cache policy that does not reset the sliding window when a cache read misses. Fuse sometimes create read requests that are out of the order and this helps the prefetch keep stable.

