### PR TITLE
Using InputStream to build XML to resolve exceptions when the filename is in Chinese

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -49,6 +49,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.text.DateFormat;
@@ -128,7 +129,7 @@ public final class S3RestUtils {
       }
       // Need to explicitly encode the string as XML because Jackson will not do it automatically.
       XmlMapper mapper = new XmlMapper();
-      return Response.ok(mapper.writeValueAsString(result)).build();
+      return Response.ok(new ByteArrayInputStream(mapper.writeValueAsBytes(result))).build();
     } catch (Exception e) {
       String errOutputMsg = e.getMessage();
       if (StringUtils.isEmpty(errOutputMsg)) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Using InputStream to build XML to resolve exceptions when the filename is in Chinese.

### Why are the changes needed?

We have a dir: 
![image](https://github.com/Alluxio/alluxio/assets/45056332/401804f6-8782-44df-bf3b-d78b028ce963)

When we list it by S3 Proxy, the response is incorrect:
![企业微信截图_1058c14a-038f-4509-be56-79b4152c00c5](https://github.com/Alluxio/alluxio/assets/45056332/537dce12-4484-431c-8be5-0eb00eafe8d9)

After we fix it:
![企业微信截图_15d4d820-de6f-430a-a7c4-ed119adbab6c](https://github.com/Alluxio/alluxio/assets/45056332/b2abcfe0-4d18-46b8-bf5f-e6cdc768fd5d)


### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs NO
  2. addition or removal of property keys NO
  3. webui NO
