### PR TITLE
[SMALLFIX] Extract create UfsBaseFileSystem for extension

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -178,9 +178,7 @@ public interface FileSystem extends Closeable {
       AlluxioConfiguration conf = context.getClusterConf();
       checkSortConf(conf);
       Optional<UfsFileSystemOptions> ufsOptions = options.getUfsFileSystemOptions();
-      Preconditions.checkArgument(ufsOptions.isPresent(),
-          "Missing UfsFileSystemOptions in FileSystemOptions");
-      FileSystem fs = new UfsBaseFileSystem(context, options.getUfsFileSystemOptions().get());
+      FileSystem fs = context.createUfsBaseFileSystem(ufsOptions);
 
       if (options.isDoraCacheEnabled()) {
         LOG.debug("Dora cache enabled");

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -21,6 +21,8 @@ import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.client.block.stream.BlockWorkerClientPool;
 import alluxio.client.file.FileSystemContextReinitializer.ReinitBlockerResource;
+import alluxio.client.file.options.UfsFileSystemOptions;
+import alluxio.client.file.ufs.UfsBaseFileSystem;
 import alluxio.client.metrics.MetricsHeartbeatContext;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
@@ -999,6 +1001,18 @@ public class FileSystemContext implements Closeable {
       }
     }
     mLocalWorkerInitialized = true;
+  }
+
+  /**
+   * Creates an underlying file system which handles UFS fallback.
+   *
+   * @param ufsOptions options to access the UFS
+   * @return a UFS-based FileSystem implementation
+   */
+  public FileSystem createUfsBaseFileSystem(Optional<UfsFileSystemOptions> ufsOptions) {
+    Preconditions.checkArgument(ufsOptions.isPresent(),
+        "Missing UfsFileSystemOptions in FileSystemOptions");
+    return new UfsBaseFileSystem(this, ufsOptions.get());
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Extract the logic to create `UfsBaseFileSystem` into `FileSystemContext`, for possible extension. This change is functionally a refactor that changes nothing.