### PR TITLE
Fix chaotic chinese characters with golang cli commands

### DIFF
--- a/cli/src/alluxio.org/cli/env/command.go
+++ b/cli/src/alluxio.org/cli/env/command.go
@@ -92,6 +92,7 @@ func (c *BaseJavaCommand) RunJavaClassCmd(args []string) *exec.Cmd {
 	cmdArgs = append(cmdArgs, args...)
 
 	ret := exec.Command(Env.EnvVar.GetString(ConfJava.EnvVar), cmdArgs...)
+	ret.Env = os.Environ()
 	for _, k := range Env.EnvVar.AllKeys() {
 		ret.Env = append(ret.Env, fmt.Sprintf("%s=%v", k, Env.EnvVar.Get(k)))
 	}


### PR DESCRIPTION
When debugging load command, it is found that `./bin/alluxio` CLI can't process Chinese characters correctly. There must be something wrong with the CLI encoding or decoding. It seems that the Chinese characters are encoded incorrectly.

This happens because the construction of CLI commands does not initialize environmental variables correctly. OS-level environmental variables are ignored, so the program uses a false encoder.

This pull request fixes this problem.