### PR TITLE
Fix the NPE in COSUnderFileSystem

### DIFF
--- a/dora/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
+++ b/dora/underfs/cos/src/main/java/alluxio/underfs/cos/COSUnderFileSystem.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -356,8 +357,9 @@ public class COSUnderFileSystem extends ObjectUnderFileSystem {
       if (meta == null) {
         return null;
       }
+      Date lastModifiedDate = meta.getLastModified();
       return new ObjectStatus(key, meta.getETag(), meta.getContentLength(),
-          meta.getLastModified().getTime());
+          lastModifiedDate != null ? lastModifiedDate.getTime() : null);
     } catch (CosClientException e) {
       return null;
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?

meta.getLastModified() could be null, and should avoid the NPE. the parameter is nullable, so give it a null in this case.

### Why are the changes needed?

meta.getLastModified() could be null, and should avoid the NPE. the parameter is nullable, so give it a null in this case.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
