### PR TITLE
Support nullable offset and length in get page RESTful API

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpRequestUri.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpRequestUri.java
@@ -11,6 +11,7 @@
 
 package alluxio.worker.http;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,9 +29,9 @@ public class HttpRequestUri {
 
   private String mMappingPath;
 
-  private List<String> mRemainingFields;
+  private List<String> mRemainingFields = new ArrayList<>();
 
-  private Map<String, String> mParameters;
+  private Map<String, String> mParameters = new HashMap<>();
 
   private HttpRequestUri() {
   }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
@@ -217,10 +217,14 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
     FileRegion fileRegion;
     String offsetStr = httpRequestUri.getParameters().get("offset");
     String lengthStr = httpRequestUri.getParameters().get("length");
-    if (offsetStr != null && !offsetStr.isEmpty() && lengthStr != null && !lengthStr.isEmpty()) {
+    if (offsetStr != null && !offsetStr.isEmpty()) {
       long offset = Long.parseLong(offsetStr);
-      long length = Long.parseLong(lengthStr);
-      fileRegion = mPagedService.getPageFileRegion(fileId, pageIndex, offset, length);
+      if (lengthStr != null && !lengthStr.isEmpty()) {
+        long length = Long.parseLong(lengthStr);
+        fileRegion = mPagedService.getPageFileRegion(fileId, pageIndex, offset, length);
+      } else {
+        fileRegion = mPagedService.getPageFileRegion(fileId, pageIndex, offset);
+      }
     } else {
       fileRegion = mPagedService.getPageFileRegion(fileId, pageIndex);
     }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
@@ -111,5 +111,19 @@ public class PagedService {
     }
     return (FileRegion) dataFileChannel.get().getNettyOutput();
   }
+
+  /**
+   * Get {@link FileRegion} object given fileId, pageIndex, and channel.
+   *
+   * @param fileId    the file ID
+   * @param pageIndex the page index
+   * @param offset offset into the page
+   * @return the ByteBuf object that wraps page bytes
+   * @throws PageNotFoundException
+   */
+  public FileRegion getPageFileRegion(String fileId, long pageIndex, long offset)
+      throws PageNotFoundException {
+    return getPageFileRegion(fileId, pageIndex, offset, (int) (mPageSize - offset));
+  }
   // TODO(JiamingMai): do we need to implement a method for reading file directly?
 }

--- a/dora/core/server/worker/src/test/java/alluxio/worker/http/TestHttpRequestUtil.java
+++ b/dora/core/server/worker/src/test/java/alluxio/worker/http/TestHttpRequestUtil.java
@@ -32,6 +32,8 @@ public class TestHttpRequestUtil {
             + "91bdf08ba9e91218e30fe39503dd42e32c/page/0", false, -1L, -1L},
         {"http://127.0.0.1:28080/v1/file/5f2829f08879b0e89d07174cffa8d8"
             + "91bdf08ba9e91218e30fe39503dd42e32c/page/0?offset=5&length=7", true, 5L, 7L},
+        {"http://127.0.0.1:28080/v1/file/5f2829f08879b0e89d07174cffa8d8"
+            + "91bdf08ba9e91218e30fe39503dd42e32c/page/0?offset=6", true, 6L, -1L},
     });
   }
 
@@ -64,14 +66,18 @@ public class TestHttpRequestUtil {
     Assert.assertEquals("0", httpRequestUri.getRemainingFields().get(2));
 
     boolean hasParametersMap = false;
-    if (httpRequestUri.getParameters() != null) {
+    if (!httpRequestUri.getParameters().isEmpty()) {
       hasParametersMap = true;
     }
     Assert.assertEquals(mHasParametersMap, hasParametersMap);
 
     if (mHasParametersMap) {
-      Assert.assertEquals(mOffset, Long.parseLong(httpRequestUri.getParameters().get("offset")));
-      Assert.assertEquals(mLength, Long.parseLong(httpRequestUri.getParameters().get("length")));
+      if (httpRequestUri.getParameters().get("offset") != null) {
+        Assert.assertEquals(mOffset, Long.parseLong(httpRequestUri.getParameters().get("offset")));
+      }
+      if (httpRequestUri.getParameters().get("length") != null) {
+        Assert.assertEquals(mLength, Long.parseLong(httpRequestUri.getParameters().get("length")));
+      }
     }
   }
 


### PR DESCRIPTION
Fix the bug that the get page RESTful API doesn't support nullable offset and length.