### PR TITLE
Fix alluxio-fuse umount help message

### DIFF
--- a/dora/integration/fuse/bin/alluxio-fuse
+++ b/dora/integration/fuse/bin/alluxio-fuse
@@ -426,7 +426,7 @@ wait_for_fuse_process_killed() {
     else
       printf "\n"
       err  "Failed to kill fuse process [${fuse_pid}] after 60 seconds.
-Run \"alluxio-fuse umount -f mount_point\" if needed to forcibly kill the alluxio fuse process and fuse mount point. "
+Run \"alluxio-fuse umount mount_point -f\" if needed to forcibly kill the alluxio fuse process and fuse mount point. "
       return 1
     fi
     (( cnt += 1 ))


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix alluxio-fuse umount help message

### Why are the changes needed?

The current help message is misguiding. Please check the below case

```
$ ./dora/integration/fuse/bin/alluxio-fuse umount mnt
...
Terminating 3315520..........................................................
[2024-02-02T10:33:28+0800]: Failed to kill fuse process [3315520] after 60 seconds.
Run "alluxio-fuse umount -f mount_point" if needed to forcibly kill the alluxio fuse process and fuse mount point.

$ ./dora/integration/fuse/bin/alluxio-fuse umount -f mnt
basename: invalid option -- 'f'
Try 'basename --help' for more information.
```

putting "-f" after the mount_point parameter is ok

```
$ ./dora/integration/fuse/bin/alluxio-fuse umount mnt -f
Forcibly killed fuse process 3315520
```

### Does this PR introduce any user facing changes?

NO
