### PR TITLE
Improve the local cache fallback behavior for corrupted pages

### DIFF
--- a/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -584,6 +584,23 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
+  public void testPageDataFileCorrupted() throws Exception
+  {
+    int pages = 10;
+    int fileSize = mPageSize * pages;
+    byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
+    ByteArrayCacheManager manager = new ByteArrayCacheManager();
+    //by default local cache fallback is not enabled, the read should fail for any error
+    LocalCacheFileInStream streamWithOutFallback = setupWithSingleFile(testData, manager);
+
+    sConf.set(PropertyKey.USER_CLIENT_CACHE_FALLBACK_ENABLED, true);
+    LocalCacheFileInStream streamWithFallback = setupWithSingleFile(testData, manager);
+    Assert.assertEquals(100, streamWithFallback.positionedRead(0, new byte[10], 100, 100));
+    Assert.assertEquals(1,
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_POSITION_READ_FALLBACK.getName()).getCount());
+  }
+
+  @Test
   public void testPositionReadFallBack() throws Exception
   {
     int pages = 10;

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/cache/store/MemoryPageStoreTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/cache/store/MemoryPageStoreTest.java
@@ -43,7 +43,8 @@ public class MemoryPageStoreTest {
     PageId id = new PageId("0", 0);
     store.put(id, msg.getBytes());
     byte[] buf = new byte[PAGE_SIZE];
-    assertEquals(msg.getBytes().length, store.get(id, new ByteArrayTargetBuffer(buf, 0)));
+    assertEquals(msg.getBytes().length,
+        store.get(id, 0, msg.length(), new ByteArrayTargetBuffer(buf, 0)));
     assertArrayEquals(msg.getBytes(), Arrays.copyOfRange(buf, 0, msg.getBytes().length));
   }
 }

--- a/dora/core/common/src/main/java/alluxio/exception/PageCorruptedException.java
+++ b/dora/core/common/src/main/java/alluxio/exception/PageCorruptedException.java
@@ -1,0 +1,35 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.exception;
+
+/**
+ * An exception that should be thrown when the data of a page has been corrupted in store.
+ */
+public class PageCorruptedException extends RuntimeException {
+
+  /**
+   * Construct PageCorruptedException with the specified message.
+   * @param message
+   */
+  public PageCorruptedException(String message) {
+    super(message);
+  }
+
+  /**
+   * Construct PageCorruptedException with the specified message and cause.
+   * @param message
+   * @param cause
+   */
+  public PageCorruptedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Throw a PageCorruptedException when the length of page inconsistent with the metadata
Do our best efforts to delete the corrupted page file
Reset the offset of buffer when we found the data has been corrupted to avoid ArrayOutOfBound exception. 

### Why are the changes needed?
We found the cache make presto keep failing when some of the page file got corrupted

### Does this PR introduce any user facing changes?

No
