### PR TITLE
Set min replication when TTL expires to free a file

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
@@ -106,6 +106,7 @@ final class InodeTtlChecker implements HeartbeatExecutor {
               case FREE: // Default: FREE
                 // public free method will lock the path, and check WRITE permission required at
                 // parent of file
+                // Also we will unpin the file if pinned and set min replication to 0
                 if (inode.isDirectory()) {
                   mFileSystemMaster.free(path, FreeContext
                       .mergeFrom(FreePOptions.newBuilder().setForced(true).setRecursive(true)));

--- a/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
@@ -31,7 +31,6 @@ import alluxio.master.file.meta.TtlBucket;
 import alluxio.master.file.meta.TtlBucketList;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.NoopJournalContext;
-import alluxio.proto.journal.File;
 import alluxio.proto.journal.File.UpdateInodeEntry;
 import alluxio.util.ThreadUtils;
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Current TTL frees a file but the file can be brought back in due to min replication being set. 
This changes that behavior and ensures the file is freed. 

### Why are the changes needed?

TTL and minreplication can conflict each other, this fixes that and allow TTL to take precedence.

### Does this PR introduce any user facing changes?
TTL free behavior change