### PR TITLE
Create metadata directory in initiateMultipartUpload method

### DIFF
--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Handler.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Handler.java
@@ -15,10 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.grpc.Bits;
-import alluxio.grpc.CreateDirectoryPOptions;
-import alluxio.grpc.PMode;
-import alluxio.grpc.XAttrPropagationStrategy;
 import alluxio.master.audit.AsyncUserAccessAuditLogWriter;
 import alluxio.s3.S3AuditContext;
 import alluxio.s3.S3Constants;
@@ -256,19 +252,6 @@ public class S3Handler {
     mMetaFS = (FileSystem) context.getAttribute(ProxyWebServer.FILE_SYSTEM_SERVLET_RESOURCE_KEY);
     mAsyncAuditLogWriter = (AsyncUserAccessAuditLogWriter) context.getAttribute(
         ProxyWebServer.ALLUXIO_PROXY_AUDIT_LOG_WRITER_KEY);
-    // Initiate the S3 API metadata directories
-    if (!mMetaFS.exists(new AlluxioURI(S3RestUtils.MULTIPART_UPLOADS_METADATA_DIR))) {
-      mMetaFS.createDirectory(new AlluxioURI(S3RestUtils.MULTIPART_UPLOADS_METADATA_DIR),
-          CreateDirectoryPOptions.newBuilder()
-            .setRecursive(true)
-            .setMode(PMode.newBuilder()
-              .setOwnerBits(Bits.ALL).setGroupBits(Bits.ALL)
-              .setOtherBits(Bits.NONE)
-              .build())
-            .setWriteType(S3RestUtils.getS3WriteType())
-            .setXattrPropStrat(XAttrPropagationStrategy.LEAF_NODE)
-            .build());
-    }
   }
 
   /**

--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ObjectTask.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ObjectTask.java
@@ -893,6 +893,7 @@ public class S3ObjectTask extends S3BaseTask {
           }
 
           try {
+            S3RestUtils.initMultipartUploadsMetadataDir(mHandler.getMetaFS());
             // Find an unused UUID
             String uploadId;
             do {

--- a/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/dora/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -182,22 +182,6 @@ public final class S3RestServiceHandler {
     mBucketInvalidSuffixPattern = Pattern.compile(".*-s3alias$");
     mBucketValidNamePattern = Pattern.compile("[a-z0-9][a-z0-9\\.-]{1,61}[a-z0-9]");
 
-    // Initiate the S3 API metadata directories
-    if (!mMetaFS.exists(new AlluxioURI(S3RestUtils.MULTIPART_UPLOADS_METADATA_DIR))) {
-      mMetaFS.createDirectory(
-          new AlluxioURI(S3RestUtils.MULTIPART_UPLOADS_METADATA_DIR),
-          CreateDirectoryPOptions.newBuilder()
-              .setRecursive(true)
-              .setMode(PMode.newBuilder()
-                  .setOwnerBits(Bits.ALL)
-                  .setGroupBits(Bits.ALL)
-                  .setOtherBits(Bits.NONE).build())
-              .setWriteType(S3RestUtils.getS3WriteType())
-              .setXattrPropStrat(XAttrPropagationStrategy.LEAF_NODE)
-              .build()
-      );
-    }
-
     mGlobalRateLimiter = (RateLimiter) context.getAttribute(
         ProxyWebServer.GLOBAL_RATE_LIMITER_SERVLET_RESOURCE_KEY);
   }
@@ -1079,6 +1063,7 @@ public final class S3RestServiceHandler {
         }
 
         try {
+          S3RestUtils.initMultipartUploadsMetadataDir(mMetaFS);
           // Find an unused UUID
           String uploadId;
           do {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Create metadata directory in initiateMultipartUpload method.

### Why are the changes needed?

Each request calls the initialization method of the handler and sends an `exists` request to the master, which is unnecessary.

