### PR TITLE
Add http server port in the worker net address

### DIFF
--- a/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
@@ -139,6 +139,7 @@ public class EtcdMembershipManager implements MembershipManager {
                 pathOnRing));
           }
           if (existingEntity.get().equals(entity)) {
+            // Same entity, update the original etcd-stored worker information
             mAlluxioEtcdClient.createForPath(pathOnRing, Optional.of(serializedEntity));
           } else {
             throw new AlreadyExistsException(

--- a/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
@@ -138,7 +138,7 @@ public class EtcdMembershipManager implements MembershipManager {
                 "Existing WorkerServiceEntity for path:%s corrupted",
                 pathOnRing));
           }
-          if (existingEntity.get().customizedEquals(entity)) {
+          if (existingEntity.get().equalsIgnoringOptionalFields(entity)) {
             // Same entity but potentially with new optional fields,
             // update the original etcd-stored worker information
             mAlluxioEtcdClient.createForPath(pathOnRing, Optional.of(serializedEntity));

--- a/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
@@ -138,8 +138,9 @@ public class EtcdMembershipManager implements MembershipManager {
                 "Existing WorkerServiceEntity for path:%s corrupted",
                 pathOnRing));
           }
-          if (existingEntity.get().equals(entity)) {
-            // Same entity, update the original etcd-stored worker information
+          if (existingEntity.get().customizedEquals(entity)) {
+            // Same entity but potentially with new optional fields,
+            // update the original etcd-stored worker information
             mAlluxioEtcdClient.createForPath(pathOnRing, Optional.of(serializedEntity));
           } else {
             throw new AlreadyExistsException(

--- a/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
@@ -138,13 +138,15 @@ public class EtcdMembershipManager implements MembershipManager {
                 "Existing WorkerServiceEntity for path:%s corrupted",
                 pathOnRing));
           }
-          throw new AlreadyExistsException(
-              String.format("Some other member with same id registered on the ring, bail."
-                  + "Conflicting worker addr:%s, worker identity:%s."
-                  + "Different workers can't assume same worker identity in non-k8s env,"
-                  + "clean local worker identity settings to continue.",
-                  existingEntity.get().getWorkerNetAddress().toString(),
-                  existingEntity.get().getIdentity()));
+          if (!existingEntity.get().equals(entity)) {
+            throw new AlreadyExistsException(
+                String.format("Some other member with same id registered on the ring, bail."
+                        + "Conflicting worker addr:%s, worker identity:%s."
+                        + "Different workers can't assume same worker identity in non-k8s env,"
+                        + "clean local worker identity settings to continue.",
+                    existingEntity.get().getWorkerNetAddress().toString(),
+                    existingEntity.get().getIdentity()));
+          }
         }
       }
     } catch (InterruptedException | ExecutionException e) {

--- a/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
@@ -138,7 +138,9 @@ public class EtcdMembershipManager implements MembershipManager {
                 "Existing WorkerServiceEntity for path:%s corrupted",
                 pathOnRing));
           }
