### PR TITLE
Add Regex support to direct access

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -73,7 +73,6 @@ import alluxio.resource.CloseableResource;
 import alluxio.security.authorization.AclEntry;
 import alluxio.uri.Authority;
 import alluxio.util.FileSystemOptionsUtils;
-import alluxio.util.io.PathUtils;
 import alluxio.wire.BlockLocation;
 import alluxio.wire.BlockLocationInfo;
 import alluxio.wire.FileBlockInfo;

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -174,9 +174,11 @@ public class BaseFileSystem implements FileSystem {
     if (!getConf().isSet(PropertyKey.USER_FILE_DIRECT_ACCESS)) {
       return false;
     }
-    mPathRegex.compareAndSet(null,
-        Pattern.compile(
-        getConf().getString(PropertyKey.USER_FILE_DIRECT_ACCESS)).matcher(""));
+    if (mPathRegex.get() == null) {
+      mPathRegex.compareAndSet(null,
+          Pattern.compile(
+              getConf().getString(PropertyKey.USER_FILE_DIRECT_ACCESS)).matcher(""));
+    }
     return mPathRegex.get().reset(uri.getPath()).matches();
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -96,7 +96,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -94,6 +94,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -113,7 +116,7 @@ public class BaseFileSystem implements FileSystem {
   private final Closer mCloser = Closer.create();
   protected final FileSystemContext mFsContext;
   protected final BlockStoreClient mBlockStore;
-  protected String mPathRegex;
+  protected Matcher mPathRegex;
 
   protected volatile boolean mClosed = false;
 
@@ -172,9 +175,10 @@ public class BaseFileSystem implements FileSystem {
       return false;
     }
     if (mPathRegex == null) {
-      mPathRegex = getConf().getString(PropertyKey.USER_FILE_DIRECT_ACCESS);
+      mPathRegex = Pattern.compile(
+          getConf().getString(PropertyKey.USER_FILE_DIRECT_ACCESS)).matcher("");
     }
-    return uri.getPath().matches(mPathRegex);
+    return mPathRegex.reset(uri.getPath()).matches();
   }
 
   private AlluxioConfiguration getDirectAccessConf(AlluxioURI uri) {

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -114,7 +114,7 @@ public class BaseFileSystem implements FileSystem {
   private final Closer mCloser = Closer.create();
   protected final FileSystemContext mFsContext;
   protected final BlockStoreClient mBlockStore;
-  protected List<String> mPathList;
+  protected String mPathRegex;
 
   protected volatile boolean mClosed = false;
 
@@ -172,16 +172,10 @@ public class BaseFileSystem implements FileSystem {
     if (!getConf().isSet(PropertyKey.USER_FILE_DIRECT_ACCESS)) {
       return false;
     }
-    if (mPathList == null) {
-      mPathList = getConf().getList(PropertyKey.USER_FILE_DIRECT_ACCESS);
+    if (mPathRegex == null) {
+      mPathRegex = getConf().getString(PropertyKey.USER_FILE_DIRECT_ACCESS);
     }
-    return mPathList.stream().anyMatch(x -> {
-      try {
-        return PathUtils.hasPrefix(uri.getPath(), x);
-      } catch (InvalidPathException e) {
-        return false;
-      }
-    });
+    return uri.getPath().matches(mPathRegex);
   }
 
   private AlluxioConfiguration getDirectAccessConf(AlluxioURI uri) {

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5835,7 +5835,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_FILE_DIRECT_ACCESS =
       listBuilder(Name.USER_FILE_DIRECT_ACCESS)
-          .setDescription("A list of Alluxio paths that are not read or write cached and "
+          .setDescription("A regular expression to define Alluxio paths that are not read"
+              + " or write cached and "
               + "always fetches from the ufs for the latest listing")
           .setScope(Scope.CLIENT)
           .build();

--- a/tests/src/test/java/alluxio/client/fs/DirectAccessIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/DirectAccessIntegrationTest.java
@@ -38,13 +38,14 @@ public class DirectAccessIntegrationTest extends BaseIntegrationTest {
   private static final byte[] TEST_BYTES = "TestBytes".getBytes();
   private static final int USER_QUOTA_UNIT_BYTES = 1000;
   private static final String DIRECT_DIR = "/mnt/direct/";
+  private static final String DIRECT_DIR_REGEX = ".?/mnt/direct/.?";
   private static final String NON_DIRECT_DIR = "/mnt/non_direct/";
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, USER_QUOTA_UNIT_BYTES)
-          .setProperty(PropertyKey.USER_FILE_DIRECT_ACCESS, DIRECT_DIR)
+          .setProperty(PropertyKey.USER_FILE_DIRECT_ACCESS, DIRECT_DIR_REGEX)
           .build();
   private FileSystem mFileSystem;
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Previously direct access is a list of paths, and makes it very difficult to specify. 

### Why are the changes needed?
Ease of use

### Does this PR introduce any user facing changes?

alluxio.user.file.direct.access is now a regex indicating the paths that should be direct access
