### PR TITLE
Make WorkerInfo enum (and some small refactors)

### DIFF
--- a/dora/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
+++ b/dora/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
@@ -36,6 +36,7 @@ import alluxio.wire.UfsInfo;
 import alluxio.wire.WorkerIdentity;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
+import alluxio.wire.WorkerState;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
@@ -317,7 +318,8 @@ public final class GrpcUtils {
         .setCapacityBytes(workerInfo.getCapacityBytes())
         .setCapacityBytesOnTiers(workerInfo.getCapacityBytesOnTiers()).setId(workerInfo.getId())
         .setLastContactSec(workerInfo.getLastContactSec())
-        .setStartTimeMs(workerInfo.getStartTimeMs()).setState(workerInfo.getState())
+        .setStartTimeMs(workerInfo.getStartTimeMs())
+        .setState(WorkerState.of(workerInfo.getState()))
         .setUsedBytes(workerInfo.getUsedBytes())
         .setUsedBytesOnTiers(workerInfo.getUsedBytesOnTiersMap())
         .setVersion(workerInfo.getBuildVersion().getVersion())
@@ -569,7 +571,8 @@ public final class GrpcUtils {
     return alluxio.grpc.WorkerInfo.newBuilder().setId(workerInfo.getId())
         .setIdentity(workerInfo.getIdentity().toProto())
         .setAddress(toProto(workerInfo.getAddress()))
-        .setLastContactSec(workerInfo.getLastContactSec()).setState(workerInfo.getState())
+        .setLastContactSec(workerInfo.getLastContactSec())
+        .setState(workerInfo.getState().toString())
         .setCapacityBytes(workerInfo.getCapacityBytes()).setUsedBytes(workerInfo.getUsedBytes())
         .setStartTimeMs(workerInfo.getStartTimeMs())
         .putAllCapacityBytesOnTiers(workerInfo.getCapacityBytesOnTiers())

--- a/dora/core/common/src/main/java/alluxio/util/webui/NodeInfo.java
+++ b/dora/core/common/src/main/java/alluxio/util/webui/NodeInfo.java
@@ -50,7 +50,7 @@ public final class NodeInfo implements Comparable<NodeInfo> {
     }
     mWebPort = workerInfo.getAddress().getWebPort();
     mLastContactSec = Integer.toString(workerInfo.getLastContactSec());
-    mWorkerState = workerInfo.getState();
+    mWorkerState = workerInfo.getState().toString();
     mCapacityBytes = workerInfo.getCapacityBytes();
     mUsedBytes = workerInfo.getUsedBytes();
     if (mCapacityBytes != 0) {

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerInfo.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerInfo.java
@@ -33,7 +33,7 @@ public final class WorkerInfo implements Serializable {
   private WorkerIdentity mIdentity;
   private WorkerNetAddress mAddress = new WorkerNetAddress();
   private int mLastContactSec;
-  private WorkerState mState = WorkerState.LIVE;
+  private WorkerState mState = WorkerState.UNRECOGNIZED;
   private long mCapacityBytes;
   private long mUsedBytes;
   private long mStartTimeMs;

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerInfo.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerInfo.java
@@ -44,6 +44,33 @@ public final class WorkerInfo implements Serializable {
   private String mRevision = "";
 
   /**
+   * Creates a new, empty instance.
+   */
+  public WorkerInfo() {
+  }
+
+  /**
+   * Copy constructor.
+   *
+   * @param copyFrom instance to copy from
+   */
+  public WorkerInfo(WorkerInfo copyFrom) {
+    mId = copyFrom.mId;
+    mIdentity = copyFrom.mIdentity; // identity is immutable so ok to reuse
+    mAddress = new WorkerNetAddress(copyFrom.mAddress);
+    mLastContactSec = copyFrom.mLastContactSec;
+    mState = copyFrom.mState;
+    mCapacityBytes = copyFrom.mCapacityBytes;
+    mUsedBytes = copyFrom.mUsedBytes;
+    mStartTimeMs = copyFrom.mStartTimeMs;
+    mCapacityBytesOnTiers = new HashMap<>(copyFrom.mCapacityBytesOnTiers);
+    mUsedBytesOnTiers = new HashMap<>(copyFrom.mUsedBytesOnTiers);
+    mBlockCount = copyFrom.mBlockCount;
+    mVersion = copyFrom.mVersion;
+    mRevision = copyFrom.mRevision;
+  }
+
+  /**
    * @return the worker id
    */
   @ApiModelProperty(value = "Worker id, used to identify the worker internally")

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerInfo.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerInfo.java
@@ -33,7 +33,7 @@ public final class WorkerInfo implements Serializable {
   private WorkerIdentity mIdentity;
   private WorkerNetAddress mAddress = new WorkerNetAddress();
   private int mLastContactSec;
-  private String mState = "";
+  private WorkerState mState = WorkerState.LIVE;
   private long mCapacityBytes;
   private long mUsedBytes;
   private long mStartTimeMs;
@@ -83,7 +83,7 @@ public final class WorkerInfo implements Serializable {
    * @return the worker state
    */
   @ApiModelProperty(value = "Operation state of the worker", example = "In Service")
-  public String getState() {
+  public WorkerState getState() {
     return mState;
   }
 
@@ -184,7 +184,7 @@ public final class WorkerInfo implements Serializable {
    * @param state the worker state to use
    * @return the worker information
    */
-  public WorkerInfo setState(String state) {
+  public WorkerInfo setState(WorkerState state) {
     Preconditions.checkNotNull(state, "state");
     mState = state;
     return this;

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerInfo.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerInfo.java
@@ -57,14 +57,20 @@ public final class WorkerInfo implements Serializable {
   public WorkerInfo(WorkerInfo copyFrom) {
     mId = copyFrom.mId;
     mIdentity = copyFrom.mIdentity; // identity is immutable so ok to reuse
-    mAddress = new WorkerNetAddress(copyFrom.mAddress);
+    mAddress = copyFrom.mAddress != null
+        ? new WorkerNetAddress(copyFrom.mAddress)
+        : null;
     mLastContactSec = copyFrom.mLastContactSec;
     mState = copyFrom.mState;
     mCapacityBytes = copyFrom.mCapacityBytes;
     mUsedBytes = copyFrom.mUsedBytes;
     mStartTimeMs = copyFrom.mStartTimeMs;
-    mCapacityBytesOnTiers = new HashMap<>(copyFrom.mCapacityBytesOnTiers);
-    mUsedBytesOnTiers = new HashMap<>(copyFrom.mUsedBytesOnTiers);
+    mCapacityBytesOnTiers = copyFrom.mCapacityBytesOnTiers != null
+        ? new HashMap<>(copyFrom.mCapacityBytesOnTiers)
+        : null;
+    mUsedBytesOnTiers = copyFrom.mUsedBytesOnTiers != null
+        ? new HashMap<>(copyFrom.mUsedBytesOnTiers)
+        : null;
     mBlockCount = copyFrom.mBlockCount;
     mVersion = copyFrom.mVersion;
     mRevision = copyFrom.mRevision;

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
@@ -60,7 +60,24 @@ public final class WorkerNetAddress implements Serializable {
   /**
    * Creates a new instance of {@link WorkerNetAddress}.
    */
-  public WorkerNetAddress() {}
+  public WorkerNetAddress() {
+  }
+
+  /**
+   * Copy constructor.
+   *
+   * @param copyFrom instance to copy from
+   */
+  public WorkerNetAddress(WorkerNetAddress copyFrom) {
+    mHost = copyFrom.mHost;
+    mContainerHost = copyFrom.mContainerHost;
+    mRpcPort = copyFrom.mRpcPort;
+    mDataPort = copyFrom.mDataPort;
+    mSecureRpcPort = copyFrom.mSecureRpcPort;
+    mNettyDataPort = copyFrom.mNettyDataPort;
+    mWebPort = copyFrom.mWebPort;
+    mDomainSocketPath = copyFrom.mDomainSocketPath;
+  }
 
   /**
    * @return the secure rpc port

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerState.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerState.java
@@ -18,7 +18,11 @@ public enum WorkerState {
   LIVE("LIVE"),
   LOST("LOST"),
   DECOMMISSIONED("Decommissioned"),
-  DISABLED("Disabled");
+  DISABLED("Disabled"),
+  // an unknown worker which is not recognized by the cluster membership manager,
+  // e.g. a worker before it registers to the manager
+  UNRECOGNIZED("UNRECOGNIZED");
+
   private final String mState;
 
   WorkerState(String s) {
@@ -42,6 +46,8 @@ public enum WorkerState {
         return DECOMMISSIONED;
       case "Disabled":
         return DISABLED;
+      case "UNRECOGNIZED":
+        return UNRECOGNIZED;
       default:
         throw new IllegalArgumentException("Unknown worker state: " + workerState);
     }

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerState.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerState.java
@@ -25,6 +25,28 @@ public enum WorkerState {
     mState = s;
   }
 
+  /**
+   * Converts from string to worker state.
+   *
+   * @param workerState string representation of worker state
+   * @return worker state
+   * @throws IllegalArgumentException if the state is unknown
+   */
+  public static WorkerState of(String workerState) throws IllegalArgumentException {
+    switch (workerState) {
+      case "LIVE":
+        return LIVE;
+      case "LOST":
+        return LOST;
+      case "Decommissioned":
+        return DECOMMISSIONED;
+      case "Disabled":
+        return DISABLED;
+      default:
+        throw new IllegalArgumentException("Unknown worker state: " + workerState);
+    }
+  }
+
   @Override
   public String toString() {
     return mState;

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerState.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerState.java
@@ -15,7 +15,7 @@ package alluxio.wire;
  * The worker state maintained by master.
  */
 public enum WorkerState {
-  LIVE("ACTIVE"),
+  LIVE("LIVE"),
   LOST("LOST"),
   DECOMMISSIONED("Decommissioned"),
   DISABLED("Disabled");

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerState.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerState.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.master;
+package alluxio.wire;
 
 /***
  * The worker state maintained by master.

--- a/dora/core/common/src/test/java/alluxio/wire/WorkerInfoTest.java
+++ b/dora/core/common/src/test/java/alluxio/wire/WorkerInfoTest.java
@@ -88,7 +88,7 @@ public class WorkerInfoTest {
     capacityBytesOnTiers.put(Constants.MEDIUM_MEM, capacityBytes);
     Map<String, Long> usedBytesOnTiers = new HashMap<>();
     usedBytesOnTiers.put(Constants.MEDIUM_MEM, usedBytes);
-    String state = random.nextInt(2) == 1 ? "In Service" : "Out of Service";
+    WorkerState state = random.nextInt(2) == 1 ? WorkerState.LIVE : WorkerState.LOST;
     String version = String.format("%d.%d.%d", random.nextInt(10),
         random.nextInt(20), random.nextInt(10));
     String revision = DigestUtils.sha1Hex(RandomStringUtils.random(10));

--- a/dora/core/common/src/test/java/alluxio/wire/WorkerInfoTest.java
+++ b/dora/core/common/src/test/java/alluxio/wire/WorkerInfoTest.java
@@ -11,15 +11,21 @@
 
 package alluxio.wire;
 
+import static org.junit.Assert.assertNotEquals;
+
 import alluxio.Constants;
 import alluxio.grpc.GrpcUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Defaults;
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -49,6 +55,39 @@ public class WorkerInfoTest {
     Assert.assertTrue(compareLostWorkersWithTimes(1, 1) == 0);
     Assert.assertTrue(compareLostWorkersWithTimes(-1, 1) < 0);
     Assert.assertTrue(compareLostWorkersWithTimes(1, -1) > 0);
+  }
+
+  @Test
+  public void copyConstructor() throws IllegalAccessException {
+    WorkerInfo original = new WorkerInfo()
+        .setId(1)
+        .setIdentity(WorkerIdentityTestUtils.ofLegacyId(1))
+        .setAddress(new WorkerNetAddress().setHost("host1"))
+        .setBlockCount(1)
+        .setCapacityBytes(1)
+        .setUsedBytes(1)
+        .setCapacityBytesOnTiers(ImmutableMap.of())
+        .setUsedBytesOnTiers(ImmutableMap.of())
+        .setLastContactSec(1)
+        .setStartTimeMs(1)
+        .setState(WorkerState.LIVE)
+        .setRevision("rev1")
+        .setVersion("ver1");
+    WorkerInfo copied = new WorkerInfo(original);
+    // copied instance should contain exactly the same content
+    checkEquality(original, copied);
+    // mutate any non-final field in the copy,
+    // and the change should not be reflected in the original
+    for (Field field : WorkerInfo.class.getDeclaredFields()) {
+      int fieldModifiers = field.getModifiers();
+      if (Modifier.isStatic(fieldModifiers) || Modifier.isFinal(fieldModifiers)) {
+        continue;
+      }
+      field.setAccessible(true);
+      // set fields in the copy to their default value
+      field.set(copied, Defaults.defaultValue(field.getType()));
+      assertNotEquals(field.getName(), field.get(original), field.get(copied));
+    }
   }
 
   public void checkEquality(WorkerInfo a, WorkerInfo b) {

--- a/dora/core/common/src/test/java/alluxio/wire/WorkerNetAddressTest.java
+++ b/dora/core/common/src/test/java/alluxio/wire/WorkerNetAddressTest.java
@@ -11,13 +11,18 @@
 
 package alluxio.wire;
 
+import static org.junit.Assert.assertNotEquals;
+
 import alluxio.grpc.GrpcUtils;
 import alluxio.util.CommonUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Defaults;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Random;
 
 public class WorkerNetAddressTest {
@@ -36,6 +41,34 @@ public class WorkerNetAddressTest {
     WorkerNetAddress workerNetAddress = createRandom();
     WorkerNetAddress other = GrpcUtils.fromProto(GrpcUtils.toProto(workerNetAddress));
     checkEquality(workerNetAddress, other);
+  }
+
+  @Test
+  public void copyConstructor() throws IllegalAccessException {
+    WorkerNetAddress original = new WorkerNetAddress()
+        .setHost("host")
+        .setContainerHost("container")
+        .setRpcPort(1)
+        .setDataPort(1)
+        .setNettyDataPort(1)
+        .setSecureRpcPort(1)
+        .setWebPort(1)
+        .setDomainSocketPath("path");
+    WorkerNetAddress copied = new WorkerNetAddress(original);
+    // copied instance should contain exactly the same content
+    checkEquality(original, copied);
+    // mutate any non-final field in the copy,
+    // and the change should not be reflected in the original
+    for (Field field : WorkerNetAddress.class.getDeclaredFields()) {
+      int fieldModifiers = field.getModifiers();
+      if (Modifier.isStatic(fieldModifiers) || Modifier.isFinal(fieldModifiers)) {
+        continue;
+      }
+      field.setAccessible(true);
+      // set fields in the copy to their default value
+      field.set(copied, Defaults.defaultValue(field.getType()));
+      assertNotEquals(field.getName(), field.get(original), field.get(copied));
+    }
   }
 
   public void checkEquality(WorkerNetAddress a, WorkerNetAddress b) {

--- a/dora/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -49,7 +49,6 @@ import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.heartbeat.HeartbeatThread;
 import alluxio.master.CoreMaster;
 import alluxio.master.CoreMasterContext;
-import alluxio.wire.WorkerState;
 import alluxio.master.block.meta.MasterWorkerInfo;
 import alluxio.master.block.meta.WorkerMetaLockSection;
 import alluxio.master.journal.JournalContext;
@@ -85,6 +84,7 @@ import alluxio.wire.BlockInfo;
 import alluxio.wire.RegisterLease;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
+import alluxio.wire.WorkerState;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;

--- a/dora/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -49,7 +49,7 @@ import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.heartbeat.HeartbeatThread;
 import alluxio.master.CoreMaster;
 import alluxio.master.CoreMasterContext;
-import alluxio.master.WorkerState;
+import alluxio.wire.WorkerState;
 import alluxio.master.block.meta.MasterWorkerInfo;
 import alluxio.master.block.meta.WorkerMetaLockSection;
 import alluxio.master.journal.JournalContext;

--- a/dora/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -330,7 +330,7 @@ public final class MasterWorkerInfo {
           info.setStartTimeMs(mMeta.mStartTimeMs);
           break;
         case STATE:
-          info.setState(workerState.toString());
+          info.setState(workerState);
           break;
         case WORKER_USED_BYTES:
           info.setUsedBytes(mUsage.mUsedBytes);

--- a/dora/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -17,12 +17,12 @@ import alluxio.client.block.options.GetWorkerReportOptions;
 import alluxio.client.block.options.GetWorkerReportOptions.WorkerInfoField;
 import alluxio.grpc.BuildVersion;
 import alluxio.grpc.StorageList;
-import alluxio.wire.WorkerState;
 import alluxio.master.block.DefaultBlockMaster;
 import alluxio.resource.LockResource;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
+import alluxio.wire.WorkerState;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;

--- a/dora/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -17,7 +17,7 @@ import alluxio.client.block.options.GetWorkerReportOptions;
 import alluxio.client.block.options.GetWorkerReportOptions.WorkerInfoField;
 import alluxio.grpc.BuildVersion;
 import alluxio.grpc.StorageList;
-import alluxio.master.WorkerState;
+import alluxio.wire.WorkerState;
 import alluxio.master.block.DefaultBlockMaster;
 import alluxio.resource.LockResource;
 import alluxio.util.CommonUtils;

--- a/dora/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -41,7 +41,6 @@ import alluxio.master.AlwaysPrimaryPrimarySelector;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
-import alluxio.wire.WorkerState;
 import alluxio.master.block.meta.MasterWorkerInfo;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.noop.NoopJournalSystem;
@@ -55,6 +54,7 @@ import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
+import alluxio.wire.WorkerState;
 import alluxio.worker.block.BlockStoreLocation;
 import alluxio.worker.block.RegisterStreamer;
 

--- a/dora/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -332,7 +332,7 @@ public class BlockMasterTest {
     assertEquals(1, liveWorkerInfo.size());
     assertEquals(1, allWorkerInfo.size());
     WorkerInfo w = liveWorkerInfo.get(0);
-    assertEquals(WorkerState.LIVE.toString(), w.getState());
+    assertEquals(WorkerState.LIVE, w.getState());
     assertEquals(OLD_VERSION.getVersion(), w.getVersion());
     assertEquals(OLD_VERSION.getRevision(), w.getRevision());
 
@@ -348,7 +348,7 @@ public class BlockMasterTest {
         mBlockMaster.getWorkerReport(createGetWorkerReportOptions());
     assertEquals(1, allWorkersAfterDecom.size());
     WorkerInfo decomWorker = allWorkersAfterDecom.get(0);
-    assertEquals(WorkerState.DECOMMISSIONED.toString(), decomWorker.getState());
+    assertEquals(WorkerState.DECOMMISSIONED, decomWorker.getState());
     assertEquals(OLD_VERSION.getVersion(), decomWorker.getVersion());
     assertEquals(OLD_VERSION.getRevision(), decomWorker.getRevision());
 
@@ -396,7 +396,7 @@ public class BlockMasterTest {
     assertEquals(1, liveWorkerAfterRestart.size());
     assertEquals(1, allWorkerAfterRestart.size());
     WorkerInfo restartedWorker = liveWorkerAfterRestart.get(0);
-    assertEquals(WorkerState.LIVE.toString(), restartedWorker.getState());
+    assertEquals(WorkerState.LIVE, restartedWorker.getState());
     assertEquals(NEW_VERSION.getVersion(), restartedWorker.getVersion());
     assertEquals(NEW_VERSION.getRevision(), restartedWorker.getRevision());
     MasterWorkerInfo upgradedWorkerInfo = mBlockMaster.getWorker(workerId);
@@ -430,7 +430,7 @@ public class BlockMasterTest {
     assertEquals(1, liveWorkerInfo.size());
     assertEquals(1, allWorkerInfo.size());
     WorkerInfo w = liveWorkerInfo.get(0);
-    assertEquals(WorkerState.LIVE.toString(), w.getState());
+    assertEquals(WorkerState.LIVE, w.getState());
     assertEquals(OLD_VERSION.getVersion(), w.getVersion());
     assertEquals(OLD_VERSION.getRevision(), w.getRevision());
 
@@ -446,7 +446,7 @@ public class BlockMasterTest {
         mBlockMaster.getWorkerReport(createGetWorkerReportOptions());
     assertEquals(1, allWorkersAfterDecom.size());
     WorkerInfo decomWorker = allWorkersAfterDecom.get(0);
-    assertEquals(WorkerState.DECOMMISSIONED.toString(), decomWorker.getState());
+    assertEquals(WorkerState.DECOMMISSIONED, decomWorker.getState());
     assertEquals(OLD_VERSION.getVersion(), decomWorker.getVersion());
     assertEquals(OLD_VERSION.getRevision(), decomWorker.getRevision());
 
@@ -488,7 +488,7 @@ public class BlockMasterTest {
     assertEquals(1, liveWorkerAfterRestart.size());
     assertEquals(1, allWorkerAfterRestart.size());
     WorkerInfo restartedWorker = liveWorkerAfterRestart.get(0);
-    assertEquals(WorkerState.LIVE.toString(), restartedWorker.getState());
+    assertEquals(WorkerState.LIVE, restartedWorker.getState());
     assertEquals(NEW_VERSION.getVersion(), restartedWorker.getVersion());
     assertEquals(NEW_VERSION.getRevision(), restartedWorker.getRevision());
     MasterWorkerInfo upgradedWorkerInfo = mBlockMaster.getWorker(workerId);
@@ -524,7 +524,7 @@ public class BlockMasterTest {
     assertEquals(1, liveWorkerInfo.size());
     assertEquals(1, allWorkerInfo.size());
     WorkerInfo w = liveWorkerInfo.get(0);
-    assertEquals(WorkerState.LIVE.toString(), w.getState());
+    assertEquals(WorkerState.LIVE, w.getState());
     assertEquals(OLD_VERSION.getVersion(), w.getVersion());
     assertEquals(OLD_VERSION.getRevision(), w.getRevision());
 
@@ -545,7 +545,7 @@ public class BlockMasterTest {
         mBlockMaster.getWorkerReport(createGetWorkerReportOptions());
     assertEquals(1, allWorkersAfterDecom.size());
     WorkerInfo decomWorker = allWorkersAfterDecom.get(0);
-    assertEquals(WorkerState.DECOMMISSIONED.toString(), decomWorker.getState());
+    assertEquals(WorkerState.DECOMMISSIONED, decomWorker.getState());
     assertEquals(OLD_VERSION.getVersion(), decomWorker.getVersion());
     assertEquals(OLD_VERSION.getRevision(), decomWorker.getRevision());
 
@@ -582,7 +582,7 @@ public class BlockMasterTest {
     assertEquals(1, liveWorkerAfterRestart.size());
     assertEquals(1, allWorkerAfterRestart.size());
     WorkerInfo restartedWorker = liveWorkerAfterRestart.get(0);
-    assertEquals(WorkerState.LIVE.toString(), restartedWorker.getState());
+    assertEquals(WorkerState.LIVE, restartedWorker.getState());
     assertEquals(NEW_VERSION.getVersion(), restartedWorker.getVersion());
     assertEquals(NEW_VERSION.getRevision(), restartedWorker.getRevision());
     MasterWorkerInfo upgradedWorkerInfo = mBlockMaster.getWorker(workerId);
@@ -619,7 +619,7 @@ public class BlockMasterTest {
     assertEquals(1, liveWorkerInfo.size());
     assertEquals(1, allWorkerInfo.size());
     WorkerInfo w = liveWorkerInfo.get(0);
-    assertEquals(WorkerState.LIVE.toString(), w.getState());
+    assertEquals(WorkerState.LIVE, w.getState());
     assertEquals(OLD_VERSION.getVersion(), w.getVersion());
     assertEquals(OLD_VERSION.getRevision(), w.getRevision());
 
@@ -640,7 +640,7 @@ public class BlockMasterTest {
         mBlockMaster.getWorkerReport(createGetWorkerReportOptions());
     assertEquals(1, allWorkersAfterDecom.size());
     WorkerInfo decomWorker = allWorkersAfterDecom.get(0);
-    assertEquals(WorkerState.DECOMMISSIONED.toString(), decomWorker.getState());
+    assertEquals(WorkerState.DECOMMISSIONED, decomWorker.getState());
     assertEquals(OLD_VERSION.getVersion(), decomWorker.getVersion());
     assertEquals(OLD_VERSION.getRevision(), decomWorker.getRevision());
 
@@ -683,7 +683,7 @@ public class BlockMasterTest {
     assertEquals(1, liveWorkerAfterRestart.size());
     assertEquals(1, allWorkerAfterRestart.size());
     WorkerInfo restartedWorker = liveWorkerAfterRestart.get(0);
-    assertEquals(WorkerState.LIVE.toString(), restartedWorker.getState());
+    assertEquals(WorkerState.LIVE, restartedWorker.getState());
     assertEquals(NEW_VERSION.getVersion(), restartedWorker.getVersion());
     assertEquals(NEW_VERSION.getRevision(), restartedWorker.getRevision());
     MasterWorkerInfo upgradedWorkerInfo = mBlockMaster.getWorker(workerId);

--- a/dora/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -41,7 +41,7 @@ import alluxio.master.AlwaysPrimaryPrimarySelector;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
-import alluxio.master.WorkerState;
+import alluxio.wire.WorkerState;
 import alluxio.master.block.meta.MasterWorkerInfo;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.noop.NoopJournalSystem;

--- a/dora/core/server/master/src/test/java/alluxio/master/block/meta/MasterWorkerInfoTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/block/meta/MasterWorkerInfoTest.java
@@ -143,7 +143,7 @@ public final class MasterWorkerInfoTest {
         WorkerState.LIVE);
     assertEquals(mInfo.getId(), workerInfo.getId());
     assertEquals(mInfo.getWorkerAddress(), workerInfo.getAddress());
-    assertEquals(WorkerState.LIVE.toString(), workerInfo.getState());
+    assertEquals(WorkerState.LIVE, workerInfo.getState());
     assertEquals(mInfo.getCapacityBytes(), workerInfo.getCapacityBytes());
     assertEquals(mInfo.getUsedBytes(), workerInfo.getUsedBytes());
     assertEquals(mInfo.getStartTime(), workerInfo.getStartTimeMs());

--- a/dora/core/server/master/src/test/java/alluxio/master/block/meta/MasterWorkerInfoTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/block/meta/MasterWorkerInfoTest.java
@@ -19,9 +19,9 @@ import alluxio.Constants;
 import alluxio.DefaultStorageTierAssoc;
 import alluxio.StorageTierAssoc;
 import alluxio.client.block.options.GetWorkerReportOptions;
-import alluxio.wire.WorkerState;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
+import alluxio.wire.WorkerState;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;

--- a/dora/core/server/master/src/test/java/alluxio/master/block/meta/MasterWorkerInfoTest.java
+++ b/dora/core/server/master/src/test/java/alluxio/master/block/meta/MasterWorkerInfoTest.java
@@ -19,7 +19,7 @@ import alluxio.Constants;
 import alluxio.DefaultStorageTierAssoc;
 import alluxio.StorageTierAssoc;
 import alluxio.client.block.options.GetWorkerReportOptions;
-import alluxio.master.WorkerState;
+import alluxio.wire.WorkerState;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 

--- a/dora/job/common/src/main/java/alluxio/job/MasterWorkerInfo.java
+++ b/dora/job/common/src/main/java/alluxio/job/MasterWorkerInfo.java
@@ -17,6 +17,7 @@ import alluxio.grpc.BuildVersion;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
+import alluxio.wire.WorkerState;
 
 import com.google.common.base.Preconditions;
 
@@ -107,8 +108,8 @@ public final class MasterWorkerInfo {
    */
   public synchronized WorkerInfo generateClientWorkerInfo() {
     return new WorkerInfo().setId(mId).setAddress(mWorkerAddress).setLastContactSec(
-        (int) ((CommonUtils.getCurrentMs() - mLastUpdatedTimeMs) / Constants.SECOND_MS))
-        .setState("In Service").setStartTimeMs(mStartTimeMs);
+            (int) ((CommonUtils.getCurrentMs() - mLastUpdatedTimeMs) / Constants.SECOND_MS))
+        .setState(WorkerState.LIVE).setStartTimeMs(mStartTimeMs);
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Move `WorkerState` enum from master package to the wire package.
2. Add a new worker state `UNRECOGNIZED` and use it as the default state.
3. Make worker state in `WorkerInfo` an enum.
4. Add copy constructors to `WorkerInfo` and `WorkerNetAddress`.

### Why are the changes needed?

1. Make sure the state of worker can be enumerated.
2. Allow safely copying mutable `WorkerInfo` and `WorkerNetAddress` objects.

### Does this PR introduce any user facing changes?

No.
