### PR TITLE
[BUG_FIX] Fix  s3 encode url with missing the asterisk *

### DIFF
--- a/dora/core/server/common/src/main/java/alluxio/s3/signature/StringToSignProducer.java
+++ b/dora/core/server/common/src/main/java/alluxio/s3/signature/StringToSignProducer.java
@@ -338,6 +338,7 @@ public final class StringToSignProducer {
     try {
       return URLEncoder.encode(str, "UTF-8")
               .replaceAll("\\+", "%20")
+              .replaceAll("\\*", "%2A")
               .replaceAll("%7E", "~");
     } catch (UnsupportedEncodingException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Replace the asterisk (*) with %2A  when s3 proxy urlEncode
### Why are the changes needed?
When the S3 path contains the * character, accessing it may result in an error.
 
### Does this PR introduce any user facing changes?
NO
