### PR TITLE
Fix standby master don't remove syncPoint correctly issue

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2440,7 +2440,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       }
 
       if (mSyncManager.isSyncPoint(inodePath.getUri())) {
-        mSyncManager.stopSyncAndJournal(RpcContext.NOOP, inodePath.getUri());
+        mSyncManager.stopSyncAndJournal(rpcContext, inodePath.getUri());
       }
 
       // Delete Inodes from children to parents
@@ -3719,7 +3719,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       throw new InvalidPathException("Failed to unmount " + inodePath.getUri() + ". Please ensure"
           + " the path is an existing mount point.");
     }
-    mSyncManager.stopSyncForMount(mountInfo.getMountId());
+    mSyncManager.stopSyncForMount(rpcContext, mountInfo.getMountId());
 
     if (!mMountTable.delete(rpcContext, inodePath.getUri(), true)) {
       throw new InvalidPathException("Failed to unmount " + inodePath.getUri() + ". Please ensure"

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -349,14 +349,15 @@ public class ActiveSyncManager implements Journaled {
   /**
    * Stop active sync on a mount id.
    *
+   * @param rpcContext rpc context
    * @param mountId mountId to stop active sync
    */
-  public void stopSyncForMount(long mountId) throws InvalidPathException {
+  public void stopSyncForMount(RpcContext rpcContext, long mountId) throws InvalidPathException {
     LOG.info("Stop sync for mount id {}", mountId);
     if (mFilterMap.containsKey(mountId)) {
       List<AlluxioURI> toBeDeleted = new ArrayList<>(mFilterMap.get(mountId));
       for (AlluxioURI uri : toBeDeleted) {
-        stopSyncAndJournal(RpcContext.NOOP, uri);
+        stopSyncAndJournal(rpcContext, uri);
       }
     }
   }
@@ -761,8 +762,9 @@ public class ActiveSyncManager implements Journaled {
     for (long mountId : new HashSet<>(mFilterMap.keySet())) {
       try {
         // stops sync point under this mount point. Note this clears the sync point and
-        // stops associated polling threads.
-        stopSyncForMount(mountId);
+        // stops associated polling threads. call this when DefaultFileSystemMaster init
+        // and don't need RpcContext
+        stopSyncForMount(RpcContext.NOOP, mountId);
       } catch (InvalidPathException e) {
         LOG.info("Exception resetting mountId {}, exception: {}", mountId, e);
       }


### PR DESCRIPTION
### What changes are proposed in this pull request?

When unmounting the mount point, make the deletion of syncPoint be applied to the standby master through journal.

### Why are the changes needed?
If use `NOOP` journal, standby master will not remove the syncPoint, then if the standby become leader, if will crash and throw exception

```
2023-11-07 20:48:30,700 ERROR [main](ProcessUtils.java:76) - Uncaught exception while running Alluxio master @xx.xxx.xxx.xxx:xxxx, stopping it and exiting. Exception "java.lang.UnsupportedOperationException: Active Sync is not supported on this UFS type: local", Root Cause "java.lang.UnsupportedOperationException: Active Sync is not supported on this UFS type: local"
java.lang.UnsupportedOperationException: Active Sync is not supported on this UFS type: local
	at alluxio.master.file.activesync.ActiveSyncManager.start(ActiveSyncManager.java:209)
	at alluxio.master.file.DefaultFileSystemMaster.start(DefaultFileSystemMaster.java:826)
	at alluxio.master.file.TxFileSystemMaster.start(TxFileSystemMaster.java:285)
	at alluxio.master.file.TxFileSystemMaster.start(TxFileSystemMaster.java:167)
	at alluxio.Registry.start(Registry.java:129)
	at alluxio.master.AlluxioMasterProcess.startMasterComponents(AlluxioMasterProcess.java:453)
	at alluxio.master.AlluxioMasterProcess.promote(AlluxioMasterProcess.java:362)
	at alluxio.master.AlluxioMasterProcess.start(AlluxioMasterProcess.java:278)
	at alluxio.ProcessUtils.run(ProcessUtils.java:69)
	at alluxio.master.AlluxioMaster.main(AlluxioMaster.java:55)
```

### Does this PR introduce any user facing changes?
No
