### PR TITLE
Fix alluxio-fuse script for finding fuse pid

### DIFF
--- a/dora/integration/fuse/bin/alluxio-fuse
+++ b/dora/integration/fuse/bin/alluxio-fuse
@@ -329,7 +329,7 @@ unmount_command() {
   readonly force_kill
 
   local fuse_pid
-  fuse_pid=$(ps ax -o pid,args | grep [A]lluxioFuse | grep " ${mount_point} " | awk '{print $1}')
+  fuse_pid=$(ps ax -o pid,args | grep [A]lluxioFuse | grep " ${mount_point}" | awk '{print $1}')
   if [[ -z "${fuse_pid}" ]];then
     err "Cannot find AlluxioFuse Java process for ${mount_point}"
     return 1

--- a/dora/integration/fuse/bin/alluxio-fuse
+++ b/dora/integration/fuse/bin/alluxio-fuse
@@ -329,7 +329,7 @@ unmount_command() {
   readonly force_kill
 
   local fuse_pid
-  fuse_pid=$(ps ax -o pid,args | grep [A]lluxioFuse | grep " ${mount_point}" | awk '{print $1}')
+  fuse_pid=$(ps ax -o pid,args | grep [A]lluxioFuse | grep " ${mount_point}\b" | awk '{print $1}')
   if [[ -z "${fuse_pid}" ]];then
     err "Cannot find AlluxioFuse Java process for ${mount_point}"
     return 1


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove additional white space in alluxio-fuse script

### Why are the changes needed?

alluxio-fuse unmount <mnt_point> is unable to find the pid of AlluxioFuse process because the grep content isn't correct.

### Does this PR introduce any user facing changes?

No
