### PR TITLE
Fix runtime stats when cache hit

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -197,16 +197,14 @@ public class LocalCacheFileInStream extends FileInStream {
     int bytesLeftInPage = (int) (mPageSize - currentPageOffset);
     int bytesToReadInPage = Math.min(bytesLeftInPage, length);
     stopwatch.reset().start();
+    if (cacheContext == null) {
+      cacheContext = mCacheContext;
+    }
     int bytesRead =
-        mCacheManager.get(pageId, currentPageOffset, bytesToReadInPage, bytesBuffer, mCacheContext);
+        mCacheManager.get(pageId, currentPageOffset, bytesToReadInPage, bytesBuffer, cacheContext);
     stopwatch.stop();
     if (bytesRead > 0) {
       MetricsSystem.counter(MetricKey.CLIENT_CACHE_HIT_REQUESTS.getName()).inc();
-      if (cacheContext != null) {
-        cacheContext.incrementCounter(
-            MetricKey.CLIENT_CACHE_PAGE_READ_CACHE_TIME_NS.getMetricName(), NANO,
-            stopwatch.elapsed(TimeUnit.NANOSECONDS));
-      }
       return bytesRead;
     }
     // on local cache miss, read a complete page from external storage. This will always make

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -584,6 +584,23 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
+  public void testPageDataFileCorrupted() throws Exception
+  {
+    int pages = 10;
+    int fileSize = mPageSize * pages;
+    byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
+    ByteArrayCacheManager manager = new ByteArrayCacheManager();
+    //by default local cache fallback is not enabled, the read should fail for any error
+    LocalCacheFileInStream streamWithOutFallback = setupWithSingleFile(testData, manager);
+
+    sConf.set(PropertyKey.USER_CLIENT_CACHE_FALLBACK_ENABLED, true);
+    LocalCacheFileInStream streamWithFallback = setupWithSingleFile(testData, manager);
+    Assert.assertEquals(100, streamWithFallback.positionedRead(0, new byte[10], 100, 100));
+    Assert.assertEquals(1,
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_POSITION_READ_FALLBACK.getName()).getCount());
+  }
+
+  @Test
   public void testPositionReadFallBack() throws Exception
   {
     int pages = 10;

--- a/dora/core/client/fs/src/test/java/alluxio/client/file/cache/store/MemoryPageStoreTest.java
+++ b/dora/core/client/fs/src/test/java/alluxio/client/file/cache/store/MemoryPageStoreTest.java
@@ -43,7 +43,8 @@ public class MemoryPageStoreTest {
     PageId id = new PageId("0", 0);
     store.put(id, msg.getBytes());
     byte[] buf = new byte[PAGE_SIZE];
-    assertEquals(msg.getBytes().length, store.get(id, new ByteArrayTargetBuffer(buf, 0)));
+    assertEquals(msg.getBytes().length,
+        store.get(id, 0, msg.length(), new ByteArrayTargetBuffer(buf, 0)));
     assertArrayEquals(msg.getBytes(), Arrays.copyOfRange(buf, 0, msg.getBytes().length));
   }
 }

