### PR TITLE
Fix empty block location

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockStore.java
@@ -389,15 +389,7 @@ public class PagedBlockStore implements BlockStore {
   public void moveBlock(long sessionId, long blockId, AllocateOptions moveOptions)
       throws IOException {
     // TODO(bowen): implement actual move and replace placeholder values
-    int dirIndex = getDirIndexOfBlock(blockId);
-    BlockStoreLocation srcLocation = new BlockStoreLocation(DEFAULT_TIER, dirIndex);
-    BlockStoreLocation destLocation = moveOptions.getLocation();
-    for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
-      synchronized (listener) {
-        listener.onMoveBlockByClient(blockId, srcLocation, destLocation);
-      }
-    }
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException("moveBlock");
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix a bug caused by empty block location strings. The worker sends block locations which contain empty medium type strings and block master sync is therefore broken.

### Why are the changes needed?

```
2023-11-06 10:18:26,714 ERROR BlockMasterSync - Failed to receive master heartbeat command. worker id 1812723380431920939
alluxio.exception.status.InternalException: MediumType must be one of {MEM, HDD and SSD} but got
        at alluxio.exception.status.AlluxioStatusException.from(AlluxioStatusException.java:159)
        at alluxio.exception.status.AlluxioStatusException.fromStatusRuntimeException(AlluxioStatusException.java:215)
        at alluxio.AbstractClient.retryRPCInternal(AbstractClient.java:486)
        at alluxio.AbstractClient.retryRPC(AbstractClient.java:450)
        at alluxio.AbstractClient.retryRPC(AbstractClient.java:439)
        at alluxio.worker.block.BlockMasterClient.heartbeat(BlockMasterClient.java:238)
        at alluxio.worker.block.BlockMasterSyncHelper.heartbeat(BlockMasterSyncHelper.java:140)
        at alluxio.worker.block.SpecificMasterBlockSync.heartbeat(SpecificMasterBlockSync.java:207)
        at alluxio.heartbeat.HeartbeatThread.run(HeartbeatThread.java:128)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: io.grpc.StatusRuntimeException: INTERNAL: MediumType must be one of {MEM, HDD and SSD} but got
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:262)
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:243)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:156)
        at alluxio.grpc.BlockMasterWorkerServiceGrpc$BlockMasterWorkerServiceBlockingStub.blockHeartbeat(BlockMasterWorkerServiceGrpc.java:611)
        at alluxio.worker.block.BlockMasterClient.lambda$heartbeat$4(BlockMasterClient.java:240)
        at alluxio.AbstractClient.retryRPCInternal(AbstractClient.java:484)
        ... 11 more

```

### Does this PR introduce any user facing changes?

No.
