### PR TITLE
Add PropertyKey for file not found metadata cache

### DIFF
--- a/dora/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingFileSystemTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingFileSystemTest.java
@@ -73,6 +73,7 @@ public class MetadataCachingFileSystemTest {
     mConf.set(PropertyKey.USER_METADATA_CACHE_MAX_SIZE, 1000, Source.RUNTIME);
     // Avoid async update file access time to call getStatus to mess up the test results
     mConf.set(PropertyKey.USER_UPDATE_FILE_ACCESSTIME_DISABLED, true);
+    mConf.set(PropertyKey.USER_METADATA_CACHE_NOT_FOUND_CACHE_ENABLED, true);
     mClientContext = ClientContext.create(mConf);
     mFileContext = PowerMockito.mock(FileSystemContext.class);
     when(mFileContext.getClientContext()).thenReturn(mClientContext);

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5839,7 +5839,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey USER_METADATA_CACHE_NEGATIVE_CACHE_ENABLED =
       booleanBuilder(Name.USER_METADATA_CACHE_NOT_FOUND_CACHE_ENABLED)
           .setDefaultValue(false)
-          .setDescription("Whether cache the file not found status.")
+          .setDescription("Whether to enable negative cache for the client metadata "
+              + "cache, which caches the absence of a file in the UFS.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5836,6 +5836,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_METADATA_CACHE_NOT_FOUND_CACHE_ENABLED =
+      booleanBuilder(Name.USER_METADATA_CACHE_NOT_FOUND_CACHE_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Whether cache the file not found status.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_METRICS_COLLECTION_ENABLED =
       booleanBuilder(Name.USER_METRICS_COLLECTION_ENABLED)
           .setDefaultValue(false)
@@ -8446,6 +8453,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.metadata.cache.max.size";
     public static final String USER_METADATA_CACHE_EXPIRATION_TIME =
         "alluxio.user.metadata.cache.expiration.time";
+    public static final String USER_METADATA_CACHE_NOT_FOUND_CACHE_ENABLED =
+        "alluxio.user.metadata.cache.not.found.cache.enabled";
     public static final String USER_METRICS_COLLECTION_ENABLED =
         "alluxio.user.metrics.collection.enabled";
     public static final String USER_METRICS_HEARTBEAT_INTERVAL_MS =

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -8453,8 +8453,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.metadata.cache.max.size";
     public static final String USER_METADATA_CACHE_EXPIRATION_TIME =
         "alluxio.user.metadata.cache.expiration.time";
-    public static final String USER_METADATA_CACHE_NOT_FOUND_CACHE_ENABLED =
-        "alluxio.user.metadata.cache.not.found.cache.enabled";
+    public static final String USER_METADATA_CACHE_NEGATIVE_CACHE_ENABLED =
+        "alluxio.user.metadata.cache.negative.cache.enabled";
     public static final String USER_METRICS_COLLECTION_ENABLED =
         "alluxio.user.metrics.collection.enabled";
     public static final String USER_METRICS_HEARTBEAT_INTERVAL_MS =

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5836,7 +5836,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey USER_METADATA_CACHE_NOT_FOUND_CACHE_ENABLED =
+  public static final PropertyKey USER_METADATA_CACHE_NEGATIVE_CACHE_ENABLED =
       booleanBuilder(Name.USER_METADATA_CACHE_NOT_FOUND_CACHE_ENABLED)
           .setDefaultValue(false)
           .setDescription("Whether cache the file not found status.")


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add PropertyKey for file not found metadata cache

### Why are the changes needed?

Without this PR, dora fuse cannot copy a file to dora cluster through dora fuse

### Does this PR introduce any user facing changes?

Add a new PropertyKey `alluxio.user.metadata.cache.not.found.cache.enabled`