### PR TITLE
Make proxy transfer buffer size configurable

### DIFF
--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5097,7 +5097,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "Set value less than or equal to 0 to disable rate limits.")
           .setDefaultValue(0)
           .setScope(Scope.SERVER)
-
+          .build();
+  public static final PropertyKey PROXY_S3_TRANSFER_BUFFER_SIZE =
+      dataSizeBuilder(Name.PROXY_S3_TRANSFER_BUFFER_SIZE)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setDescription("Buffer size used for proxy data transfer.")
+          .setDefaultValue("8KB")
+          .setScope(Scope.SERVER)
           .build();
 
   //
@@ -8225,6 +8231,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.proxy.s3.global.read.rate.limit.mb";
     public static final String PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB =
         "alluxio.proxy.s3.single.connection.read.rate.limit.mb";
+    public static final String PROXY_S3_TRANSFER_BUFFER_SIZE =
+        "alluxio.proxy.transfer.buffer.size";
 
     //
     // User related properties

--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Handler.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Handler.java
@@ -93,7 +93,8 @@ public class S3Handler {
       .build();
   private static final Logger LOG = LoggerFactory.getLogger(S3Handler.class);
   private static final ThreadLocal<byte[]> TLS_BYTES =
-          ThreadLocal.withInitial(() -> new byte[8 * 1024]);
+      ThreadLocal.withInitial(
+          () -> new byte[(int) Configuration.getBytes(PropertyKey.PROXY_S3_TRANSFER_BUFFER_SIZE)]);
   private final String mBucket;
   private final String mObject;
   private final HttpServletRequest mServletRequest;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Make the buffer size in s3 proxy configurable, which is currently 8KB and unchangeable.