### PR TITLE
Fix MemoryPageStore error on commit() and clear cache on close()

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
@@ -47,7 +47,7 @@ public class NoExceptionCacheManager implements CacheManager {
     try {
       mCacheManager.commitFile(fileId);
     } catch (Exception e) {
-      LOG.error("Failed to commit file {}", fileId);
+      LOG.error("Failed to commit file {}", fileId, e);
     }
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

This change mainly adds two fixes to the `MemoryPageStore`:
1. Add a noop implementation to commit() so it does nothing instead of throwing `UnsupportedOperationException`
2. Clears the cache on close explicitly
