### PR TITLE
[SMALLFIX] Fix a flaky test S3RestServiceHandlerTest.java

### DIFF
--- a/dora/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java
+++ b/dora/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java
@@ -21,6 +21,7 @@ import alluxio.s3.DeleteObjectsRequest;
 import alluxio.s3.DeleteObjectsResult;
 import alluxio.s3.S3Exception;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.junit.Assert;
 import org.junit.Test;
@@ -63,7 +64,9 @@ public class S3RestServiceHandlerTest {
     String o = mapper.writerFor(DeleteObjectsRequest.class).writeValueAsString(r);
     assertTrue(r.getQuiet());
     assertEquals(2, r.getToDelete().size());
-    assertEquals(o, content);
+    JsonNode tree1 = mapper.readTree(o);
+    JsonNode tree2 = mapper.readTree(content);
+    assertTrue(tree1.equals(tree2));
   }
 
   @Test


### PR DESCRIPTION
### What changes are proposed in this pull request?

In this PR I have fixed the flaky test `testDeleteObjectReq` in `alluxio.proxy.s3.S3RestServiceHandlerTest`

The following command was used to detect flakiness using [nondex](https://github.com/TestingResearchIllinois/NonDex) and can be used to re-produce the flakiness:
```
mvn  -pl dora/core/server/proxy  edu.illinois:nondex-maven-plugin:2.1.1:nondex  -Dtest=alluxio.proxy.s3.S3RestServiceHandlerTest#testDeleteObjectReq 
```
NonDex detects flakiness in the assert statement that compares the two XML strings shown below

https://github.com/Alluxio/alluxio/blob/e83066383524537ada5af32eca5236632cd245b9/dora/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java#L66

**Explanation:**
We have defined one expected string and we are constructing the other string by converting an object of class `DeleteObjectsRequest` to string using jackson xmlMapper's `writeValueAsString` function. 

The `writeValueAsString` function as per [docs](https://javadoc.io/static/com.fasterxml.jackson.core/jackson-databind/2.3.1/com/fasterxml/jackson/databind/ObjectMapper.html#writeValueAsString(java.lang.Object)) internally serializes any Java value as JSON output and then converts it into a string using [string writer](https://docs.oracle.com/javase/6/docs/api/java/io/StringWriter.html?is-external=true). The conversion of intermediate JSON object to the final string causes flakiness as JSON does not preserve order. 

Therefore, the output string `o` of the below line is non deterministic which can lead to failures during the assert check:
https://github.com/Alluxio/alluxio/blob/e83066383524537ada5af32eca5236632cd245b9/dora/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java#L61-L63

### Why are the changes needed?

I have written a custom code to compare the XML strings

```
JsonNode tree1 = mapper.readTree(o);
JsonNode tree2 = mapper.readTree(content);
assertTrue(tree1.equals(tree2));
```

We convert both the xml strings to  set of `JsonNode` instances. Then we compare these two nodes. The `equals`  function as per [docs](https://javadoc.io/static/com.fasterxml.jackson.core/jackson-databind/2.3.1/com/fasterxml/jackson/databind/JsonNode.html#equals(java.lang.Object)) performs a full value quality check ensuring no order change issues arise. After this fix, nondex did not detect any flakiness.

**Test Environment:**
> openjdk version "11.0.20.1"
> Apache Maven 3.6.3
> Ubuntu 20.04.6 LTS
> Linux version 5.4.0-156-generic

### Does this PR introduce any user facing changes?
No
