### PR TITLE
Remove malformed empty page files on access

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -11,6 +11,7 @@
 
 package alluxio.client.file.cache;
 
+import alluxio.Constants;
 import alluxio.client.file.cache.store.LocalPageStore;
 import alluxio.client.file.cache.store.MemoryPageStore;
 import alluxio.client.file.cache.store.PageStoreOptions;
@@ -20,6 +21,7 @@ import alluxio.file.ReadTargetBuffer;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.network.protocol.databuffer.DataFileChannel;
+import alluxio.util.logging.SamplingLogger;
 
 import com.codahale.metrics.Counter;
 import org.slf4j.Logger;
@@ -34,6 +36,7 @@ import java.nio.ByteBuffer;
  */
 public interface PageStore extends AutoCloseable {
   Logger LOG = LoggerFactory.getLogger(PageStore.class);
+  Logger SAMPLING_LOG = new SamplingLogger(LOG, Constants.SECOND_MS * 10);
 
   /**
    * Create an instance of PageStore.

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -121,6 +121,7 @@ public class LocalPageStore implements PageStore {
         bytesLeft -= bytes;
       }
       if (bytesRead == 0) {
+        SAMPLING_LOG.warn("Read 0 bytes from page {}, the page is probably empty", pageId);
         // no bytes have been read at all, but the requested length > 0
         // this means the file is empty
         return -1;
@@ -226,6 +227,7 @@ public class LocalPageStore implements PageStore {
     if (fileLength == 0 && pageId.getPageIndex() > 0) {
       // pages other than the first page should always be non-empty
       // remove this malformed page
+      SAMPLING_LOG.warn("Length of page {} is 0, removing this malformed page", pageId);
       try {
         Files.deleteIfExists(pagePath);
       } catch (IOException ignored) {

--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -95,6 +95,10 @@ public class LocalPageStore implements PageStore {
   public int get(PageId pageId, int pageOffset, int bytesToRead, ReadTargetBuffer target,
       boolean isTemporary) throws IOException, PageNotFoundException {
     Preconditions.checkArgument(pageOffset >= 0, "page offset should be non-negative");
+    Preconditions.checkArgument(bytesToRead >= 0, "bytes to read should be non-negative");
+    if (target.remaining() == 0 || bytesToRead == 0) {
+      return 0;
+    }
     Path pagePath = getPagePath(pageId, isTemporary);
     try (RandomAccessFile localFile = new RandomAccessFile(pagePath.toString(), "r")) {
       int bytesSkipped = localFile.skipBytes(pageOffset);
@@ -115,6 +119,11 @@ public class LocalPageStore implements PageStore {
         }
         bytesRead += bytes;
         bytesLeft -= bytes;
+      }
+      if (bytesRead == 0) {
+        // no bytes have been read at all, but the requested length > 0
+        // this means the file is empty
+        return -1;
       }
       return bytesRead;
     } catch (FileNotFoundException e) {
@@ -205,6 +214,8 @@ public class LocalPageStore implements PageStore {
       throws PageNotFoundException {
     Preconditions.checkArgument(pageOffset >= 0,
         "page offset should be non-negative");
+    Preconditions.checkArgument(!isTemporary,
+        "cannot acquire a data file channel to a temporary page");
     Path pagePath = getPagePath(pageId, isTemporary);
     File pageFile = pagePath.toFile();
     if (!pageFile.exists()) {
@@ -212,6 +223,20 @@ public class LocalPageStore implements PageStore {
     }
 
     long fileLength = pageFile.length();
+    if (fileLength == 0 && pageId.getPageIndex() > 0) {
+      // pages other than the first page should always be non-empty
+      // remove this malformed page
+      try {
+        Files.deleteIfExists(pagePath);
+      } catch (IOException ignored) {
+        // do nothing
+      }
+      throw new PageNotFoundException(pagePath.toString());
+    }
+    if (fileLength < pageOffset) {
+      throw new IllegalArgumentException(
+          String.format("offset %s exceeds length of page %s", pageOffset, fileLength));
+    }
     if (pageOffset + bytesToRead > fileLength) {
       bytesToRead = (int) (fileLength - (long) pageOffset);
     }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
@@ -128,6 +128,8 @@ public class PagedFileReader extends BlockReader implements PositionReader {
         dataBuffer = dataFileChannel.get();
         if (dataBuffer.getLength() > 0) {
           mPos += dataBuffer.getLength();
+        } else {
+          dataBuffer = getDataBufferByCopying(channel, (int) lengthPerOp);
         }
       }
       // update bytesToTransferLeft


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove empty pages when they are accessed by the get page methods. Empty pages except for the vert first page of a file are most likely malformed and are a result of a failed put attempt.

### Why are the changes needed?

Reading empty pages causes 0 bytes to be read, and in some cases causing an infinite loop in the caller. When used with `getDataFileChannel`, it results in the channel to be created multiple times for a given empty page, because the channels are always 0 sized.

### Does this PR introduce any user facing changes?

No.
