### PR TITLE
Fix the bug that HdfsUfsStatusIterator returns wrong path

### DIFF
--- a/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUfsStatusIterator.java
+++ b/dora/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUfsStatusIterator.java
@@ -97,21 +97,24 @@ public class HdfsUfsStatusIterator implements Iterator<UfsStatus> {
       FileStatus fileStatus = mHdfsRemoteIterator.next();
       UfsStatus ufsStatus;
       Path path = fileStatus.getPath();
+
       AlluxioURI alluxioUri = new AlluxioURI(path.toString());
+      AlluxioURI rootUri = new AlluxioURI(alluxioUri.getRootPath());
       if (fileStatus.isDirectory()) {
-        ufsStatus = new UfsDirectoryStatus(path.getName(), fileStatus.getOwner(),
+        ufsStatus = new UfsDirectoryStatus(path.toUri().getPath(), fileStatus.getOwner(),
             fileStatus.getGroup(), fileStatus.getPermission().toShort(),
             fileStatus.getModificationTime());
+        ufsStatus.setUfsFullPath(rootUri.join(ufsStatus.getName()));
         mDirPathsToProcess.addLast(new Pair<>(path.toString(), ufsStatus));
       } else {
         String contentHash =
             UnderFileSystemUtils.approximateContentHash(
                 fileStatus.getLen(), fileStatus.getModificationTime());
-        ufsStatus = new UfsFileStatus(path.getName(), contentHash, fileStatus.getLen(),
+        ufsStatus = new UfsFileStatus(path.toUri().getPath(), contentHash, fileStatus.getLen(),
             fileStatus.getModificationTime(), fileStatus.getOwner(), fileStatus.getGroup(),
             fileStatus.getPermission().toShort(), fileStatus.getBlockSize());
+        ufsStatus.setUfsFullPath(rootUri.join(ufsStatus.getName()));
       }
-      ufsStatus.setUfsFullPath(alluxioUri);
       return ufsStatus;
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/dora/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/hdfs3/HdfsUnderFileSystemIntegrationTest.java
+++ b/dora/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/hdfs3/HdfsUnderFileSystemIntegrationTest.java
@@ -131,13 +131,13 @@ public class HdfsUnderFileSystemIntegrationTest extends HdfsUnderFileSystemInteg
       listResult.add(ufsStatus);
     }
     assertEquals(8, listResult.size());
-    assertEquals("testDirectory1", listResult.get(0).getName());
-    assertEquals("testDirectory2", listResult.get(1).getName());
-    assertEquals("testFileA", listResult.get(2).getName());
-    assertEquals("testFileC", listResult.get(3).getName());
-    assertEquals("testFileB", listResult.get(4).getName());
-    assertEquals("testDirectory3", listResult.get(5).getName());
-    assertEquals("testFileD", listResult.get(6).getName());
-    assertEquals("testFileE", listResult.get(7).getName());
+    assertEquals("/testRoot/testDirectory1", listResult.get(0).getName());
+    assertEquals("/testRoot/testDirectory2", listResult.get(1).getName());
+    assertEquals("/testRoot/testFileA", listResult.get(2).getName());
+    assertEquals("/testRoot/testFileC", listResult.get(3).getName());
+    assertEquals("/testRoot/testDirectory1/testFileB", listResult.get(4).getName());
+    assertEquals("/testRoot/testDirectory2/testDirectory3", listResult.get(5).getName());
+    assertEquals("/testRoot/testDirectory2/testFileD", listResult.get(6).getName());
+    assertEquals("/testRoot/testDirectory2/testDirectory3/testFileE", listResult.get(7).getName());
   }
 }


### PR DESCRIPTION
Fix the bug that `HdfsUfsStatusIterator` returns wrong path (the getName() method of `UfsStatus` should return a relative path, but not just the file name).