### PR TITLE
Bug fix, fix the time judgment logic for judging stale client channel…

### DIFF
--- a/dora/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
+++ b/dora/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
@@ -26,6 +26,7 @@ import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -160,12 +161,12 @@ public class DefaultAuthenticationServer
    * stale.
    */
   private void cleanupStaleClients() {
-    LocalTime cleanupTime = LocalTime.now();
+    LocalDateTime cleanupTime = LocalDateTime.now();
     LOG.debug("Starting cleanup authentication registry at {}", cleanupTime);
     // Get a list of stale clients under read lock.
     List<UUID> staleChannels = new ArrayList<>();
     for (Map.Entry<UUID, AuthenticatedChannelInfo> clientEntry : mChannels.entrySet()) {
-      LocalTime lat = clientEntry.getValue().getLastAccessTime();
+      LocalDateTime lat = clientEntry.getValue().getLastAccessTime();
       if (lat.plusSeconds(mCleanupIntervalMs / 1000).isBefore(cleanupTime)) {
         staleChannels.add(clientEntry.getKey());
       }
@@ -201,7 +202,8 @@ public class DefaultAuthenticationServer
    * and Sasl objects per channel.
    */
   class AuthenticatedChannelInfo {
-    private LocalTime mLastAccessTime;
+    // private LocalTime mLastAccessTime;
+    private LocalDateTime mLastAccessTime;
     private AuthenticatedUserInfo mUserInfo;
     private AuthenticatedChannelServerDriver mSaslServerDriver;
 
@@ -213,17 +215,17 @@ public class DefaultAuthenticationServer
         AuthenticatedChannelServerDriver saslServerDriver) {
       mUserInfo = userInfo;
       mSaslServerDriver = saslServerDriver;
-      mLastAccessTime = LocalTime.now();
+      mLastAccessTime =  LocalDateTime.now();
     }
 
     private synchronized void updateLastAccessTime() {
-      mLastAccessTime = LocalTime.now();
+      mLastAccessTime  = LocalDateTime.now();
     }
 
     /**
      * @return the last access time
      */
-    public synchronized LocalTime getLastAccessTime() {
+    public synchronized LocalDateTime getLastAccessTime() {
       return mLastAccessTime;
     }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Bug fix, fix the time judgment logic for judging whether stale client channels are inactive. Using the `LocaTime` object cannot correctly judge whether a channel client is inactive, because a LocalTime plus or minus time offset only changes the hour, minute, second attribute value, and It will not affect the date, you actually need to use the `LocalDateTime` object

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
1. In the code, the `LocaTime` class is used to determine that a client channel is inactive. The LocalTime object adds or subtracts the time offset. It only changes the hour, minute and second attribute value and does not affect the date. In fact, you need to use the `LocalDateTime` object.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  none
