### PR TITLE
Fix consistent hash policy returns stale worker addresses

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashProvider.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/dora/ConsistentHashProvider.java
@@ -16,7 +16,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
+import alluxio.collections.Pair;
 import alluxio.wire.WorkerIdentity;
+import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -191,10 +193,13 @@ public class ConsistentHashProvider {
     if (workerInfoList == anotherWorkerInfoList) {
       return false;
     }
-    Set<WorkerIdentity> workerAddressSet = workerInfoList.stream()
-        .map(BlockWorkerInfo::getIdentity).collect(Collectors.toSet());
-    Set<WorkerIdentity> anotherWorkerAddressSet = anotherWorkerInfoList.stream()
-        .map(BlockWorkerInfo::getIdentity).collect(Collectors.toSet());
+    Set<Pair<WorkerIdentity, WorkerNetAddress>> workerAddressSet = workerInfoList.stream()
+        .map(info -> new Pair<>(info.getIdentity(), info.getNetAddress()))
+        .collect(Collectors.toSet());
+    Set<Pair<WorkerIdentity, WorkerNetAddress>> anotherWorkerAddressSet =
+        anotherWorkerInfoList.stream()
+            .map(info -> new Pair<>(info.getIdentity(), info.getNetAddress()))
+            .collect(Collectors.toSet());
     return !workerAddressSet.equals(anotherWorkerAddressSet);
   }
 

--- a/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraLsCommandIntegrationTest.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraLsCommandIntegrationTest.java
@@ -185,14 +185,14 @@ public class DoraLsCommandIntegrationTest extends AbstractDoraFileSystemShellTes
   }
 
   @Test
-  public void testLsWithSortByLastModifiedTime() throws IOException, AlluxioException {
+  public void testLsWithSortByLastModificationTime() throws IOException, AlluxioException {
     String oldFile = "/testRoot/oldFile";
     String newFile = "/testRoot/newFile";
     createByteFileInAlluxio(oldFile, BufferUtils.getIncreasingByteArray(Constants.MB),
         WritePType.CACHE_THROUGH);
     createByteFileInAlluxio(newFile, BufferUtils.getIncreasingByteArray(Constants.MB),
         WritePType.CACHE_THROUGH);
-    assertEquals(0, mFsShell.run("ls", "--sort", "lastModifiedTime", "/testRoot"));
+    assertEquals(0, mFsShell.run("ls", "--sort", "lastModificationTime", "/testRoot"));
     checkOutput(
         ".*FILE " + oldFile,
         ".*FILE " + newFile

--- a/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraLsCommandIntegrationTest.java
+++ b/dora/tests/integration/src/test/java/alluxio/client/cli/fs/command/DoraLsCommandIntegrationTest.java
@@ -15,12 +15,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
+import alluxio.annotation.dora.DoraTestTodoItem;
 import alluxio.client.cli.fs.AbstractDoraFileSystemShellTest;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.WritePType;
 import alluxio.util.io.BufferUtils;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -134,6 +136,9 @@ public class DoraLsCommandIntegrationTest extends AbstractDoraFileSystemShellTes
     );
   }
 
+  @DoraTestTodoItem(owner = "Hua", action = DoraTestTodoItem.Action.FIX,
+      comment = "access time is not recorded or updated currently")
+  @Ignore
   @Test
   public void testLsWithSortByAccessTime() throws IOException, AlluxioException {
     String oldFile = "/testRoot/oldFile";
@@ -180,14 +185,14 @@ public class DoraLsCommandIntegrationTest extends AbstractDoraFileSystemShellTes
   }
 
   @Test
-  public void testLsWithSortByCreationTime() throws IOException, AlluxioException {
+  public void testLsWithSortByLastModifiedTime() throws IOException, AlluxioException {
     String oldFile = "/testRoot/oldFile";
     String newFile = "/testRoot/newFile";
     createByteFileInAlluxio(oldFile, BufferUtils.getIncreasingByteArray(Constants.MB),
         WritePType.CACHE_THROUGH);
     createByteFileInAlluxio(newFile, BufferUtils.getIncreasingByteArray(Constants.MB),
         WritePType.CACHE_THROUGH);
-    assertEquals(0, mFsShell.run("ls", "--sort", "creationTime", "/testRoot"));
+    assertEquals(0, mFsShell.run("ls", "--sort", "lastModifiedTime", "/testRoot"));
     checkOutput(
         ".*FILE " + oldFile,
         ".*FILE " + newFile


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix consistent hash policy returns stale worker addresses

### Why are the changes needed?

Consistent hash policy only considers worker identities when building the hash ring. When a worker changes its network address but its ID stays the same, the update is ignored by the policy, so clients will try to connect with stale worker address.

### Does this PR introduce any user facing changes?

No.