### PR TITLE
Fix cosn ufs cannot find class

### DIFF
--- a/dora/underfs/cosn/pom.xml
+++ b/dora/underfs/cosn/pom.xml
@@ -78,8 +78,6 @@
                 <filter>
                   <artifact>org.alluxio:alluxio-underfs-hdfs</artifact>
                   <excludes>
-                    <!-- Because this module depends on alluxio-underfs-hdfs, eliminate HDFS factory implementation -->
-                    <exclude>alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.*</exclude>
                     <exclude>META-INF/services/alluxio.underfs.UnderFileSystemFactory</exclude>
                   </excludes>
                 </filter>


### PR DESCRIPTION
Fix bug involved by https://github.com/Alluxio/alluxio/pull/17024

After https://github.com/Alluxio/alluxio/pull/18143, HdfsUnderFileSystemFactory is no longer included in COSN jar therefore no need to exclude.

Same PR as https://github.com/Alluxio/alluxio/pull/18303 but pushing to the main branch