### PR TITLE
Optimize listing objects for s3 api

### DIFF
--- a/dora/core/server/common/src/main/java/alluxio/s3/ListBucketResult.java
+++ b/dora/core/server/common/src/main/java/alluxio/s3/ListBucketResult.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.google.common.collect.Streams;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -33,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -132,6 +134,20 @@ public class ListBucketResult {
    */
   public ListBucketResult(
       String bucketName, List<URIStatus> children, ListBucketOptions options) throws S3Exception {
+    this(bucketName, children.stream().sorted(Comparator.comparing(URIStatus::getPath)).iterator(),
+        options);
+  }
+
+  /**
+   * Creates an {@link ListBucketResult}.
+   *
+   * @param bucketName the bucket name
+   * @param iterator an iterator of {@link URIStatus}, and the order of returned elements
+   *                 must be based on the path of URIStatus.
+   * @param options the list bucket options
+   */
+  public ListBucketResult(String bucketName, Iterator<URIStatus> iterator,
+      ListBucketOptions options) throws S3Exception {
     mName = bucketName;
     if (mName == null || mName.isEmpty()) {
       throw new S3Exception(S3ErrorCode.INVALID_BUCKET_NAME);
@@ -173,16 +189,16 @@ public class ListBucketResult {
       return;
     }
     // contains both ends of "/" character
-    final String bucketPrefix = AlluxioURI.SEPARATOR + mName + AlluxioURI.SEPARATOR;
-    buildListBucketResult(bucketPrefix, children);
+    final String bucketPrefix = getBucketPrefix(mName);
+    buildListBucketResult(bucketPrefix, iterator);
   }
 
   /**
    * Filter {@link URIStatus} use marker/continuation-token, prefix, delimiter, and max-keys.
-   * @param children a list of {@link URIStatus}, representing the objects and common prefixes
+   * @param iterator a list of {@link URIStatus}, representing the objects and common prefixes
    */
   private void buildListBucketResult(
-      String bucketPrefix, List<URIStatus> children) throws S3Exception {
+      String bucketPrefix, Iterator<URIStatus> iterator) throws S3Exception {
     final String marker;
     if (isVersion2()) {
       if (mContinuationToken != null) {
@@ -199,9 +215,7 @@ public class ListBucketResult {
     // used when handling truncating
     int[] keyCount = {0}; // must use an array to have a mutable variable during sequential stream
 
-    //sort use uri path
-    children.sort(Comparator.comparing(URIStatus::getPath));
-    mContents = children.stream()
+    mContents = Streams.stream(iterator)
         //marker filter
         .filter(status -> {
           String path = status.getPath().substring(bucketPrefix.length());
@@ -515,6 +529,15 @@ public class ListBucketResult {
     } else {
       return "";
     }
+  }
+
+  /**
+   *
+   * @param bucketName
+   * @return the bucket prefix in alluxio
+   */
+  public static String getBucketPrefix(String bucketName) {
+    return AlluxioURI.SEPARATOR + bucketName + AlluxioURI.SEPARATOR;
   }
 
   /**

--- a/dora/core/server/common/src/main/java/alluxio/s3/ListPrefixIterator.java
+++ b/dora/core/server/common/src/main/java/alluxio/s3/ListPrefixIterator.java
@@ -1,0 +1,112 @@
+package alluxio.s3;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.URIStatus;
+import alluxio.exception.AlluxioException;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * An iterator for listing a given path, and its working mode is lazy loading.
+ */
+public class ListPrefixIterator implements Iterator<URIStatus> {
+
+  private static final URIStatus[] EMPTY_ARRAY = new URIStatus[0];
+
+  private final AlluxioURI mPath;
+  private final ChildrenSupplier mChildrenSupplier;
+  private final String mPrefix;
+  private final Deque<URIStatus> mStack;
+  private URIStatus[] mChildren;
+  private int mIndex;
+
+  /**
+   *
+   * @param path the path to list status
+   * @param childrenSupplier the method is used to list status
+   * @param prefix the prefix to filter
+   */
+  public ListPrefixIterator(AlluxioURI path, ChildrenSupplier childrenSupplier,
+      @Nullable String prefix) {
+    mPath = path;
+    mChildrenSupplier = childrenSupplier;
+    mPrefix = prefix == null ? "" : prefix;
+    mStack = new ArrayDeque<>();
+    mChildren = listSortedChildren(mPath);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return !mStack.isEmpty() || mIndex < mChildren.length;
+  }
+
+  @Override
+  public URIStatus next() {
+    if (mIndex < mChildren.length) {
+      URIStatus status = mChildren[mIndex];
+      if (status.isFolder()) {
+        for (int i = mChildren.length - 1; i > mIndex; i--) {
+          mStack.push(mChildren[i]);
+        }
+        mIndex = 0;
+        mChildren = listSortedChildren(new AlluxioURI(status.getPath()));
+      } else {
+        mIndex++;
+      }
+      return status;
+    }
+    URIStatus status = mStack.pop();
+    mIndex = 0;
+    mChildren = EMPTY_ARRAY;
+    if (status.isFolder()) {
+      mChildren = listSortedChildren(new AlluxioURI(status.getPath()));
+    }
+    return status;
+  }
+
+  private URIStatus[] listSortedChildren(AlluxioURI parent) {
+    try {
+      return mChildrenSupplier.getChildren(parent).stream()
+          .filter(status -> status.getPath().startsWith(mPrefix))
+          .sorted(Comparator.comparing(URIStatus::getPath))
+          .toArray(URIStatus[]::new);
+    } catch (IOException | AlluxioException e) {
+      throw new ListPrefixException(e);
+    }
+  }
+
+  /**
+   * A function interface for listing status.
+   */
+  public interface ChildrenSupplier {
+
+    /**
+     *
+     * @param path
+     * @return Children of given parent path
+     * @throws IOException
+     * @throws AlluxioException
+     */
+    List<URIStatus> getChildren(AlluxioURI path) throws IOException, AlluxioException;
+  }
+
+  /**
+   * An RuntimeException to wrap Exception.
+   */
+  public static class ListPrefixException extends RuntimeException {
+
+    /**
+     *
+     * @param cause
+     */
+    public ListPrefixException(Exception cause) {
+      super(cause);
+    }
+  }
+}

--- a/dora/core/server/proxy/src/test/java/alluxio/proxy/s3/ListPrefixIteratorTest.java
+++ b/dora/core/server/proxy/src/test/java/alluxio/proxy/s3/ListPrefixIteratorTest.java
@@ -1,0 +1,129 @@
+package alluxio.proxy.s3;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.URIStatus;
+import alluxio.s3.ListPrefixIterator;
+import alluxio.s3.ListPrefixIterator.ChildrenSupplier;
+import alluxio.wire.FileInfo;
+import com.google.common.collect.Streams;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ListPrefixIteratorTest {
+
+  @Rule
+  public final TemporaryFolder mTestFolder = new TemporaryFolder();
+
+  private final Random mRandom = new Random();
+  private final char[] mChars = new char[]{'a', 'b', 'c'};
+  private final ChildrenSupplier mLocalFileChildrenSupplier = alluxioURI -> {
+    File[] files = new File(alluxioURI.getPath()).listFiles();
+    if (files == null) {
+      return Collections.emptyList();
+    } else {
+      return Arrays.stream(files).map(this::fromFile).collect(Collectors.toList());
+    }
+  };
+
+  private String getRandomFileName() {
+    int length = mRandom.nextInt(3) + 1;
+    StringBuilder name = new StringBuilder();
+    for (int i = 0; i < length; i++) {
+      name.append(mChars[mRandom.nextInt(mChars.length)]);
+    }
+    return name.toString();
+  }
+
+  private String getRandomFilePath(int depths) {
+    return IntStream.range(0, depths)
+        .mapToObj(i -> getRandomFileName())
+        .collect(Collectors.joining("/"));
+  }
+
+  public List<String> createRandomTmpFile(String root) throws IOException {
+    // clear
+    mTestFolder.delete();
+    // create 100 dirs
+    int depths = mRandom.nextInt(3) + 1;
+    Set<String> files = new HashSet<>();
+    for (int i = 0; i < 100; i++) {
+      files.add(getRandomFilePath(depths));
+    }
+    return files.stream().sorted(Comparator.naturalOrder()).map(s -> {
+          try {
+            return mTestFolder.newFolder(root + File.separator + s).getPath();
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Test
+  public void testUriStatusIteratorWithoutPrefix() throws IOException {
+    for (int i = 0; i < 100; i++) {
+      String rootDir = "root" + i;
+      createRandomTmpFile(rootDir);
+      AlluxioURI path = new AlluxioURI(mTestFolder.getRoot().getPath() + File.separator + rootDir);
+      ListPrefixIterator listPrefixIterator = new ListPrefixIterator(path, mLocalFileChildrenSupplier,
+          null);
+      List<String> actual = Streams.stream(listPrefixIterator).map(URIStatus::getPath)
+          .collect(Collectors.toList());
+      List<String> expect = listLocalDir(
+          new AlluxioURI(mTestFolder.getRoot().getPath() + File.separator + rootDir));
+      Assert.assertEquals(expect, actual);
+    }
+  }
+
+  @Test
+  public void testUriStatusIteratorWithPrefix() throws IOException {
+    for (int i = 0; i < 100; i++) {
+      String rootDir = "root" + i;
+      createRandomTmpFile(rootDir);
+      AlluxioURI path = new AlluxioURI(mTestFolder.getRoot().getPath() + File.separator + rootDir);
+      List<String> local = listLocalDir(
+          new AlluxioURI(mTestFolder.getRoot().getPath() + File.separator + rootDir));
+      // test 100 times: random select prefix
+      for (int j = 0; j < 100; j++) {
+        String prefix = local.get(mRandom.nextInt(local.size()));
+        ListPrefixIterator listPrefixIterator = new ListPrefixIterator(path,
+            mLocalFileChildrenSupplier, prefix);
+        List<String> actual = Streams.stream(listPrefixIterator).map(URIStatus::getPath)
+            .collect(Collectors.toList());
+        List<String> expect = local.stream().filter(s -> s.startsWith(prefix))
+            .collect(Collectors.toList());
+        Assert.assertEquals(expect, actual);
+      }
+    }
+  }
+
+  private URIStatus fromFile(File file) {
+    return new URIStatus(new FileInfo().setPath(file.getPath()).setFolder(file.isDirectory()));
+  }
+
+  private List<String> listLocalDir(AlluxioURI path) throws IOException {
+    return Files.walk(new File(path.getPath()).toPath(),
+            FileVisitOption.FOLLOW_LINKS)
+        .map(Path::toString)
+        .sorted(Comparator.naturalOrder())
+        .skip(1)
+        .collect(Collectors.toList());
+  }
+
+}

--- a/dora/core/server/worker/src/main/java/alluxio/worker/s3/S3NettyBucketTask.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/s3/S3NettyBucketTask.java
@@ -24,7 +24,6 @@ import alluxio.exception.InvalidPathException;
 import alluxio.grpc.Bits;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.DeletePOptions;
-import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.PMode;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.s3.DeleteObjectsRequest;
@@ -32,6 +31,8 @@ import alluxio.s3.DeleteObjectsResult;
 import alluxio.s3.ListAllMyBucketsResult;
 import alluxio.s3.ListBucketOptions;
 import alluxio.s3.ListBucketResult;
+import alluxio.s3.ListPrefixIterator;
+import alluxio.s3.ListPrefixIterator.ListPrefixException;
 import alluxio.s3.NettyRestUtils;
 import alluxio.s3.S3AuditContext;
 import alluxio.s3.S3Constants;
@@ -52,7 +53,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
@@ -215,7 +218,7 @@ public class S3NettyBucketTask extends S3NettyBaseTask {
               .setContinuationToken(continuationTokenParam)
               .setStartAfter(startAfterParam);
 
-          List<URIStatus> children;
+          Iterator<URIStatus> uriStatusIterator;
           try {
             // TODO(czhu): allow non-"/" delimiters by parsing the prefix & delimiter pair to
             //             determine what directory to list the contents of
@@ -226,26 +229,29 @@ public class S3NettyBucketTask extends S3NettyBaseTask {
               } else {
                 path = parsePathWithDelimiter(path, prefixParam, delimiterParam);
               }
-              children = userFs.listStatus(new AlluxioURI(path));
+              uriStatusIterator = userFs.listStatus(new AlluxioURI(path)).stream()
+                  .sorted(Comparator.comparing(URIStatus::getPath)).iterator();
             } else {
               if (prefixParam != null) {
                 path = parsePathWithDelimiter(path, prefixParam, AlluxioURI.SEPARATOR);
               }
-              ListStatusPOptions options = ListStatusPOptions.newBuilder()
-                  .setRecursive(true).build();
-              children = userFs.listStatus(new AlluxioURI(path), options);
+              String absolutePrefix =  ListBucketResult.getBucketPrefix(mHandler.getBucket())
+                  + listBucketOptions.getPrefix();
+              uriStatusIterator = new ListPrefixIterator(new AlluxioURI(path),
+                  userFs::listStatus, absolutePrefix);
             }
+            return new ListBucketResult(mHandler.getBucket(), uriStatusIterator, listBucketOptions);
           } catch (FileDoesNotExistException e) {
             // Since we've called S3RestUtils.checkPathIsAlluxioDirectory() on the bucket path
             // already, this indicates that the prefix was unable to be found in the Alluxio FS
-            children = new ArrayList<>();
+            return new ListBucketResult(mHandler.getBucket(), Collections.emptyIterator(),
+                listBucketOptions);
+          } catch (ListPrefixException e) {
+            throw NettyRestUtils.toBucketS3Exception((Exception) e.getCause(), mHandler.getBucket(),
+                auditContext);
           } catch (IOException | AlluxioException e) {
             throw NettyRestUtils.toBucketS3Exception(e, mHandler.getBucket(), auditContext);
           }
-          return new ListBucketResult(
-              mHandler.getBucket(),
-              children,
-              listBucketOptions);
         } // end try-with-resources block
       });
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?



### Why are the changes needed?

The listObjects API of Alluxio S3 Proxy has been plagued by serious performance issues. The issue can be described as follows:

Assuming we have two directories under the `s3` bucket, namely `a/` and `aa/`. The `a/` directory contains one file, while the `aa/` directory has one billion files. When trying to retrieve the files under the `a/` directory using the command `curl localhost:29998/s3?prefix=a&max-keys=1000`, the S3 Proxy ends up listing all one billion files under `aa/` as well, storing them in memory, and then filtering the results to return to the user. This results in a severe performance bottleneck and could potentially lead to Out of Memory (OOM) errors.

From my discussions with the community, it's evident that unless this problem is addressed, it will be challenging to effectively use the S3 Proxy. This issue has been raised in the past, but for some unknown reason, it has been lingering without a resolution.

Perhaps the listObjects API will be refactored in the future, but for now, there seems to be no straightforward solution for users to address the performance problem. I believe this issue should not be ignored and that there should be some means to address it. Therefore, I am providing a lightweight patch to improve the performance of the S3 Proxy's listObjects API. Of course, it would be ideal if this patch could be **merged.**

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs. **yes**
  2. addition or removal of property keys. no
  3. webui. no
