### PR TITLE
Add the metrics to record the direct memory used by Netty

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -2739,12 +2739,12 @@ public final class MetricKey implements Comparable<MetricKey> {
   // Other system related metrics
   public static final MetricKey PROCESS_POOL_DIRECT_MEM_USED =
       new Builder("Process.pool.direct.mem.used")
-          .setDescription("The used direct memory")
+          .setDescription("Direct memory used by NIO direct buffer pool ")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey PROCESS_NETTY_DIRECT_MEM_USED =
-      new Builder("Process.Netty.direct.mem.used")
-          .setDescription("The used direct memory of netty")
+      new Builder("Process.netty.direct.mem.used")
+          .setDescription("Direct memory used by Netty")
           .setMetricType(MetricType.GAUGE)
           .build();
 

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -2742,6 +2742,11 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("The used direct memory")
           .setMetricType(MetricType.GAUGE)
           .build();
+  public static final MetricKey PROCESS_NETTY_DIRECT_MEM_USED =
+      new Builder("Process.Netty.direct.mem.used")
+          .setDescription("The used direct memory of netty")
+          .setMetricType(MetricType.GAUGE)
+          .build();
 
   /**
    * A nested class to hold named string constants for their corresponding metrics.

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -38,6 +38,7 @@ import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import io.netty.util.internal.PlatformDependent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -163,6 +164,9 @@ public final class MetricsSystem {
     MetricsSystem.registerGaugeIfAbsent(
         MetricsSystem.getMetricName(MetricKey.PROCESS_POOL_DIRECT_MEM_USED.getName()),
         MetricsSystem::getDirectMemUsed);
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricsSystem.getMetricName(MetricKey.PROCESS_NETTY_DIRECT_MEM_USED.getName()),
+        MetricsSystem::getDirectMemUsedForNetty);
   }
 
   private static BufferPoolMXBean getDirectBufferPool() {
@@ -184,6 +188,13 @@ public final class MetricsSystem {
       return DIRECT_BUFFER_POOL.getMemoryUsed();
     }
     return 0;
+  }
+
+  /**
+   * @return the used direct memory of netty
+   */
+  public static long getDirectMemUsedForNetty() {
+    return PlatformDependent.usedDirectMemory();
   }
 
   @GuardedBy("MetricsSystem")

--- a/core/server/master/src/main/java/alluxio/master/throttle/MetricsMonitorUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/throttle/MetricsMonitorUtils.java
@@ -40,6 +40,8 @@ public class MetricsMonitorUtils {
     public static final String HEAP_USED = "heap.used";
 
     public static final String DIRECT_MEM_USED = MetricKey.PROCESS_POOL_DIRECT_MEM_USED.getName();
+    public static final String NETTY_DIRECT_MEM_USED =
+        MetricKey.PROCESS_NETTY_DIRECT_MEM_USED.getName();
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/throttle/SystemMonitor.java
+++ b/core/server/master/src/main/java/alluxio/master/throttle/SystemMonitor.java
@@ -182,19 +182,19 @@ public class SystemMonitor {
         Configuration.getDouble(PropertyKey.MASTER_THROTTLE_ACTIVE_HEAP_USED_RATIO),
         Configuration.getDouble(PropertyKey.MASTER_THROTTLE_ACTIVE_CPU_LOAD_RATIO),
         Configuration.getMs(PropertyKey.MASTER_THROTTLE_ACTIVE_HEAP_GC_TIME),
-        Configuration.getInt(PropertyKey.MASTER_THROTTLE_ACTIVE_RPC_QUEUE_SIZE));
+        Configuration.getInt(PropertyKey.MASTER_THROTTLE_ACTIVE_RPC_QUEUE_SIZE), 0);
     // mPitThresholdStressed;
     mPitThresholdStressed = ServerIndicator.createThresholdIndicator(0,
         Configuration.getDouble(PropertyKey.MASTER_THROTTLE_STRESSED_HEAP_USED_RATIO),
         Configuration.getDouble(PropertyKey.MASTER_THROTTLE_STRESSED_CPU_LOAD_RATIO),
         Configuration.getMs(PropertyKey.MASTER_THROTTLE_STRESSED_HEAP_GC_TIME),
-        Configuration.getInt(PropertyKey.MASTER_THROTTLE_STRESSED_RPC_QUEUE_SIZE));
+        Configuration.getInt(PropertyKey.MASTER_THROTTLE_STRESSED_RPC_QUEUE_SIZE), 0);
     // mPitThresholdOverloaded;
     mPitThresholdOverloaded = ServerIndicator.createThresholdIndicator(0,
         Configuration.getDouble(PropertyKey.MASTER_THROTTLE_OVERLOADED_HEAP_USED_RATIO),
         Configuration.getDouble(PropertyKey.MASTER_THROTTLE_OVERLOADED_CPU_LOAD_RATIO),
         Configuration.getMs(PropertyKey.MASTER_THROTTLE_OVERLOADED_HEAP_GC_TIME),
-        Configuration.getInt(PropertyKey.MASTER_THROTTLE_OVERLOADED_RPC_QUEUE_SIZE));
+        Configuration.getInt(PropertyKey.MASTER_THROTTLE_OVERLOADED_RPC_QUEUE_SIZE), 0);
     mAggregateThresholdActive = new ServerIndicator(mPitThresholdActive, mMaxNumberOfSnapshot);
     mAggregateThresholdStressed
         = new ServerIndicator(mPitThresholdStressed, mMaxNumberOfSnapshot);

