### PR TITLE
Avoid get block info when positioned read for first retry

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -131,8 +131,8 @@ public class AlluxioFileInStream extends FileInStream {
               .withMaxSleep(blockReadRetrySleepMax)
               .withSkipInitialSleep().build();
       mStatus = status;
-      mStatusOutdatedTime = System.currentTimeMillis() +
-          conf.getMs(PropertyKey.USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME);
+      mStatusOutdatedTime = System.currentTimeMillis()
+          + conf.getMs(PropertyKey.USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME);
       mOptions = options;
       mBlockStore = BlockStoreClient.create(mContext);
       mLength = mStatus.getLength();

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -423,7 +423,8 @@ public class AlluxioFileInStream extends FileInStream {
     mBlockInStream.seek(offset);
   }
 
-  private boolean isStatusOutdated() {
+  @VisibleForTesting
+  public boolean isStatusOutdated() {
     return System.currentTimeMillis() > mStatusOutdatedTime;
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -302,11 +302,15 @@ public class AlluxioFileInStream extends FileInStream {
       try {
         // Positioned read may be called multiple times for the same block. Caching the in-stream
         // allows us to avoid the block store rpc to open a new stream for each call.
+        BlockInfo blockInfo = lastException == null
+            ? mStatus.getBlockInfo(blockId) : mBlockStore.getInfo(blockId);
         if (mCachedPositionedReadStream == null) {
-          mCachedPositionedReadStream = mBlockStore.getInStream(blockId, mOptions, mFailedWorkers);
+          mCachedPositionedReadStream = mBlockStore.getInStream(
+              blockInfo, mOptions, mFailedWorkers);
         } else if (mCachedPositionedReadStream.getId() != blockId) {
           closeBlockInStream(mCachedPositionedReadStream);
-          mCachedPositionedReadStream = mBlockStore.getInStream(blockId, mOptions, mFailedWorkers);
+          mCachedPositionedReadStream = mBlockStore.getInStream(
+              blockInfo, mOptions, mFailedWorkers);
         }
         long offset = pos % mBlockSize;
         int bytesRead = mCachedPositionedReadStream.positionedRead(offset, b, off,

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -428,7 +428,7 @@ public class AlluxioFileInStream extends FileInStream {
    */
   @VisibleForTesting
   public boolean isStatusOutdated() {
-    return System.currentTimeMillis() > mStatusOutdatedTime;
+    return System.currentTimeMillis() >= mStatusOutdatedTime;
   }
 
   private void closeBlockInStream(BlockInStream stream) throws IOException {

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -82,6 +82,7 @@ public class AlluxioFileInStream extends FileInStream {
   private final BlockStoreClient mBlockStore;
   private final FileSystemContext mContext;
   private final boolean mPassiveCachingEnabled;
+  private final long mStatusOutdatedTime;
 
   /* Convenience values derived from mStatus, use these instead of querying mStatus. */
   /** Length of the file in bytes. */
@@ -130,6 +131,8 @@ public class AlluxioFileInStream extends FileInStream {
               .withMaxSleep(blockReadRetrySleepMax)
               .withSkipInitialSleep().build();
       mStatus = status;
+      mStatusOutdatedTime = System.currentTimeMillis() +
+          conf.getMs(PropertyKey.USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME);
       mOptions = options;
       mBlockStore = BlockStoreClient.create(mContext);
       mLength = mStatus.getLength();
@@ -302,8 +305,8 @@ public class AlluxioFileInStream extends FileInStream {
       try {
         // Positioned read may be called multiple times for the same block. Caching the in-stream
         // allows us to avoid the block store rpc to open a new stream for each call.
-        BlockInfo blockInfo = lastException == null
-            ? mStatus.getBlockInfo(blockId) : mBlockStore.getInfo(blockId);
+        BlockInfo blockInfo = isStatusOutdated() || lastException != null
+            ? mBlockStore.getInfo(blockId) : mStatus.getBlockInfo(blockId);
         if (mCachedPositionedReadStream == null) {
           mCachedPositionedReadStream = mBlockStore.getInStream(
               blockInfo, mOptions, mFailedWorkers);
@@ -410,7 +413,7 @@ public class AlluxioFileInStream extends FileInStream {
         }
       }
     }
-    if (isBlockInfoOutdated) {
+    if (isBlockInfoOutdated || isStatusOutdated()) {
       mBlockInStream = mBlockStore.getInStream(blockId, mOptions, mFailedWorkers);
     } else {
       mBlockInStream = mBlockStore.getInStream(blockInfo, mOptions, mFailedWorkers);
@@ -418,6 +421,10 @@ public class AlluxioFileInStream extends FileInStream {
     // Set the stream to the correct position.
     long offset = mPosition % mBlockSize;
     mBlockInStream.seek(offset);
+  }
+
+  private boolean isStatusOutdated() {
+    return System.currentTimeMillis() > mStatusOutdatedTime;
   }
 
   private void closeBlockInStream(BlockInStream stream) throws IOException {

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -423,6 +423,9 @@ public class AlluxioFileInStream extends FileInStream {
     mBlockInStream.seek(offset);
   }
 
+  /**
+   * @return true if the status is outdated
+   */
   @VisibleForTesting
   public boolean isStatusOutdated() {
     return System.currentTimeMillis() > mStatusOutdatedTime;

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -968,7 +968,7 @@ public final class AlluxioFileInStreamTest {
         new InStreamOptions(mStatus, options, mConf, mContext), mContext)) {
       Assert.assertFalse(testStream.isStatusOutdated());
     }
-
+    mConf.set(PropertyKey.USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME, 0L);
     try (AlluxioFileInStream testStream = new AlluxioFileInStream(mStatus,
         new InStreamOptions(mStatus, options, mConf, mContext), mContext)) {
       Assert.assertTrue(testStream.isStatusOutdated());

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -961,16 +961,18 @@ public final class AlluxioFileInStreamTest {
   }
 
   @Test
-  public void testStatusOutdated() throws IOException {
+  public void testStatusOutdated() throws IOException, InterruptedException {
     OpenFilePOptions options =
         OpenFilePOptions.newBuilder().setReadType(ReadPType.CACHE_PROMOTE).build();
     try (AlluxioFileInStream testStream = new AlluxioFileInStream(mStatus,
         new InStreamOptions(mStatus, options, mConf, mContext), mContext)) {
+      Thread.sleep(1);
       Assert.assertFalse(testStream.isStatusOutdated());
     }
     mConf.set(PropertyKey.USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME, 0L);
     try (AlluxioFileInStream testStream = new AlluxioFileInStream(mStatus,
         new InStreamOptions(mStatus, options, mConf, mContext), mContext)) {
+      Thread.sleep(1);
       Assert.assertTrue(testStream.isStatusOutdated());
     }
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -964,12 +964,14 @@ public final class AlluxioFileInStreamTest {
   public void testStatusOutdated() throws IOException {
     OpenFilePOptions options =
         OpenFilePOptions.newBuilder().setReadType(ReadPType.CACHE_PROMOTE).build();
-    mTestStream = new AlluxioFileInStream(mStatus, new InStreamOptions(mStatus, options, mConf,
-        mContext), mContext);
-    Assert.assertFalse(mTestStream.isStatusOutdated());
-    mConf.set(PropertyKey.USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME, 0L);
-    mTestStream = new AlluxioFileInStream(mStatus, new InStreamOptions(mStatus, options, mConf,
-        mContext), mContext);
-    Assert.assertTrue(mTestStream.isStatusOutdated());
+    try (AlluxioFileInStream testStream = new AlluxioFileInStream(mStatus,
+        new InStreamOptions(mStatus, options, mConf, mContext), mContext)) {
+      Assert.assertFalse(testStream.isStatusOutdated());
+    }
+
+    try (AlluxioFileInStream testStream = new AlluxioFileInStream(mStatus,
+        new InStreamOptions(mStatus, options, mConf, mContext), mContext)) {
+      Assert.assertTrue(testStream.isStatusOutdated());
+    }
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -53,6 +53,7 @@ import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -957,5 +958,18 @@ public final class AlluxioFileInStreamTest {
   // block is sent to the netty channel
   private void validatePartialCaching(int index, int readSize) {
     assertEquals(readSize, mInStreams.get(index).getBytesRead());
+  }
+
+  @Test
+  public void testStatusOutdated() throws IOException {
+    OpenFilePOptions options =
+        OpenFilePOptions.newBuilder().setReadType(ReadPType.CACHE_PROMOTE).build();
+    mTestStream = new AlluxioFileInStream(mStatus, new InStreamOptions(mStatus, options, mConf,
+        mContext), mContext);
+    Assert.assertFalse(mTestStream.isStatusOutdated());
+    mConf.set(PropertyKey.USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME, 0L);
+    mTestStream = new AlluxioFileInStream(mStatus, new InStreamOptions(mStatus, options, mConf,
+        mContext), mContext);
+    Assert.assertTrue(mTestStream.isStatusOutdated());
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -766,8 +766,15 @@ public final class AlluxioFileInStreamTest {
     when(mBlockStore
         .getInStream(eq(0L), any(InStreamOptions.class), any()))
         .thenReturn(brokenStream).thenReturn(workingStream);
+    when(mBlockStore
+        .getInStream(eq(new BlockInfo().setBlockId(0)), any(InStreamOptions.class), any()))
+        .thenReturn(brokenStream).thenReturn(workingStream);
     when(brokenStream.positionedRead(anyLong(), any(byte[].class), anyInt(), anyInt()))
         .thenThrow(new UnavailableException("test exception"));
+    when(mBlockStore.getInfo(anyLong())).thenAnswer(invocation -> {
+      long blockId = invocation.getArgument(0);
+      return mStatus.getBlockInfo(blockId);
+    });
 
     byte[] b = new byte[(int) BLOCK_LENGTH * 2];
     mTestStream.positionedRead(BLOCK_LENGTH / 2, b, 0, b.length);

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6307,6 +6307,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME =
+      durationBuilder(Name.USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME)
+          .setDefaultValue("5min")
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_FILE_WRITE_INIT_SLEEP_MIN =
       durationBuilder(Name.USER_FILE_WRITE_INIT_SLEEP_MIN)
           .setDefaultValue("1sec")
@@ -8965,6 +8970,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.file.write.tier.default";
     public static final String USER_FILE_INCLUDE_OPERATION_ID =
         "alluxio.user.file.include.operation.id";
+    public static final String USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME =
+        "alluxio.user.file.in.stream.expiration.time";
     public static final String USER_FILE_WRITE_INIT_SLEEP_MIN =
         "alluxio.user.file.write.init.sleep.min";
     public static final String USER_FILE_WRITE_INIT_SLEEP_MAX =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -8971,7 +8971,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_FILE_INCLUDE_OPERATION_ID =
         "alluxio.user.file.include.operation.id";
     public static final String USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME =
-        "alluxio.user.file.in.stream.expiration.time";
+        "alluxio.user.file.in.stream.status.expiration.time";
     public static final String USER_FILE_WRITE_INIT_SLEEP_MIN =
         "alluxio.user.file.write.init.sleep.min";
     public static final String USER_FILE_WRITE_INIT_SLEEP_MAX =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6310,6 +6310,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME =
       durationBuilder(Name.USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME)
           .setDefaultValue("5min")
+          .setDescription("Specifies how long the file metadata can be cached and reused during the "
+              + "FileInStream. Once the specified expiration time has elapsed, the file metadata "
+              + "will be reloaded from the Alluxio master. The cache reduces the number of "
+              + "metadata requests to the Master. The default is 5 minutes.")
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_FILE_WRITE_INIT_SLEEP_MIN =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6310,10 +6310,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME =
       durationBuilder(Name.USER_FILE_IN_STREAM_STATUS_EXPIRATION_TIME)
           .setDefaultValue("5min")
-          .setDescription("Specifies how long the file metadata can be cached and reused during the "
-              + "FileInStream. Once the specified expiration time has elapsed, the file metadata "
-              + "will be reloaded from the Alluxio master. The cache reduces the number of "
-              + "metadata requests to the Master. The default is 5 minutes.")
+          .setDescription("Specifies how long the file metadata can be cached and reused during "
+              + "the FileInStream. Once the specified expiration time has elapsed, the file "
+              + "metadata will be reloaded from the Alluxio master. The cache reduces the number "
+              + "of metadata requests to the Master. The default is 5 minutes.")
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_FILE_WRITE_INIT_SLEEP_MIN =


### PR DESCRIPTION
### What changes are proposed in this pull request?

Reduce talk to master to improve the performance for small file scenario.

I guess this is introduced by  https://github.com/Alluxio/alluxio/commit/ed53d541d16ef1212936d8226b1df64c4478a707

### Why are the changes needed?

The block info can be get from file status, so we should not ask it from master every time.

### Does this PR introduce any user facing changes?

No
