### PR TITLE
Change file exist exception to runtime exception in PagedDoraWorker

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -1093,7 +1093,9 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
         throw new AlreadyExistsException(String.format("%s already exists", path));
       }
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      // why wrap a IOE in to a RuntimeException??? no way AlluxioRuntimeException can catch it
+      // IOE would be caught by AlluxioRuntimeException
+      throw e;
     }
   }
 

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -1093,7 +1093,6 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
         throw new AlreadyExistsException(String.format("%s already exists", path));
       }
     } catch (IOException e) {
-      // why wrap a IOE in to a RuntimeException??? no way AlluxioRuntimeException can catch it
       // IOE would be caught by AlluxioRuntimeException
       throw e;
     }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -961,7 +961,8 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
       boolean overWrite = options.hasOverwrite() ? options.getOverwrite() : false;
       boolean exists = ufs.exists(path);
       if (!overWrite && exists) {
-        throw new AlreadyExistsException(String.format("File %s already exists but no overwrite flag", path));
+        throw new AlreadyExistsException(String.format("File %s already exists"
+            + "but no overwrite flag", path));
       } else if (overWrite) {
         // client is going to overwrite this file. We need to invalidate the cached meta and data.
         mMetaManager.removeFromMetaStore(path);

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -32,10 +32,10 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AccessControlException;
-import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.runtime.AlluxioRuntimeException;
 import alluxio.exception.runtime.FailedPreconditionRuntimeException;
 import alluxio.exception.runtime.UnavailableRuntimeException;
+import alluxio.exception.status.AlreadyExistsException;
 import alluxio.exception.status.FailedPreconditionException;
 import alluxio.grpc.Command;
 import alluxio.grpc.CommandType;
@@ -961,9 +961,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
       boolean overWrite = options.hasOverwrite() ? options.getOverwrite() : false;
       boolean exists = ufs.exists(path);
       if (!overWrite && exists) {
-        throw new RuntimeException(
-            new FileAlreadyExistsException(
-                String.format("File %s already exists but no overwrite flag", path)));
+        throw new AlreadyExistsException(String.format("File %s already exists but no overwrite flag", path));
       } else if (overWrite) {
         // client is going to overwrite this file. We need to invalidate the cached meta and data.
         mMetaManager.removeFromMetaStore(path);
@@ -1091,8 +1089,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
       mMetaManager.loadFromUfs(path);
       mMetaManager.invalidateListingCacheOfParent(path);
       if (!success) {
-        throw new RuntimeException(
-            new FileAlreadyExistsException(String.format("%s already exists", path)));
+        throw new AlreadyExistsException(String.format("%s already exists", path));
       }
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraMkdirCommandIntegrationTest.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraMkdirCommandIntegrationTest.java
@@ -72,7 +72,6 @@ public class DoraMkdirCommandIntegrationTest extends AbstractDoraFileSystemShell
     }
   }
 
-  // TODO(xinyu): should test a invalid path, maybe redesign this test case XD
   @Test
   public void testMkdirInvalidPath() {
     assertEquals(-1, mFsShell.run("mkdir", ""));

--- a/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraMkdirCommandIntegrationTest.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraMkdirCommandIntegrationTest.java
@@ -51,7 +51,7 @@ public class DoraMkdirCommandIntegrationTest extends AbstractDoraFileSystemShell
     assertEquals(0, mFsShell.run("mkdir", uri.toString()));
     assertEquals(-1, mFsShell.run("mkdir", uri.toString()));
     assertTrue(
-        mOutput.toString().contains("UNKNOWN: alluxio.exception.FileAlreadyExistsException"));
+        mOutput.toString().contains("ALREADY_EXISTS"));
   }
 
   @Test
@@ -72,11 +72,12 @@ public class DoraMkdirCommandIntegrationTest extends AbstractDoraFileSystemShell
     }
   }
 
+  // TODO(xinyu): should test a invalid path, maybe redesign this test case XD
   @Test
   public void testMkdirInvalidPath() {
     assertEquals(-1, mFsShell.run("mkdir", ""));
     assertTrue(
-        mOutput.toString().contains("UNKNOWN: alluxio.exception.FileAlreadyExistsException"));
+        mOutput.toString().contains("ALREADY_EXISTS"));
   }
 
   @Test


### PR DESCRIPTION
### What changes are proposed in this pull request?

The `RuntimeException(FileAlreadyExistException)` changed to `AlreadyExistException()` in `PagedDoraWorker`

### Why are the changes needed?

`RuntimeException(FileAlreadyExistException)` seems won't be caught in `DoraWorkerClientServiceHandler` when convertin it to `AlluxioRuntimeException`, which willl cause the loss status code

### Does this PR introduce any user facing changes?

no
