### PR TITLE
Fix the issue of S3 range read

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/s3/S3NettyObjectTask.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/s3/S3NettyObjectTask.java
@@ -300,7 +300,7 @@ public class S3NettyObjectTask extends S3NettyBaseTask {
       DataBuffer packet = null;
       long offset = range.getOffset(objectSize);
       long length = range.getLength(objectSize);
-        BlockReader blockReader = mHandler.openBlock(ufsFullPath, offset, offset + length);
+      BlockReader blockReader = mHandler.openBlock(ufsFullPath, offset, offset + length);
 
       // Writes http response to the netty channel before data.
       mHandler.processHttpResponse(response, false);

--- a/dora/core/server/worker/src/main/java/alluxio/worker/s3/S3NettyObjectTask.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/s3/S3NettyObjectTask.java
@@ -246,7 +246,7 @@ public class S3NettyObjectTask extends S3NettyBaseTask {
             response.headers()
                 .set(HttpHeaderNames.LAST_MODIFIED, new Date(status.getLastModificationTimeMs()));
             response.headers().set(S3Constants.S3_CONTENT_LENGTH_HEADER,
-                status.isFolder() ? 0 : status.getLength());
+                    status.isFolder() ? 0 : s3Range.getLength(status.getLength()));
 
             // Check range
             if (s3Range.isValid()) {
@@ -300,7 +300,7 @@ public class S3NettyObjectTask extends S3NettyBaseTask {
       DataBuffer packet = null;
       long offset = range.getOffset(objectSize);
       long length = range.getLength(objectSize);
-      BlockReader blockReader = mHandler.openBlock(ufsFullPath, offset, length);
+        BlockReader blockReader = mHandler.openBlock(ufsFullPath, offset, offset + length);
 
       // Writes http response to the netty channel before data.
       mHandler.processHttpResponse(response, false);


### PR DESCRIPTION
### What changes are proposed in this pull request?

fix the issue of S3 range read. 

### Why are the changes needed?

there is a bug when setting  S3 range offset.

### Does this PR introduce any user facing changes?

user can try the following cmd to validate S3 range read.
`aws --endpoint http://localhost:39999/api/v1/s3 s3api get-object --range bytes=10-20 --bucket [bucket-name] --key=[key-name] [output-file]`


