### PR TITLE
Fix StressWorkerBench with remote worker policy

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/RemoteWorkerList.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/RemoteWorkerList.java
@@ -76,7 +76,7 @@ public class RemoteWorkerList {
    *
    * @return the next worker
    */
-  public BlockWorkerInfo findNextWorker() {
+  public synchronized BlockWorkerInfo findNextWorker() {
     BlockWorkerInfo nextWorker = mRemoteWorkers.get(mNextIndex);
     mNextIndex++;
     if (mNextIndex >= mRemoteWorkers.size()) {

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -14,7 +14,6 @@ package alluxio.stress.cli.worker;
 import static alluxio.Constants.MB;
 import static alluxio.Constants.SECOND_NANO;
 import static alluxio.stress.BaseParameters.DEFAULT_TASK_ID;
-import static alluxio.stress.worker.WorkerBenchMode.LOCAL_ONLY;
 
 import alluxio.Constants;
 import alluxio.annotation.SuppressFBWarnings;
@@ -27,7 +26,6 @@ import alluxio.stress.cli.AbstractStressBench;
 import alluxio.stress.common.FileSystemParameters;
 import alluxio.stress.worker.WorkerBenchCoarseDataPoint;
 import alluxio.stress.worker.WorkerBenchDataPoint;
-import alluxio.stress.worker.WorkerBenchMode;
 import alluxio.stress.worker.WorkerBenchParameters;
 import alluxio.stress.worker.WorkerBenchTaskResult;
 import alluxio.util.CommonUtils;

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -202,12 +202,8 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
       case REMOTE_ONLY:
         // if is cluster run and cluster size = 1, REMOTE_ONLY is not supported.
         if (mBaseParameters.mClusterLimit == 1) {
-          LOG.warn("Cluster size is 1. REMOTE_ONLY mode not supported. Using LOCAL_ONLY mode.");
-          hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
-              "alluxio.client.file.dora.LocalWorkerPolicy");
+          throw new IllegalArgumentException("Cluster size is 1. REMOTE_ONLY mode not supported.");
         }
-        hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
-            "alluxio.client.file.dora.RemoteOnlyPolicy");
         break;
       default:
         throw new IllegalArgumentException("Unrecognized mode" + mParameters.mMode);

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -14,6 +14,7 @@ package alluxio.stress.cli.worker;
 import static alluxio.Constants.MB;
 import static alluxio.Constants.SECOND_NANO;
 import static alluxio.stress.BaseParameters.DEFAULT_TASK_ID;
+import static alluxio.stress.worker.WorkerBenchMode.LOCAL_ONLY;
 
 import alluxio.Constants;
 import alluxio.annotation.SuppressFBWarnings;
@@ -26,6 +27,7 @@ import alluxio.stress.cli.AbstractStressBench;
 import alluxio.stress.common.FileSystemParameters;
 import alluxio.stress.worker.WorkerBenchCoarseDataPoint;
 import alluxio.stress.worker.WorkerBenchDataPoint;
+import alluxio.stress.worker.WorkerBenchMode;
 import alluxio.stress.worker.WorkerBenchParameters;
 import alluxio.stress.worker.WorkerBenchTaskResult;
 import alluxio.util.CommonUtils;
@@ -190,7 +192,6 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
         "true");
 
     // default mode value: hash, using consistent hash
-    // TODO(jiacheng): we may need a policy to only IO to remote worker
     switch (mParameters.mMode) {
       case HASH:
         hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
@@ -201,6 +202,12 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
             "alluxio.client.file.dora.LocalWorkerPolicy");
         break;
       case REMOTE_ONLY:
+        // if is cluster run and cluster size = 1, REMOTE_ONLY is not supported.
+        if (mBaseParameters.mClusterLimit == 1) {
+          LOG.warn("Cluster size is 1. REMOTE_ONLY mode not supported. Using LOCAL_ONLY mode.");
+          hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
+              "alluxio.client.file.dora.LocalWorkerPolicy");
+        }
         hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
             "alluxio.client.file.dora.RemoteOnlyPolicy");
         break;


### PR DESCRIPTION
This pull request fixes a bug on stress worker bench.

1. When using the remote worker policy, running `findNextWorker()`, multiple threads increment `mNextIndex`, leading to possible array out of bounds errors when getting worker info.
2. If use remote worker policy and the cluster size is 1, no workers can be found in `findNextWorker()`, resulting in errors.

This fix turns `findNextWorker()` into a synchronized function, which can avoid data corruption. In addition, this policy can only be used when cluster size > 1.