### PR TITLE
[BUG_FIX] Fix  s3 encode url with some encoded char

### DIFF
--- a/dora/core/server/common/src/main/java/alluxio/s3/signature/StringToSignProducer.java
+++ b/dora/core/server/common/src/main/java/alluxio/s3/signature/StringToSignProducer.java
@@ -27,11 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
-import java.net.InetAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLEncoder;
-import java.net.UnknownHostException;
+import java.net.*;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
@@ -336,7 +332,7 @@ public final class StringToSignProducer {
    */
   private static String urlEncode(String str) {
     try {
-      return URLEncoder.encode(str, "UTF-8")
+      return URLEncoder.encode(URLDecoder.decode(str, "UTF-8"), "UTF-8")
               .replaceAll("\\+", "%20")
               .replaceAll("%7E", "~");
     } catch (UnsupportedEncodingException e) {

--- a/dora/core/server/common/src/main/java/alluxio/s3/signature/StringToSignProducer.java
+++ b/dora/core/server/common/src/main/java/alluxio/s3/signature/StringToSignProducer.java
@@ -27,7 +27,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
-import java.net.*;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.net.UnknownHostException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;


### PR DESCRIPTION
### What changes are proposed in this pull request?

When performing URL encoding, it is necessary to decode the URL first to prevent problems caused by repeated encoding when accessing s3a.

### Why are the changes needed?

When we use s3a read s3 proxy , if s3 path with char `=`,  it threw exception with 403.
`hdfs dfs -ls -Dfs.s3a.endpoint=http://s3-proxy:39999/api/v1/s3  -Dfs.s3a.path.style.access=true  s3a://xxx/xxx/dt=20230906`

![image](https://github.com/Alluxio/alluxio/assets/10757009/4d96e3f7-af4d-4b99-b7ed-34b710942bb0)


### Does this PR introduce any user facing changes?
NO
