### PR TITLE
[Security] Fix log4j 1.x CVE-2019-17571 critical vulnerability

### DIFF
--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -133,6 +133,11 @@
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <version>2.0.56.Final</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-reload4j</artifactId>
+      <version>1.7.34</version>
+    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>

--- a/core/common/src/main/java/alluxio/util/LogUtils.java
+++ b/core/common/src/main/java/alluxio/util/LogUtils.java
@@ -21,7 +21,7 @@ import org.apache.commons.logging.impl.Log4JLogger;
 import org.apache.log4j.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.impl.Log4jLoggerAdapter;
+import org.slf4j.impl.Reload4jLoggerAdapter;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -57,9 +57,9 @@ public final class LogUtils {
         process(((Log4JLogger) log).getLogger(), level, result);
       } else if (log instanceof Jdk14Logger) {
         process(((Jdk14Logger) log).getLogger(), level, result);
-      } else if (logger instanceof Log4jLoggerAdapter) {
+      } else if (logger instanceof Reload4jLoggerAdapter) {
         try {
-          Field field = Log4jLoggerAdapter.class.getDeclaredField("logger");
+          Field field = Reload4jLoggerAdapter.class.getDeclaredField("logger");
           field.setAccessible(true);
           org.apache.log4j.Logger log4jLogger = (org.apache.log4j.Logger) field.get(logger);
           process(log4jLogger, level, result);

--- a/core/server/master/src/test/java/alluxio/master/metastore/InodeStoreBench.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/InodeStoreBench.java
@@ -53,7 +53,9 @@ public class InodeStoreBench {
   public static void main(String[] args) throws Exception {
     // Enable logging to stdout.
     Layout layout = new PatternLayout("%d [%t] %-5p %c %x - %m%n");
-    Logger.getRootLogger().addAppender(new ConsoleAppender(layout));
+    ConsoleAppender consoleAppender = new ConsoleAppender();
+    consoleAppender.setLayout(layout);
+    Logger.getRootLogger().addAppender(consoleAppender);
 
     System.out.printf("Running benchmarks for rocks inode store%n");
     sStore = new RocksInodeStore(Configuration.getString(PropertyKey.MASTER_METASTORE_DIR));

--- a/integration/tools/hms/pom.xml
+++ b/integration/tools/hms/pom.xml
@@ -65,6 +65,10 @@
           <artifactId>log4j</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-1.2-api</artifactId>
         </exclusion>

--- a/logserver/pom.xml
+++ b/logserver/pom.xml
@@ -64,12 +64,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -601,6 +601,16 @@
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
         <version>3.5.5</version>
+        <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/table/server/underdb/glue/pom.xml
+++ b/table/server/underdb/glue/pom.xml
@@ -70,6 +70,14 @@
                   <artifactId>log4j-slf4j-impl</artifactId>
               </exclusion>
               <exclusion>
+                  <groupId>log4j</groupId>
+                  <artifactId>log4j</artifactId>
+              </exclusion>
+              <exclusion>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-log4j12</artifactId>
+              </exclusion>
+              <exclusion>
                   <groupId>com.google.protobuf</groupId>
                   <artifactId>protobuf-java</artifactId>
               </exclusion>

--- a/table/server/underdb/hive/pom.xml
+++ b/table/server/underdb/hive/pom.xml
@@ -52,6 +52,14 @@
           <artifactId>log4j-slf4j-impl</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>

--- a/underfs/cephfs-hadoop/pom.xml
+++ b/underfs/cephfs-hadoop/pom.xml
@@ -32,6 +32,16 @@
     <dependency>
       <groupId>io.github.opendataio</groupId>
       <artifactId>cephfs-hadoop</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Internal dependencies -->
     <dependency>


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR fixes `log4j 1.x` [CVE-2019-17571](https://nvd.nist.gov/vuln/detail/CVE-2019-17571) critical vulnerability, by excluding all the `log4j 1.x` dependencies and replacing them with [reload4j](https://reload4j.qos.ch).

### Why are the changes needed?

Fixing the `log4j 1.x CVE-2019-17571` critical vulnerability is imperative due to its potential for remote code execution, posing a significant security breach risk. Addressing this vulnerability is essential for maintaining compliance and adhering to best security practices.

### Does this PR introduce any user facing changes?

Being a `“binary compatible, drop-in replacement for log4j version 1.2.17”`, the `reload4j` library used in this fix should not introduce any user-facing changes.

### Rationale behind the strategy of this implementation

Migrating to `log4j 2.x`, or using the `adapter technique`, would have implied more implementation effort and considerable user-facing changes, since `log4j.properties` / `log4j.xml` should have been converted to `log4j2.xml` format. With `reload4j`, which is a drop-in replacement for `log4j 1.x`, you get both security and configuration compatibility with `log4j 1.x` format.
In case you’re not sure about `reload4j`’s adoption rate in general, take a look at the following:

- `org.apache.hadoop:hadoop-common` is a widely-used transitive dependency that needs `reload4j`
- `org.slf4j:slf4j-log4j12` starting from version [1.7.34](https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12/1.7.34), it was moved to [org.slf4j:slf4j-reload4j](https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j/1.7.34)