--- a/core/server/master/src/test/java/alluxio/master/throttle/IndicatorsTests.java
+++ b/core/server/master/src/test/java/alluxio/master/throttle/IndicatorsTests.java
@@ -78,6 +78,7 @@ public class IndicatorsTests {
   @Test
   public void basicIndicatorComparisonTest() throws InterruptedException {
     long directMemUsed = 8;
+    long nettyDirectMemUsed = 8;
     long headMax = 1000;
     long headUsed = 800;
     double cpuLoad = 0.3;
@@ -85,8 +86,9 @@ public class IndicatorsTests {
     long pitTotalJVMPauseTime = 30;
     long rpcQueueSize = 50;
     long snapshotTimeMS = 33;
-    ServerIndicator serverIndicator = new ServerIndicator(directMemUsed, headMax, headUsed, cpuLoad,
-        totalJVMPauseTimeMS, pitTotalJVMPauseTime, rpcQueueSize, snapshotTimeMS);
+    ServerIndicator serverIndicator =
+        new ServerIndicator(directMemUsed, headMax, headUsed, cpuLoad, totalJVMPauseTimeMS,
+            pitTotalJVMPauseTime, rpcQueueSize, snapshotTimeMS, nettyDirectMemUsed);
 
     int times = 3;
     ServerIndicator serverIndicatorM = new ServerIndicator(serverIndicator, times);
@@ -96,6 +98,8 @@ public class IndicatorsTests {
         (serverIndicator.getCpuLoad() * times), 0.0000001);
     Assert.assertEquals(serverIndicatorM.getDirectMemUsed(),
         (serverIndicator.getDirectMemUsed() * times));
+    Assert.assertEquals(serverIndicatorM.getNettyDirectMemUsed(),
+        (serverIndicator.getNettyDirectMemUsed() * times));
     Assert.assertEquals(serverIndicatorM.getTotalJVMPauseTimeMS(),
         (serverIndicator.getTotalJVMPauseTimeMS() * times));
     Assert.assertEquals(serverIndicatorM.getRpcQueueSize(),
@@ -109,13 +113,14 @@ public class IndicatorsTests {
         headMax,
         headUsed + deltaLong, cpuLoad + deltaDouble,
         totalJVMPauseTimeMS + deltaLong, pitTotalJVMPauseTime + deltaLong,
-        rpcQueueSize + deltaLong, snapshotTimeMS);
+        rpcQueueSize + deltaLong, snapshotTimeMS, nettyDirectMemUsed + deltaLong);
 
     ServerIndicator deltaIndicator = new ServerIndicator(serverIndicator1Delta);
     deltaIndicator.reduction(serverIndicator);
     Assert.assertEquals(deltaLong, deltaIndicator.getRpcQueueSize());
     Assert.assertEquals(deltaDouble, deltaIndicator.getCpuLoad(), 0.00001);
     Assert.assertEquals(deltaLong, deltaIndicator.getDirectMemUsed());
+    Assert.assertEquals(deltaLong, deltaIndicator.getNettyDirectMemUsed());
     Assert.assertEquals(deltaLong, deltaIndicator.getHeapUsed());
     Assert.assertEquals(deltaLong, deltaIndicator.getTotalJVMPauseTimeMS());
 
@@ -125,12 +130,13 @@ public class IndicatorsTests {
         headMax,
         headUsed + deltaLong, cpuLoad + deltaDouble,
         totalJVMPauseTimeMS + deltaLong, pitTotalJVMPauseTime + deltaLong,
-        rpcQueueSize + deltaLong, snapshotTimeMS);
+        rpcQueueSize + deltaLong, snapshotTimeMS, nettyDirectMemUsed + deltaLong);
     deltaIndicator = new ServerIndicator(serverIndicator2Delta);
     deltaIndicator.reduction(serverIndicator);
     Assert.assertEquals(deltaIndicator.getRpcQueueSize(), deltaLong);
     Assert.assertEquals(deltaIndicator.getCpuLoad(), deltaDouble, 0.00001);
     Assert.assertEquals(deltaIndicator.getDirectMemUsed(), deltaLong);
+    Assert.assertEquals(deltaIndicator.getNettyDirectMemUsed(), deltaLong);
     Assert.assertEquals(deltaIndicator.getHeapUsed(), deltaLong);
     Assert.assertEquals(deltaIndicator.getTotalJVMPauseTimeMS(), deltaLong);
 
@@ -142,6 +148,8 @@ public class IndicatorsTests {
     Assert.assertEquals(aggTimes * serverIndicator.getRpcQueueSize(), serverAgg.getRpcQueueSize());
     Assert.assertEquals(aggTimes * serverIndicator.getDirectMemUsed(),
         serverAgg.getDirectMemUsed());
+    Assert.assertEquals(aggTimes * serverIndicator.getNettyDirectMemUsed(),
+        serverAgg.getNettyDirectMemUsed());
     Assert.assertEquals(aggTimes * serverIndicator.getHeapUsed(), serverAgg.getHeapUsed());
     Assert.assertEquals(aggTimes * serverIndicator.getTotalJVMPauseTimeMS(),
         serverAgg.getTotalJVMPauseTimeMS());

--- a/docs/_data/table/cn/process-metrics.yml
+++ b/docs/_data/table/cn/process-metrics.yml
@@ -1,4 +1,4 @@
 Process.pool.direct.mem.used:
-  '已使用的直接内存'
-Process.Netty.direct.mem.used:
-  'Netty使用的直接内存统计'
+  'NIO Direct buffer pool已使用的直接内存'
+Process.netty.direct.mem.used:
+  'Netty已使用的直接内存'

--- a/docs/_data/table/cn/process-metrics.yml
+++ b/docs/_data/table/cn/process-metrics.yml
@@ -1,2 +1,4 @@
 Process.pool.direct.mem.used:
   '已使用的直接内存'
+Process.Netty.direct.mem.used:
+  'Netty使用的直接内存统计'

--- a/docs/_data/table/en/process-metrics.yml
+++ b/docs/_data/table/en/process-metrics.yml
@@ -1,4 +1,4 @@
 Process.pool.direct.mem.used:
-  'The used direct memory'
-Process.Netty.direct.mem.used:
-  'The used direct memory of netty'
+  'The used direct memory by NIO direct buffer pool'
+Process.netty.direct.mem.used:
+  'The used direct memory by Netty'

--- a/docs/_data/table/en/process-metrics.yml
+++ b/docs/_data/table/en/process-metrics.yml
@@ -1,2 +1,4 @@
 Process.pool.direct.mem.used:
   'The used direct memory'
+Process.Netty.direct.mem.used:
+  'The used direct memory of netty'


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add a metric to record the direct memory usage of Netty.

### Why are the changes needed?
when high business pressure, there may be OOM issues when using Netty direct memory to transfer data. Adding this metric to monitor the usage of direct memory.


### Does this PR introduce any user facing changes?
No
