### PR TITLE
Make alluxio client return block location count configurable

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6843,6 +6843,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_UFS_BLOCK_LOCATION_RETURN_COUNT =
+      intBuilder(Name.USER_UFS_BLOCK_LOCATION_RETURN_COUNT)
+          .setDefaultValue(-1)
+          .setDescription("The return count of workers as block location if ufs block locations "
+              + "are not co-located with any Alluxio workers or is empty. This item should be "
+              + "greater than or equal to -1 and '-1' means return all workers")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_UFS_BLOCK_READ_LOCATION_POLICY =
       classBuilder(Name.USER_UFS_BLOCK_READ_LOCATION_POLICY)
           .setDefaultValue("alluxio.client.block.policy.LocalFirstPolicy")
@@ -9082,6 +9091,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_RPC_RETRY_MAX_SLEEP_MS = "alluxio.user.rpc.retry.max.sleep";
     public static final String USER_UFS_BLOCK_LOCATION_ALL_FALLBACK_ENABLED =
         "alluxio.user.ufs.block.location.all.fallback.enabled";
+    public static final String USER_UFS_BLOCK_LOCATION_RETURN_COUNT =
+        "alluxio.user.block.location.return.count";
     public static final String USER_UFS_BLOCK_READ_LOCATION_POLICY =
         "alluxio.user.ufs.block.read.location.policy";
     public static final String USER_UFS_BLOCK_READ_LOCATION_POLICY_DETERMINISTIC_HASH_SHARDS =


### PR DESCRIPTION
### What changes are proposed in this pull request?

make alluxio client return block location count configurable

### Why are the changes needed?
When accessing alluxio in the hive + yarn + mr scenario, the metadata will be accessed and split before the job is submitted, which will generate the job.splitmetainfo file. This file should not be too large. When accessing alluxio, if the data does not exist in alluxio, all worker address information will be returned, which will expand the size of the generated job.splitmetainfo file and eventually result in an error as below. This PR makes the number of returned worker addresses configurable

`org.apache.hadoop.yarn.exceptions.YarnRuntimeException: java.io.IOException: Split metadata size exceeded 50000000. Aborting job job_1698927225178_1330717`

### Does this PR introduce any user facing changes?
No