-          if (!existingEntity.get().equals(entity)) {
+          if (existingEntity.get().equals(entity)) {
+            mAlluxioEtcdClient.createForPath(pathOnRing, Optional.of(serializedEntity));
+          } else {
             throw new AlreadyExistsException(
                 String.format("Some other member with same id registered on the ring, bail."
                         + "Conflicting worker addr:%s, worker identity:%s."

--- a/dora/core/common/src/main/java/alluxio/membership/StaticMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/StaticMembershipManager.java
@@ -87,7 +87,8 @@ public class StaticMembershipManager implements MembershipManager {
           .setContainerHost(Configuration.global()
               .getOrDefault(PropertyKey.WORKER_CONTAINER_HOSTNAME, ""))
           .setRpcPort(conf.getInt(PropertyKey.WORKER_RPC_PORT))
-          .setWebPort(conf.getInt(PropertyKey.WORKER_WEB_PORT));
+          .setWebPort(conf.getInt(PropertyKey.WORKER_WEB_PORT))
+          .setHttpServerPort(conf.getInt(PropertyKey.WORKER_HTTP_SERVER_PORT));
       //data port, these are initialized from configuration for client to deduce the
       //workeraddr related info, on worker side, it will be corrected by join().
       InetSocketAddress inetAddr;
@@ -126,7 +127,8 @@ public class StaticMembershipManager implements MembershipManager {
         .setDomainSocketPath(addr.getDomainSocketPath())
         .setNettyDataPort(addr.getNettyDataPort())
         .setWebPort(addr.getWebPort())
-        .setSecureRpcPort(addr.getSecureRpcPort()));
+        .setSecureRpcPort(addr.getSecureRpcPort())
+        .setHttpServerPort(addr.getHttpServerPort()));
   }
 
   @Override

--- a/dora/core/common/src/main/java/alluxio/membership/WorkerServiceEntity.java
+++ b/dora/core/common/src/main/java/alluxio/membership/WorkerServiceEntity.java
@@ -108,7 +108,8 @@ public class WorkerServiceEntity extends DefaultServiceEntity {
     // only the service name and the identity are the factors that define
     // what a WorkerServiceEntity is. Any other is either ephemeral or supplementary data.
     return mIdentity.equals(anotherO.mIdentity)
-        && getServiceEntityName().equals(anotherO.getServiceEntityName());
+        && getServiceEntityName().equals(anotherO.getServiceEntityName())
+        && mAddress.equals(anotherO.getWorkerNetAddress());
   }
 
   @Override

--- a/dora/core/common/src/main/java/alluxio/membership/WorkerServiceEntity.java
+++ b/dora/core/common/src/main/java/alluxio/membership/WorkerServiceEntity.java
@@ -128,13 +128,14 @@ public class WorkerServiceEntity extends DefaultServiceEntity {
   }
 
   /**
-   * A customized equality comparison which uses the customized comparison of WorkerNetAddress
-   * objects.
+   * A customized equality comparison which ignores optional fields such as mHttpServerPort in the
+   * WorkerNetAddress.
    *
-   * @param o The object to be compared with this WorkerServiceEntity for customized equality
-   * @return true if the specified object is equal to this WorkerServiceEntity; false otherwise
+   * @param o The object to be compared with this WorkerServiceEntity for equality
+   * @return true if the specified object is equal to this WorkerServiceEntity by ignoring optional
+   *         fields; false otherwise
    */
-  public boolean customizedEquals(Object o) {
+  public boolean equalsIgnoringOptionalFields(Object o) {
     if (this == o) {
       return true;
     }
@@ -144,6 +145,16 @@ public class WorkerServiceEntity extends DefaultServiceEntity {
     WorkerServiceEntity anotherO = (WorkerServiceEntity) o;
     return mIdentity.equals(anotherO.mIdentity)
         && getServiceEntityName().equals(anotherO.getServiceEntityName())
-        && mAddress.customizedEquals(anotherO.getWorkerNetAddress());
+        && equalsIgnoringHttpServerPort(anotherO.getWorkerNetAddress());
+  }
+
+  private boolean equalsIgnoringHttpServerPort(WorkerNetAddress other) {
+    return mAddress.getHost().equals(other.getHost())
+        && mAddress.getContainerHost().equals(other.getContainerHost())
+        && mAddress.getSecureRpcPort() == other.getSecureRpcPort()
+        && mAddress.getRpcPort() == other.getRpcPort()
+        && mAddress.getDataPort() == other.getDataPort()
+        && mAddress.getWebPort() == other.getWebPort()
+        && mAddress.getDomainSocketPath().equals(other.getDomainSocketPath());
   }
 }

--- a/dora/core/common/src/main/java/alluxio/membership/WorkerServiceEntity.java
+++ b/dora/core/common/src/main/java/alluxio/membership/WorkerServiceEntity.java
@@ -108,8 +108,7 @@ public class WorkerServiceEntity extends DefaultServiceEntity {
     // only the service name and the identity are the factors that define
     // what a WorkerServiceEntity is. Any other is either ephemeral or supplementary data.
     return mIdentity.equals(anotherO.mIdentity)
-        && getServiceEntityName().equals(anotherO.getServiceEntityName())
-        && mAddress.equals(anotherO.getWorkerNetAddress());
+        && getServiceEntityName().equals(anotherO.getServiceEntityName());
   }
 
   @Override
@@ -126,5 +125,25 @@ public class WorkerServiceEntity extends DefaultServiceEntity {
         .registerTypeAdapter(WorkerServiceEntity.class, creator)
         .create();
     gson.fromJson(new InputStreamReader(new ByteArrayInputStream(buf)), WorkerServiceEntity.class);
+  }
+
+  /**
+   * A customized equality comparison which uses the customized comparison of WorkerNetAddress
+   * objects.
+   *
+   * @param o The object to be compared with this WorkerServiceEntity for customized equality
+   * @return true if the specified object is equal to this WorkerServiceEntity; false otherwise
+   */
+  public boolean customizedEquals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WorkerServiceEntity anotherO = (WorkerServiceEntity) o;
+    return mIdentity.equals(anotherO.mIdentity)
+        && getServiceEntityName().equals(anotherO.getServiceEntityName())
+        && mAddress.customizedEquals(anotherO.getWorkerNetAddress());
   }
 }

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
@@ -58,6 +58,7 @@ public final class WorkerNetAddress implements Serializable {
   private String mDomainSocketPath = "";
   @Expose
   @com.google.gson.annotations.SerializedName("HttpServerPort")
+  // Optional field - skipped in the equality comparison
   private int mHttpServerPort;
 
   /**

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
@@ -265,30 +265,6 @@ public final class WorkerNetAddress implements Serializable {
   }
 
   /**
-   * A customized equality comparison which skips the comparison of optional fields, including
-   * mHttpServerPort, for backward compatibility.
-   *
-   * @param o The object to be compared with this WorkerNetAddress for customized equality
-   * @return true if the specified object is equal to this WorkerNetAddress; false otherwise
-   */
-  public boolean customizedEquals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof WorkerNetAddress)) {
-      return false;
-    }
-    WorkerNetAddress that = (WorkerNetAddress) o;
-    return mHost.equals(that.mHost)
-        && mContainerHost.equals(that.mContainerHost)
-        && mSecureRpcPort == that.mSecureRpcPort
-        && mRpcPort == that.mRpcPort
-        && mDataPort == that.mDataPort
-        && mWebPort == that.mWebPort
-        && mDomainSocketPath.equals(that.mDomainSocketPath);
-  }
-
-  /**
    * dump the main info of the WorkerNetAddress object.
    *
    * @return the main info string of the WorkerNetAddress object

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
@@ -58,7 +58,7 @@ public final class WorkerNetAddress implements Serializable {
   private String mDomainSocketPath = "";
   @Expose
   @com.google.gson.annotations.SerializedName("HttpServerPort")
-  // Optional field - skipped in the equality comparison
+  // Optional field - skipped in the customized equality comparison
   private int mHttpServerPort;
 
   /**
@@ -254,15 +254,38 @@ public final class WorkerNetAddress implements Serializable {
         && mRpcPort == that.mRpcPort
         && mDataPort == that.mDataPort
         && mWebPort == that.mWebPort
-        && mDomainSocketPath.equals(that.mDomainSocketPath);
-        // Skip the comparison of mHttpServerPort for backward compatibility
+        && mDomainSocketPath.equals(that.mDomainSocketPath)
+        && mHttpServerPort == that.mHttpServerPort;
   }
 
   @Override
   public int hashCode() {
-    // Skip the mHttpServerPort for backward compatibility
     return Objects.hashCode(mSecureRpcPort, mHost, mContainerHost, mDataPort, mRpcPort, mWebPort,
-        mDomainSocketPath);
+        mDomainSocketPath, mHttpServerPort);
+  }
+
+  /**
+   * A customized equality comparison which skips the comparison of optional fields, including
+   * mHttpServerPort, for backward compatibility.
+   *
+   * @param o The object to be compared with this WorkerNetAddress for customized equality
+   * @return true if the specified object is equal to this WorkerNetAddress; false otherwise
+   */
+  public boolean customizedEquals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof WorkerNetAddress)) {
+      return false;
+    }
+    WorkerNetAddress that = (WorkerNetAddress) o;
+    return mHost.equals(that.mHost)
+        && mContainerHost.equals(that.mContainerHost)
+        && mSecureRpcPort == that.mSecureRpcPort
+        && mRpcPort == that.mRpcPort
+        && mDataPort == that.mDataPort
+        && mWebPort == that.mWebPort
+        && mDomainSocketPath.equals(that.mDomainSocketPath);
   }
 
   /**

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
@@ -255,11 +255,11 @@ public final class WorkerNetAddress implements Serializable {
         && mWebPort == that.mWebPort
         && mDomainSocketPath.equals(that.mDomainSocketPath);
         // Skip the comparison of mHttpServerPort for backward compatibility
-        // && mHttpServerPort == that.mHttpServerPort;
   }
 
   @Override
   public int hashCode() {
+    // Skip the mHttpServerPort for backward compatibility
     return Objects.hashCode(mSecureRpcPort, mHost, mContainerHost, mDataPort, mRpcPort, mWebPort,
         mDomainSocketPath);
   }

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
@@ -56,6 +56,9 @@ public final class WorkerNetAddress implements Serializable {
   @Expose
   @com.google.gson.annotations.SerializedName("DomainSocketPath")
   private String mDomainSocketPath = "";
+  @Expose
+  @com.google.gson.annotations.SerializedName("HttpServerPort")
+  private int mHttpServerPort;
 
   /**
    * Creates a new instance of {@link WorkerNetAddress}.
@@ -77,6 +80,7 @@ public final class WorkerNetAddress implements Serializable {
     mNettyDataPort = copyFrom.mNettyDataPort;
     mWebPort = copyFrom.mWebPort;
     mDomainSocketPath = copyFrom.mDomainSocketPath;
+    mHttpServerPort = copyFrom.mHttpServerPort;
   }
 
   /**
@@ -141,6 +145,14 @@ public final class WorkerNetAddress implements Serializable {
   @ApiModelProperty(value = "The domain socket path used by the worker, disabled if empty")
   public String getDomainSocketPath() {
     return mDomainSocketPath;
+  }
+
+  /**
+   * @return the http server port
+   */
+  @ApiModelProperty(value = "Port of the worker's http server for rest apis")
+  public int getHttpServerPort() {
+    return mHttpServerPort;
   }
 
   /**
@@ -217,6 +229,15 @@ public final class WorkerNetAddress implements Serializable {
     return this;
   }
 
+  /**
+   * @param httpServerPort the http server port to use
+   * @return the worker net address
+   */
+  public WorkerNetAddress setHttpServerPort(int httpServerPort) {
+    mHttpServerPort = httpServerPort;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -232,13 +253,14 @@ public final class WorkerNetAddress implements Serializable {
         && mRpcPort == that.mRpcPort
         && mDataPort == that.mDataPort
         && mWebPort == that.mWebPort
-        && mDomainSocketPath.equals(that.mDomainSocketPath);
+        && mDomainSocketPath.equals(that.mDomainSocketPath)
+        && mHttpServerPort == that.mHttpServerPort;
   }
 
   @Override
   public int hashCode() {
     return Objects.hashCode(mSecureRpcPort, mHost, mContainerHost, mDataPort, mRpcPort, mWebPort,
-        mDomainSocketPath);
+        mDomainSocketPath, mHttpServerPort);
   }
 
   /**
@@ -254,6 +276,7 @@ public final class WorkerNetAddress implements Serializable {
         .add("dataPort", mDataPort)
         .add("webPort", mWebPort)
         .add("domainSocketPath", mDomainSocketPath)
+        .add("httpServerPort", mHttpServerPort)
         .toString();
   }
 
@@ -267,6 +290,7 @@ public final class WorkerNetAddress implements Serializable {
         .add("webPort", mWebPort)
         .add("domainSocketPath", mDomainSocketPath)
         .add("secureRpcPort", mSecureRpcPort)
+        .add("httpServerPort", mHttpServerPort)
         .toString();
   }
 }

--- a/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
+++ b/dora/core/common/src/main/java/alluxio/wire/WorkerNetAddress.java
@@ -253,14 +253,15 @@ public final class WorkerNetAddress implements Serializable {
         && mRpcPort == that.mRpcPort
         && mDataPort == that.mDataPort
         && mWebPort == that.mWebPort
-        && mDomainSocketPath.equals(that.mDomainSocketPath)
-        && mHttpServerPort == that.mHttpServerPort;
+        && mDomainSocketPath.equals(that.mDomainSocketPath);
+        // Skip the comparison of mHttpServerPort for backward compatibility
+        // && mHttpServerPort == that.mHttpServerPort;
   }
 
   @Override
   public int hashCode() {
     return Objects.hashCode(mSecureRpcPort, mHost, mContainerHost, mDataPort, mRpcPort, mWebPort,
-        mDomainSocketPath, mHttpServerPort);
+        mDomainSocketPath);
   }
 
   /**

--- a/dora/core/common/src/test/java/alluxio/membership/ServiceEntityTest.java
+++ b/dora/core/common/src/test/java/alluxio/membership/ServiceEntityTest.java
@@ -38,4 +38,32 @@ public final class ServiceEntityTest {
     deserialized.deserialize(jsonBytes);
     Assert.assertEquals(deserialized, entity);
   }
+
+  @Test
+  public void testEqualsIgnoringOptionalFields() throws Exception {
+    final WorkerNetAddress workerNetAddress1 = new WorkerNetAddress()
+        .setHost("worker1").setContainerHost("containerhostname1")
+        .setRpcPort(1000).setDataPort(1001).setWebPort(1011)
+        .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(1021);
+    final WorkerNetAddress workerNetAddress2 = new WorkerNetAddress()
+        .setHost("worker1").setContainerHost("containerhostname1")
+        .setRpcPort(1000).setDataPort(1001).setWebPort(1011)
+        .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(2021);
+    final WorkerNetAddress workerNetAddress3 = new WorkerNetAddress()
+        .setHost("worker3").setContainerHost("containerhostname1")
+        .setRpcPort(1000).setDataPort(1001).setWebPort(1011)
+        .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(1021);
+    final WorkerIdentity identity = WorkerIdentity.fromProto(
+        alluxio.grpc.WorkerIdentity.newBuilder()
+            .setIdentifier(ByteString.copyFrom(Longs.toByteArray(1L)))
+            .setVersion(0)
+            .build());
+    WorkerServiceEntity entity1 = new WorkerServiceEntity(identity, workerNetAddress1);
+    WorkerServiceEntity entity2 = new WorkerServiceEntity(identity, workerNetAddress2);
+    WorkerServiceEntity entity3 = new WorkerServiceEntity(identity, workerNetAddress3);
+
+    Assert.assertTrue(entity1.equalsIgnoringOptionalFields(entity2));
+    Assert.assertFalse(entity2.equalsIgnoringOptionalFields(entity3));
+    Assert.assertFalse(entity3.equalsIgnoringOptionalFields(entity1));
+  }
 }

--- a/dora/core/common/src/test/java/alluxio/wire/WorkerNetAddressTest.java
+++ b/dora/core/common/src/test/java/alluxio/wire/WorkerNetAddressTest.java
@@ -72,6 +72,43 @@ public class WorkerNetAddressTest {
     }
   }
 
+  @Test
+  public void testCustomizedEquals() {
+    WorkerNetAddress workerNetAddress1 = new WorkerNetAddress()
+        .setHost("host")
+        .setContainerHost("container")
+        .setRpcPort(1)
+        .setDataPort(1)
+        .setNettyDataPort(1)
+        .setSecureRpcPort(1)
+        .setWebPort(1)
+        .setDomainSocketPath("path")
+        .setHttpServerPort(1);
+    WorkerNetAddress workerNetAddress2 = new WorkerNetAddress()
+        .setHost("host")
+        .setContainerHost("container")
+        .setRpcPort(1)
+        .setDataPort(1)
+        .setNettyDataPort(1)
+        .setSecureRpcPort(1)
+        .setWebPort(1)
+        .setDomainSocketPath("path")
+        .setHttpServerPort(2);
+    WorkerNetAddress workerNetAddress3 = new WorkerNetAddress()
+        .setHost("host2")
+        .setContainerHost("container")
+        .setRpcPort(1)
+        .setDataPort(1)
+        .setNettyDataPort(1)
+        .setSecureRpcPort(1)
+        .setWebPort(1)
+        .setDomainSocketPath("path")
+        .setHttpServerPort(1);
+    Assert.assertTrue(workerNetAddress1.customizedEquals(workerNetAddress2));
+    Assert.assertFalse(workerNetAddress1.customizedEquals(workerNetAddress3));
+    Assert.assertFalse(workerNetAddress2.customizedEquals(workerNetAddress3));
+  }
+
   public void checkEquality(WorkerNetAddress a, WorkerNetAddress b) {
     Assert.assertEquals(a.getHost(), b.getHost());
     Assert.assertEquals(a.getRpcPort(), b.getRpcPort());

--- a/dora/core/common/src/test/java/alluxio/wire/WorkerNetAddressTest.java
+++ b/dora/core/common/src/test/java/alluxio/wire/WorkerNetAddressTest.java
@@ -53,7 +53,8 @@ public class WorkerNetAddressTest {
         .setNettyDataPort(1)
         .setSecureRpcPort(1)
         .setWebPort(1)
-        .setDomainSocketPath("path");
+        .setDomainSocketPath("path")
+        .setHttpServerPort(1);
     WorkerNetAddress copied = new WorkerNetAddress(original);
     // copied instance should contain exactly the same content
     checkEquality(original, copied);

--- a/dora/core/common/src/test/java/alluxio/wire/WorkerNetAddressTest.java
+++ b/dora/core/common/src/test/java/alluxio/wire/WorkerNetAddressTest.java
@@ -72,43 +72,6 @@ public class WorkerNetAddressTest {
     }
   }
 
-  @Test
-  public void testCustomizedEquals() {
-    WorkerNetAddress workerNetAddress1 = new WorkerNetAddress()
-        .setHost("host")
-        .setContainerHost("container")
-        .setRpcPort(1)
-        .setDataPort(1)
-        .setNettyDataPort(1)
-        .setSecureRpcPort(1)
-        .setWebPort(1)
-        .setDomainSocketPath("path")
-        .setHttpServerPort(1);
-    WorkerNetAddress workerNetAddress2 = new WorkerNetAddress()
-        .setHost("host")
-        .setContainerHost("container")
-        .setRpcPort(1)
-        .setDataPort(1)
-        .setNettyDataPort(1)
-        .setSecureRpcPort(1)
-        .setWebPort(1)
-        .setDomainSocketPath("path")
-        .setHttpServerPort(2);
-    WorkerNetAddress workerNetAddress3 = new WorkerNetAddress()
-        .setHost("host2")
-        .setContainerHost("container")
-        .setRpcPort(1)
-        .setDataPort(1)
-        .setNettyDataPort(1)
-        .setSecureRpcPort(1)
-        .setWebPort(1)
-        .setDomainSocketPath("path")
-        .setHttpServerPort(1);
-    Assert.assertTrue(workerNetAddress1.customizedEquals(workerNetAddress2));
-    Assert.assertFalse(workerNetAddress1.customizedEquals(workerNetAddress3));
-    Assert.assertFalse(workerNetAddress2.customizedEquals(workerNetAddress3));
-  }
-
   public void checkEquality(WorkerNetAddress a, WorkerNetAddress b) {
     Assert.assertEquals(a.getHost(), b.getHost());
     Assert.assertEquals(a.getRpcPort(), b.getRpcPort());

--- a/dora/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -393,6 +393,9 @@ public class AlluxioWorkerProcess implements WorkerProcess {
     if (mNettyDataTransmissionEnable) {
       workerNetAddress.setNettyDataPort(getNettyDataLocalPort());
     }
+    if (Configuration.getBoolean(PropertyKey.WORKER_HTTP_SERVER_ENABLED)) {
+      workerNetAddress.setHttpServerPort(Configuration.getInt(PropertyKey.WORKER_HTTP_SERVER_PORT));
+    }
     return workerNetAddress;
   }
 

--- a/dora/tests/testcontainers/src/test/java/alluxio/membership/MembershipManagerTest.java
+++ b/dora/tests/testcontainers/src/test/java/alluxio/membership/MembershipManagerTest.java
@@ -403,10 +403,8 @@ public class MembershipManagerTest {
   }
 
   @Test
-  public void testWorkerHttpServerPorts() throws Exception {
+  public void testOptionalHttpPortChangeInWorkerAddress() throws Exception {
     final MembershipManager membershipManager = getHealthyEtcdMemberMgr();
-    Configuration.set(PropertyKey.WORKER_MEMBERSHIP_MANAGER_TYPE, MembershipType.ETCD);
-    Configuration.set(PropertyKey.ETCD_ENDPOINTS, getClientEndpoints());
     Assert.assertTrue(membershipManager instanceof EtcdMembershipManager);
     // join without http server ports
     WorkerIdentity workerIdentity = WorkerIdentityTestUtils.randomUuidBasedId();
@@ -435,6 +433,8 @@ public class MembershipManagerTest {
     workerNetAddress.setHttpServerPort(1021);
     membershipManager.join(wkr);
     // check if the worker is rejoined and information updated
+    WorkerClusterView allMembers = membershipManager.getAllMembers();
+    Assert.assertEquals(1, allMembers.size());
     curWorkerInfo = membershipManager.getLiveMembers().getWorkerById(workerIdentity);
     Assert.assertTrue(curWorkerInfo.isPresent());
     Assert.assertEquals(wkr.getAddress(), curWorkerInfo.get().getAddress());

--- a/dora/tests/testcontainers/src/test/java/alluxio/membership/MembershipManagerTest.java
+++ b/dora/tests/testcontainers/src/test/java/alluxio/membership/MembershipManagerTest.java
@@ -200,19 +200,19 @@ public class MembershipManagerTest {
         .setAddress(new WorkerNetAddress()
             .setHost("worker1").setContainerHost("containerhostname1")
             .setRpcPort(1000).setDataPort(1001).setWebPort(1011)
-            .setDomainSocketPath("/var/lib/domain.sock"));
+            .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(1021));
     WorkerInfo wkr2 = new WorkerInfo()
         .setIdentity(WorkerIdentityTestUtils.randomUuidBasedId())
         .setAddress(new WorkerNetAddress()
             .setHost("worker2").setContainerHost("containerhostname2")
             .setRpcPort(2000).setDataPort(2001).setWebPort(2011)
-            .setDomainSocketPath("/var/lib/domain.sock"));
+            .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(2021));
     WorkerInfo wkr3 = new WorkerInfo()
         .setIdentity(WorkerIdentityTestUtils.randomUuidBasedId())
         .setAddress(new WorkerNetAddress()
             .setHost("worker3").setContainerHost("containerhostname3")
             .setRpcPort(3000).setDataPort(3001).setWebPort(3011)
-            .setDomainSocketPath("/var/lib/domain.sock"));
+            .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(3031));
     membershipManager.join(wkr1);
     membershipManager.join(wkr2);
     membershipManager.join(wkr3);
@@ -260,13 +260,13 @@ public class MembershipManagerTest {
         .setAddress(new WorkerNetAddress()
             .setHost("worker-1").setContainerHost("containerhostname1")
             .setRpcPort(29999).setDataPort(29997).setWebPort(30000)
-            .setDomainSocketPath("/var/lib/domain.sock"));
+            .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(30001));
     WorkerInfo wkr2 = new WorkerInfo()
         .setIdentity(WorkerIdentityTestUtils.randomUuidBasedId())
         .setAddress(new WorkerNetAddress()
             .setHost("worker-2").setContainerHost("containerhostname2")
             .setRpcPort(29999).setDataPort(29997).setWebPort(30000)
-            .setDomainSocketPath("/var/lib/domain.sock"));
+            .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(30001));
     membershipManager.join(wkr1);
     membershipManager.join(wkr2);
     CommonUtils.waitFor("Workers joined",
@@ -326,19 +326,19 @@ public class MembershipManagerTest {
         .setAddress(new WorkerNetAddress()
             .setHost("worker1").setContainerHost("containerhostname1")
             .setRpcPort(1000).setDataPort(1001).setWebPort(1011)
-            .setDomainSocketPath("/var/lib/domain.sock"));
+            .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(1021));
     WorkerInfo wkr2 = new WorkerInfo()
         .setIdentity(WorkerIdentityTestUtils.randomUuidBasedId())
         .setAddress(new WorkerNetAddress()
             .setHost("worker2").setContainerHost("containerhostname2")
             .setRpcPort(2000).setDataPort(2001).setWebPort(2011)
-            .setDomainSocketPath("/var/lib/domain.sock"));
+            .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(2021));
     WorkerInfo wkr3 = new WorkerInfo()
         .setIdentity(WorkerIdentityTestUtils.randomUuidBasedId())
         .setAddress(new WorkerNetAddress()
             .setHost("worker3").setContainerHost("containerhostname3")
             .setRpcPort(3000).setDataPort(3001).setWebPort(3011)
-            .setDomainSocketPath("/var/lib/domain.sock"));
+            .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(3021));
     membershipManager.join(wkr1);
     membershipManager.join(wkr2);
     membershipManager.join(wkr3);
@@ -367,13 +367,13 @@ public class MembershipManagerTest {
         .setAddress(new WorkerNetAddress()
             .setHost("worker1").setContainerHost("containerhostname1")
             .setRpcPort(1000).setDataPort(1001).setWebPort(1011)
-            .setDomainSocketPath("/var/lib/domain.sock"));
+            .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(1021));
     WorkerInfo wkr2 = new WorkerInfo()
         .setIdentity(workerIdentity1)
         .setAddress(new WorkerNetAddress()
             .setHost("worker2").setContainerHost("containerhostname2")
             .setRpcPort(2000).setDataPort(2001).setWebPort(2011)
-            .setDomainSocketPath("/var/lib/domain.sock"));
+            .setDomainSocketPath("/var/lib/domain.sock").setHttpServerPort(2021));
     membershipManager.join(wkr1);
     // bring wrk1 down and join wrk2 with a same worker identity.
     membershipManager.stopHeartBeat(wkr1);


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR enables registering the worker's HTTP server's port in the etcd. This helps to find worker's restful APIs from the Python client.

### Why are the changes needed?

Alluxio Python client (e.g. in ML use cases) needs to connect to the worker's REST APIs. But as the http server port isn't included in the worker's information in the etcd, the client fails to find the API endpoint.

### Does this PR introduce any user facing changes?

No.
