### PR TITLE
Use generic Exception to catch all exceptions in getStatus()

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -167,8 +167,8 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
         throw ex;
       }
       UFS_FALLBACK_COUNTER.inc();
-      LOG.error("Dora client get status error ({} times). Fall back to UFS.",
-          UFS_FALLBACK_COUNTER.getCount(), ex);
+      LOG.error("Dora client get status of '{}' error ({} times). Fall back to UFS.",
+          ufsFullPath, UFS_FALLBACK_COUNTER.getCount(), ex);
       return mDelegatedFileSystem.getStatus(ufsFullPath, options).setFromUFSFallBack();
     }
   }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -17,7 +17,6 @@ import alluxio.RpcUtils;
 import alluxio.annotation.SuppressFBWarnings;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.exception.AccessControlException;
 import alluxio.exception.runtime.AlluxioRuntimeException;
 import alluxio.exception.runtime.NotFoundRuntimeException;
 import alluxio.grpc.BlockWorkerGrpc;
@@ -68,7 +67,6 @@ import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/dora/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -203,7 +203,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
               .build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } catch (IOException | AccessControlException e) {
+    } catch (Exception e) {
       LOG.debug(String.format("Failed to get status of %s: ", request.getPath()), e);
       responseObserver.onError(AlluxioRuntimeException.from(e).toGrpcStatusRuntimeException());
     }


### PR DESCRIPTION
Also print file path in getStatus() exception on client side

### What changes are proposed in this pull request?

Use generic Exception to catch all exceptions in getStatus(), just like that in all other handlers.
File path will be included in log message for getStatus().

### Why are the changes needed?

Sometimes, exceptions are thrown in under file system and/or other third-party libraries.
We don't know the exact type of the specific exceptions. If they are not caught, client will
report unknown exceptions in logs. This is misleading. 

### Does this PR introduce any user facing changes?

Client will show logs with detailed exception information if there is any.
For getStatus(), file path will also be shown in log.
