### PR TITLE
Fix negative size if specified filesize over Integer.MAX_VALUE for stressWorkerBench

### DIFF
--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -155,7 +155,7 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
 
     // initialize the base, for only the non-distributed task (the cluster launching task)
     Path basePath = new Path(mParameters.mBasePath);
-    int fileSize = (int) FormatUtils.parseSpaceSize(mParameters.mFileSize);
+    long fileSize = FormatUtils.parseSpaceSize(mParameters.mFileSize);
     int numFiles = getTotalFileNumber();
 
     // Generate the file paths using the same heuristics so all nodes have the same set of paths
@@ -266,7 +266,7 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
     LOG.info("{} file paths generated", mFilePaths.length);
   }
 
-  private void prepareTestFiles(Path basePath, int fileSize, FileSystem prepareFs)
+  private void prepareTestFiles(Path basePath, long fileSize, FileSystem prepareFs)
       throws IOException {
     int numFiles = mFilePaths.length;
     LOG.info("Preparing {} test files under {}", numFiles, basePath);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Change to use long type store file size.

### Why are the changes needed?

Without this PR, we cannot specified a filesize lagger than Integer.MAX_VALUE.

### Does this PR introduce any user facing changes?

No
