### PR TITLE
Bump jetty from 9.4.46.v20220331 to 9.4.53.v20231009

### DIFF
--- a/docs/en/api/S3-API.md
+++ b/docs/en/api/S3-API.md
@@ -251,7 +251,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:45:17 GMT
 Content-Type: application/xml
 Content-Length: 583
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListBucketResult>
   <version2>false</version2>
@@ -282,7 +282,7 @@ $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHead
   -X DELETE "http://localhost:39999/api/v1/s3/testbucket/multipart.txt?uploadId=6367cf96-ea4e-4447-b931-c5bc91200375"
 HTTP/1.1 204 No Content
 Date: Tue, 03 May 2022 23:45:30 GMT
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHeaders=... Signature=..." \
   -X GET "http://localhost:39999/api/v1/s3/testbucket"
@@ -290,7 +290,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:45:36 GMT
 Content-Type: application/xml
 Content-Length: 318
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListBucketResult>
   <version2>false</version2>
@@ -358,7 +358,7 @@ $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHead
 Date: Tue, 03 May 2022 23:59:17 GMT
 Content-Type: text/xml;charset=utf-8
 Transfer-Encoding: chunked
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <CompleteMultipartUploadResult>
   <Location>/testbucket/multipart.txt</Location>
@@ -377,7 +377,7 @@ Last-Modified: Tue, 03 May 2022 23:59:18 GMT
 ETag: 0cc175b9c0f1b6a831c399e269772661
 Content-Type: application/octet-stream
 Content-Length: 27040
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -425,7 +425,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:50:07 GMT
 Content-Type: application/xml
 Content-Length: 135
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <CopyObjectResult>
   <ETag>911df44b7ff57801ca8d74568e4ebfbe</ETag>
@@ -438,7 +438,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:50:26 GMT
 Content-Type: application/xml
 Content-Length: 434
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListBucketResult>
   <version2>false</version2>
@@ -492,7 +492,7 @@ $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHead
 HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:35:05 GMT
 Content-Length: 0
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHeaders=... Signature=..." \
   -X GET http://localhost:39999/api/v1/s3/
@@ -500,7 +500,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:35:23 GMT
 Content-Type: application/xml
 Content-Length: 161
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListAllMyBucketsResult>
   <Buckets>
@@ -538,7 +538,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:41:26 GMT
 Content-Type: application/xml
 Content-Length: 147
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <InitiateMultipartUploadResult>
   <Bucket>testbucket</Bucket>
@@ -592,7 +592,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:43:20 GMT
 Content-Type: application/xml
 Content-Length: 254
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListAllMyBucketsResult>
   <Buckets>
@@ -611,7 +611,7 @@ $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHead
   -X DELETE http://localhost:39999/api/v1/s3/tempbucket
 HTTP/1.1 204 No Content
 Date: Tue, 03 May 2022 21:43:25 GMT
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHeaders=... Signature=..." \
   -X GET http://localhost:39999/api/v1/s3/
@@ -619,7 +619,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:43:28 GMT
 Content-Type: application/xml
 Content-Length: 161
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListAllMyBucketsResult>
   <Buckets>
@@ -673,7 +673,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:31:07 GMT
 Content-Type: application/xml
 Content-Length: 124
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <Tagging>
   <TagSet>
@@ -692,7 +692,7 @@ $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHead
   -X DELETE "http://localhost:39999/api/v1/s3/testbucket?tagging"
 HTTP/1.1 204 No Content
 Date: Tue, 03 May 2022 23:32:26 GMT
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHeaders=... Signature=..." \
   -X GET "http://localhost:39999/api/v1/s3/testbucket?tagging"
@@ -700,7 +700,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:32:27 GMT
 Content-Type: application/xml
 Content-Length: 28
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <Tagging><TagSet/></Tagging>
 ```
@@ -755,7 +755,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:59:27 GMT
 Content-Type: application/xml
 Content-Length: 540
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListBucketResult>
   <version2>false</version2>
@@ -781,7 +781,7 @@ $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHead
   -X DELETE http://localhost:39999/api/v1/s3/testbucket/temp.txt
 HTTP/1.1 204 No Content
 Date: Tue, 03 May 2022 22:01:56 GMT
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHeaders=... Signature=..." \
   -X GET http://localhost:39999/api/v1/s3/testbucket
@@ -789,7 +789,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 22:01:59 GMT
 Content-Type: application/xml
 Content-Length: 318
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListBucketResult>
   <version2>false</version2>
@@ -862,7 +862,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:59:27 GMT
 Content-Type: application/xml
 Content-Length: 540
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListBucketResult>
   <version2>false</version2>
@@ -907,7 +907,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 22:56:17 GMT
 Content-Type: application/xml
 Content-Length: 208
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <DeleteResult>
   <Deleted>
@@ -930,7 +930,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 22:28:31 GMT
 Content-Type: application/xml
 Content-Length: 317
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListBucketResult>
   <version2>false</version2>
@@ -990,7 +990,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:31:07 GMT
 Content-Type: application/xml
 Content-Length: 124
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <Tagging>
   <TagSet>
@@ -1009,7 +1009,7 @@ $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHead
   -X DELETE "http://localhost:39999/api/v1/s3/testbucket/test.txt?tagging"
 HTTP/1.1 204 No Content
 Date: Tue, 03 May 2022 23:37:46 GMT
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHeaders=... Signature=..." \
   -X GET "http://localhost:39999/api/v1/s3/testbucket/test.txt?tagging"
@@ -1017,7 +1017,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:37:47 GMT
 Content-Type: application/octet-stream
 Content-Length: 28
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <Tagging><TagSet/></Tagging>
 ```
