### PR TITLE
[SMALLFIX] Allow extension on `UfsManager.tryUfsFileSystem()`

### DIFF
--- a/dora/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
+++ b/dora/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
@@ -192,7 +192,7 @@ public abstract class AbstractUfsManager implements UfsManager {
    * @param ufsPath the UFS path
    * @throws Exception
    */
-  private void tryUseFileSystem(UnderFileSystem fs, String ufsPath) throws Exception {
+  protected void tryUseFileSystem(UnderFileSystem fs, String ufsPath) throws Exception {
     fs.exists(ufsPath);
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Change the method visibility to `protected` to allow overriding this method.

### Why are the changes needed?

I can override this method to a noop so the `UfsManager` does not connect to the real UFS instance.
