### PR TITLE
Fix file mtime display when ufs mtime is not null

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -1179,10 +1179,12 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
         infoBuilder.putXattr(entry.getKey(), ByteString.copyFromUtf8(entry.getValue()));
       }
     }
+    if (status.getLastModifiedTime() != null) {
+      infoBuilder.setLastModificationTimeMs(status.getLastModifiedTime());
+    }
     if (status instanceof UfsFileStatus) {
       UfsFileStatus fileStatus = (UfsFileStatus) status;
       infoBuilder.setLength(fileStatus.getContentLength())
-          .setLastModificationTimeMs(status.getLastModifiedTime())
           .setBlockSizeBytes(fileStatus.getBlockSize());
       String contentHash = ((UfsFileStatus) status).getContentHash();
       if (contentHash != null) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

https://github.com/Alluxio/alluxio/issues/18357

### Why are the changes needed?

mtime display error when ufs is hdfs
![企业微信截图_9ff2cbaf-4e24-4cbc-ae11-6a5ace7812f1](https://github.com/Alluxio/alluxio/assets/800042/606cbcb0-b07f-4f91-8919-b1fe1b9e6dcc)

after this commit:

![企业微信截图_8c7ee012-851c-425e-a4c1-d22f0d39984b](https://github.com/Alluxio/alluxio/assets/800042/e05bfed5-c929-43c1-a633-6b6dee3f10ef)



### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs. no
  2. addition or removal of property keys. no
  3. webui. no
