### PR TITLE
Replace the FOLDER_SUFFIX from "_$folder$" to "/" in OSS UFS

### DIFF
--- a/dora/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/dora/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -76,7 +76,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(OSSUnderFileSystem.class);
 
   /** Suffix for an empty file to flag it as a directory. */
-  private static final String FOLDER_SUFFIX = "_$folder$";
+  private static final String FOLDER_SUFFIX = "/";
 
   private static final String NO_SUCH_KEY = "NoSuchKey";
 

--- a/dora/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
+++ b/dora/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
@@ -215,7 +215,7 @@ public class OSSUnderFileSystemTest {
    */
   @Test
   public void testGetFolderSuffix() {
-    Assert.assertEquals("_$folder$", mOSSUnderFileSystem.getFolderSuffix());
+    Assert.assertEquals("/", mOSSUnderFileSystem.getFolderSuffix());
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?
Replace the FOLDER_SUFFIX from "_$folder$" to "/" in OSS UFS

### Why are the changes needed?
We don't want to use '_$ Folder $" to represent the directory. We want to use a more general "/" instead to avoid some issues


### Does this PR introduce any user facing changes?
No
