### PR TITLE
[DOCFIX] Update kerberos configuration 'alluxio.hadoop.kerberos.keytab.login.autorenewal' in HDFS docs

### DIFF
--- a/docs/en/ufs/HDFS.md
+++ b/docs/en/ufs/HDFS.md
@@ -142,7 +142,7 @@ Use the principal `hdfs` and the keytab that you configured earlier in `alluxio-
 A known limitation is that the Kerberos TGT may expire after
 the max renewal lifetime. You can work around this by renewing the TGT periodically. Otherwise you
 may see `No valid credentials provided (Mechanism level: Failed to find any Kerberos tgt)`
-when starting Alluxio services. Another option is to set `alluxio.hadoop.security.kerberos.keytab.login.autorenewal=true`
+when starting Alluxio services. Another option is to set `alluxio.hadoop.kerberos.keytab.login.autorenewal=true`
 so the TGT is automatically refreshed.
 
 The user can also use `alluxio.hadoop.security.krb5.conf` to specify the krb5.conf file location


### PR DESCRIPTION


### What changes are proposed in this pull request?

Update the correct kerberos configuration 'alluxio.hadoop.kerberos.keytab.login.autorenewal' in HDFS docs to avoid user confusion.

### Why are the changes needed?

Fix #18486 


