### PR TITLE
Decode URI if needed when create signature

### DIFF
--- a/dora/core/server/common/src/main/java/alluxio/s3/signature/StringToSignProducer.java
+++ b/dora/core/server/common/src/main/java/alluxio/s3/signature/StringToSignProducer.java
@@ -105,7 +105,7 @@ public final class StringToSignProducer {
     return createSignatureBase(signatureInfo,
         request.getScheme(),
         request.getMethod(),
-        request.getRequestURI(),
+        URI.create(request.getRequestURI()).getPath(),
         getHeaders(request),
         getParameterMap(request));
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix #18442.

### Why are the changes needed?
Using URI. getPath() will decode the original path.



