### PR TITLE
Fix stress worker bench remote only policy not working

### DIFF
--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -204,6 +204,8 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
         if (mBaseParameters.mClusterLimit == 1) {
           throw new IllegalArgumentException("Cluster size is 1. REMOTE_ONLY mode not supported.");
         }
+        hdfsConf.set(PropertyKey.Name.USER_WORKER_SELECTION_POLICY,
+            "alluxio.client.file.dora.RemoteOnlyPolicy");
         break;
       default:
         throw new IllegalArgumentException("Unrecognized mode" + mParameters.mMode);


### PR DESCRIPTION
PR #18377 removes setting property `alluxio.user.worker.selection.policy` by mistake.

This will cause remote only policy not working.

This PR fixes this problem.