--- a/dora/core/common/src/main/java/alluxio/exception/PageCorruptedException.java
+++ b/dora/core/common/src/main/java/alluxio/exception/PageCorruptedException.java
@@ -1,0 +1,35 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.exception;
+
+/**
+ * An exception that should be thrown when the data of a page has been corrupted in store.
+ */
+public class PageCorruptedException extends RuntimeException {
+
+  /**
+   * Construct PageCorruptedException with the specified message.
+   * @param message
+   */
+  public PageCorruptedException(String message) {
+    super(message);
+  }
+
+  /**
+   * Construct PageCorruptedException with the specified message and cause.
+   * @param message
+   * @param cause
+   */
+  public PageCorruptedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/dora/core/common/src/main/java/alluxio/membership/MembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/MembershipManager.java
@@ -125,6 +125,8 @@ public interface MembershipManager extends AutoCloseable {
           return EtcdMembershipManager.create(conf);
         case MASTER:
           return MasterMembershipManager.create();
+        case SERVICE_REGISTRY:
+          return ServiceRegistryMembershipManager.create(conf);
         default:
           throw new IllegalStateException("Unrecognized Membership Type");
       }

--- a/dora/core/common/src/main/java/alluxio/membership/MembershipType.java
+++ b/dora/core/common/src/main/java/alluxio/membership/MembershipType.java
@@ -17,5 +17,6 @@ package alluxio.membership;
 public enum MembershipType {
   STATIC, // Use a static file to configure a static member list for MembershipManager
   ETCD, // Use etcd for MembershipManager
-  MASTER // For regression purpose, still leverage Master for worker registration
+  MASTER, // For regression purpose, still leverage Master for worker registration
+  SERVICE_REGISTRY // Use SERVICE REGISTRY MembershipManager, which only use active workers
 }

--- a/dora/core/common/src/main/java/alluxio/membership/ServiceRegistryMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/ServiceRegistryMembershipManager.java
@@ -1,0 +1,153 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.membership;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.wire.WorkerInfo;
+import alluxio.wire.WorkerState;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.JsonParseException;
+import io.etcd.jetcd.KeyValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * MembershipManager backed by configured etcd cluster. Only use active users
+ */
+public class ServiceRegistryMembershipManager implements MembershipManager {
+  private static final Logger LOG = LoggerFactory.getLogger(ServiceRegistryMembershipManager.class);
+
+  private AlluxioEtcdClient mAlluxioEtcdClient;
+
+  /**
+   * @param conf
+   * @return ServiceRegistryMembershipManager
+   */
+  public static ServiceRegistryMembershipManager create(AlluxioConfiguration conf) {
+    return new ServiceRegistryMembershipManager(conf);
+  }
+
+  /**
+   * CTOR for ServiceRegistryMembershipManager.
+   * @param conf
+   */
+  public ServiceRegistryMembershipManager(AlluxioConfiguration conf) {
+    this(conf, AlluxioEtcdClient.getInstance(conf));
+  }
+
+  /**
+   * Default ServiceRegistryMembershipManager with given AlluxioEtcdClient client.
+   * Only contains live workers.
+   *
+   * @param conf              Alluxio configuration
+   * @param alluxioEtcdClient etcd client
+   */
+  public ServiceRegistryMembershipManager(AlluxioConfiguration conf,
+      AlluxioEtcdClient alluxioEtcdClient) {
+    mAlluxioEtcdClient = alluxioEtcdClient;
+  }
+
+  @Override
+  public void join(WorkerInfo workerInfo) throws IOException {
+    LOG.info("Try joining Service Registry for worker:{} ", workerInfo);
+    WorkerServiceEntity entity =
+        new WorkerServiceEntity(workerInfo.getIdentity(), workerInfo.getAddress());
+    mAlluxioEtcdClient.mServiceDiscovery.registerAndStartSync(entity);
+    LOG.info("register to service registry for worker:{} ", workerInfo);
+  }
+
+  @Override
+  public WorkerClusterView getAllMembers() throws IOException {
+    return getLiveMembers();
+  }
+
+  @Override
+  public WorkerClusterView getLiveMembers() throws IOException {
+    Iterable<WorkerInfo> workerInfoIterable = parseWorkersFromEtcdKvPairs(
+        mAlluxioEtcdClient.mServiceDiscovery.getAllLiveServices())
+        .map(w -> new WorkerInfo()
+            .setIdentity(w.getIdentity())
+            .setAddress(w.getWorkerNetAddress())
+            .setState(WorkerState.LIVE))
+        ::iterator;
+    return new WorkerClusterView(workerInfoIterable);
+  }
+
+  @Override
+  public WorkerClusterView getFailedMembers() {
+    return new WorkerClusterView(Collections.emptyList());
+  }
+
+  private Stream<WorkerServiceEntity> parseWorkersFromEtcdKvPairs(List<KeyValue> workerKvs) {
+    return workerKvs
+        .stream()
+        .map(this::parseWorkerServiceEntity)
+        .filter(Optional::isPresent)
+        .map(Optional::get);
+  }
+
+  private Optional<WorkerServiceEntity> parseWorkerServiceEntity(KeyValue etcdKvPair) {
+    try {
+      WorkerServiceEntity entity = new WorkerServiceEntity();
+      entity.deserialize(etcdKvPair.getValue().getBytes());
+      return Optional.of(entity);
+    } catch (JsonParseException ex) {
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  @VisibleForTesting
+  public String showAllMembers() {
+    try {
+      WorkerClusterView registeredWorkers = getAllMembers();
+      String printFormat = "%s\t%s\t%s%n";
+      StringBuilder sb = new StringBuilder(
+          String.format(printFormat, "WorkerId", "Address", "Status"));
+      for (WorkerInfo entity : registeredWorkers) {
+        String entryLine = String.format(printFormat,
+            entity.getIdentity(),
+            entity.getAddress().getHost() + ":"
+                + entity.getAddress().getRpcPort(), "ONLINE");
+        sb.append(entryLine);
+      }
+      return sb.toString();
+    } catch (IOException ex) {
+      return String.format("Exception happened:%s", ex.getMessage());
+    }
+  }
+
+  @Override
+  @VisibleForTesting
+  public void stopHeartBeat(WorkerInfo worker) throws IOException {
+    WorkerServiceEntity entity = new WorkerServiceEntity(worker.getIdentity(), worker.getAddress());
+    mAlluxioEtcdClient.mServiceDiscovery.unregisterService(entity.getServiceEntityName());
+  }
+
+  @Override
+  public void decommission(WorkerInfo worker) throws IOException {
+    // NOOP since we only have active workers
+  }
+
+  @Override
+  public void close() throws Exception {
+    // NOTHING TO CLOSE
+    // The EtcdClient is a singleton so its life cycle is managed by the class itself
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

we count the runtime stats in the local cache manager, but we need to pass in the correct cache context

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