@@ -1055,7 +1055,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:31:07 GMT
 Content-Type: application/xml
 Content-Length: 124
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <Tagging>
   <TagSet>
@@ -1107,7 +1107,7 @@ Last-Modified: Tue, 03 May 2022 21:47:36 GMT
 ETag: 0cc175b9c0f1b6a831c399e269772661
 Content-Type: application/octet-stream
 Content-Length: 27040
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 ................. file contents .................
 ```
@@ -1145,7 +1145,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:31:07 GMT
 Content-Type: application/xml
 Content-Length: 124
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <Tagging>
   <TagSet>
@@ -1182,7 +1182,7 @@ HTTP/1.1 200 OK
 Date: Tue, 15 Nov 2022 04:49:12 GMT
 Content-Type: application/xml
 Content-Length: 0
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -1215,7 +1215,7 @@ Last-Modified: Tue, 03 May 2022 21:47:36 GMT
 ETag: 0cc175b9c0f1b6a831c399e269772661
 Content-Type: application/octet-stream
 Content-Length: 27040
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -1246,7 +1246,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:35:23 GMT
 Content-Type: application/xml
 Content-Length: 161
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListAllMyBucketsResult>
   <Buckets>
@@ -1293,7 +1293,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:50:26 GMT
 Content-Type: application/xml
 Content-Length: 434
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListBucketResult>
   <version2>false</version2>
@@ -1412,7 +1412,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:56:20 GMT
 Content-Type: application/xml
 Content-Length: 438
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListBucketResult>
   <version2>true</version2>
@@ -1471,7 +1471,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:49:05 GMT
 Content-Type: application/octet-stream
 Content-Length: 314
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListPartsResult>
   <Bucket>/testbucket</Bucket>
@@ -1530,7 +1530,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:30:25 GMT
 Content-Type: application/xml
 Content-Length: 28
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <Tagging><TagSet/></Tagging>
 
@@ -1554,7 +1554,7 @@ $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHead
 HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:31:05 GMT
 Content-Length: 0
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHeaders=... Signature=..." \
   -X GET "http://localhost:39999/api/v1/s3/testbucket?tagging"
@@ -1562,7 +1562,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:31:07 GMT
 Content-Type: application/xml
 Content-Length: 124
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <Tagging>
   <TagSet>
@@ -1616,7 +1616,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:47:36 GMT
 ETag: 911df44b7ff57801ca8d74568e4ebfbe
 Content-Length: 0
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHeaders=... Signature=..." \
   -X GET http://localhost:39999/api/v1/s3/testbucket
@@ -1624,7 +1624,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 21:47:44 GMT
 Content-Type: application/xml
 Content-Length: 318
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <ListBucketResult>
   <version2>false</version2>
@@ -1684,7 +1684,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:30:25 GMT
 Content-Type: application/xml
 Content-Length: 28
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <Tagging><TagSet/></Tagging>
 
@@ -1708,7 +1708,7 @@ $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHead
 HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:35:28 GMT
 Content-Length: 0
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHeaders=... Signature=..." \
   -X GET "http://localhost:39999/api/v1/s3/testbucket/test.txt?tagging"
@@ -1716,7 +1716,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:35:58 GMT
 Content-Type: application/octet-stream
 Content-Length: 126
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 <Tagging>
   <TagSet>
@@ -1775,7 +1775,7 @@ HTTP/1.1 200 OK
 Date: Tue, 03 May 2022 23:51:19 GMT
 ETag: "911df44b7ff57801ca8d74568e4ebfbe"
 Content-Length: 0
-Server: Jetty(9.4.43.v20210629)
+Server: Jetty(9.4.53.v20231009)
 
 $ aws --profile alluxio-s3 --endpoint "http://localhost:39999/api/v1/s3/" s3api list-parts \
   --bucket=testbucket --key=multipart_copy.txt --upload-id=6367cf96-ea4e-4447-b931-c5bc91200375

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <java.version>1.8</java.version>
     <jaxb.version>2.3.3</jaxb.version>
     <jersey.version>2.34</jersey.version>
-    <jetty.version>9.4.46.v20220331</jetty.version>
+    <jetty.version>9.4.53.v20231009</jetty.version>
     <jnr-fuse.version>0.5.5</jnr-fuse.version>
     <junit.version>4.13.1</junit.version>
     <jupiter.version>5.9.2</jupiter.version>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Upgrading jetty from 9.4.46.v20220331 to 9.4.53.v20231009 fixes security issues.

### Why are the changes needed?

  1. The jetty version 9.4.46.v20220331 has disclosed a lot of CVEs, it needs to be upgraded

