### PR TITLE
Fix NPE during DelegatingBlockReader initialization with debug logging

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
@@ -76,6 +76,9 @@ public class DelegatingBlockReader extends BlockReader {
 
   @Override
   public String toString() {
+    if (mBlockReader == null) {
+      return "DelegatingBlockReader not fully initialized.";
+    }
     return mBlockReader.toString();
   }
 


### PR DESCRIPTION
…during the initialization of DelegatingBlockReader with debug log level enabled

### What changes are proposed in this pull request?

This PR updates the toString method in DelegatingBlockReader to prevent a NullPointerException when logging at debug level before mBlockReader is initialized. It adds a null check for mBlockReader and returns a descriptive message if it is null.

### Why are the changes needed?

The changes are necessary to fix a bug that leads to a NullPointerException during the debug-level logging of the DelegatingBlockReader initialization process.

  1. Prevents NPE in Debug Logging: By adding a null check before accessing mBlockReader.toString(), this PR prevents the NPE that previously occurred during debug logging when mBlockReader was not fully initialized.
  2. Enhances Logging Clarity: The PR ensures that logging during the initialization phase of DelegatingBlockReader provides clear and accurate information, which is crucial for effective debugging and monitoring.

### Does this PR introduce any user facing changes?

  1. No change in user-facing APIs: This PR does not modify any APIs that are exposed to the end-users.
  2. No addition or removal of property keys: There are no changes to the configuration properties as part of this PR.
  3. No changes to the WebUI: This PR does not involve any modifications to the WebUI.
