### PR TITLE
Fix integration tests again

### DIFF
--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -58,6 +58,7 @@ jobs:
           mkdir -p ~/.m2
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=dora/tests/integration \
           ALLUXIO_DOCKER_MVN_TESTS=${{ matrix.modules }} \
           dev/github/run_docker.sh
         timeout-minutes: 60

--- a/.github/workflows/java8_integration_tests_ft.yml
+++ b/.github/workflows/java8_integration_tests_ft.yml
@@ -53,6 +53,7 @@ jobs:
           ALLUXIO_DOCKER_FORK_COUNT=1 \
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=dora/tests/integration \
           ALLUXIO_DOCKER_MVN_TESTS=${{ matrix.modules }} \
           dev/github/run_docker.sh
         timeout-minutes: 60

--- a/.github/workflows/java8_integration_tests_webui.yml
+++ b/.github/workflows/java8_integration_tests_webui.yml
@@ -49,6 +49,7 @@ jobs:
           mkdir -p ~/.m2
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=dora/tests/integration,webui \
           ALLUXIO_DOCKER_MVN_TESTS=${{ matrix.modules }} \
           dev/github/run_docker.sh
         timeout-minutes: 60

--- a/dev/github/run_tests.sh
+++ b/dev/github/run_tests.sh
@@ -27,7 +27,7 @@ fi
 
 mvn_args=""
 if [ -n "${ALLUXIO_MVN_PROJECT_LIST}" ]; then
-  mvn_args+="-am -pl ${ALLUXIO_MVN_PROJECT_LIST}"
+  mvn_args+="-pl ${ALLUXIO_MVN_PROJECT_LIST}"
 fi
 
 export MAVEN_OPTS="-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"
@@ -38,7 +38,7 @@ PATH_BACKUP=${PATH}
 JAVA_HOME=/usr/local/openjdk-8
 PATH=$JAVA_HOME/bin:$PATH
 mvn -Duser.home=/home/jenkins -T 4C clean install -Dfindbugs.skip -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip \
--Dlicense.skip -Dsort.skip ${mvn_args}
+-Dlicense.skip -Dsort.skip -am ${mvn_args}
 
 # Set things up so that the current user has a real name and can authenticate.
 myuid=$(id -u)


### PR DESCRIPTION
a previous PR https://github.com/Alluxio/alluxio/pull/18313 restored the integration tests but caused the unit tests to also run with the integration tests.

the issue was correctly identified as an issue with the maven project list but the underlying problem was that the project name was not correctly set; `dora/tests` is not a module. it was previously a module until `dora/tests/testcontainers` was introduced, thus separating testcontainer tests vs integration tests.

this fix updates the previous project list with the correct module name