### PR TITLE
Fix etcd calls exception handling and adjust failure detection timeout

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -878,17 +878,22 @@ public class FileSystemContext implements Closeable {
     synchronized (mCachedWorkerClusterView) {
       if (mCachedWorkerClusterView.get() == null || mCachedWorkerClusterView.get().isEmpty()
           || mWorkerRefreshPolicy.attempt()) {
-        switch (type) {
-          case ALL:
-            mCachedWorkerClusterView.set(getAllWorkers());
-            break;
-          case LIVE:
-            mCachedWorkerClusterView.set(getLiveWorkers());
-            break;
-          case LOST:
-            mCachedWorkerClusterView.set(getLostWorkers());
-            break;
-          default:
+        try {
+          switch (type) {
+            case ALL:
+              mCachedWorkerClusterView.set(getAllWorkers());
+              break;
+            case LIVE:
+              mCachedWorkerClusterView.set(getLiveWorkers());
+              break;
+            case LOST:
+              mCachedWorkerClusterView.set(getLostWorkers());
+              break;
+            default:
+          }
+        } catch (Throwable th) {
+          LOG.warn("Got exception while trying to refresh {} worker list, ex:{},"
+              + " using the last updated worker cluster view.", type, th.getMessage());
         }
       }
       return mCachedWorkerClusterView.get();

--- a/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/dora/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4842,6 +4842,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.ALL)
           .build();
+  public static final PropertyKey WORKER_FAILURE_DETECTION_TIMEOUT =
+      durationBuilder(Name.WORKER_FAILURE_DETECTION_TIMEOUT)
+          .setDefaultValue("2min")
+          .setDescription("The timeout to consider a worker failure in membership"
+              + " failure detection.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.ALL)
+          .build();
   public static final PropertyKey WORKER_STATIC_MEMBERSHIP_MANAGER_CONFIG_FILE =
       stringBuilder(Name.WORKER_STATIC_MEMBERSHIP_MANAGER_CONFIG_FILE)
           .setDefaultValue(format("${%s}/workers", Name.CONF_DIR))
@@ -8211,6 +8219,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.ufs.instream.cache.max.size";
     public static final String WORKER_MEMBERSHIP_MANAGER_TYPE =
         "alluxio.worker.membership.manager.type";
+    public static final String WORKER_FAILURE_DETECTION_TIMEOUT =
+        "alluxio.worker.failure.detection.timeout";
     public static final String WORKER_STATIC_MEMBERSHIP_MANAGER_CONFIG_FILE =
         "alluxio.worker.static.membership.manager.config.file";
 

--- a/dora/core/common/src/main/java/alluxio/membership/AlluxioEtcdClient.java
+++ b/dora/core/common/src/main/java/alluxio/membership/AlluxioEtcdClient.java
@@ -80,11 +80,11 @@ public class AlluxioEtcdClient {
   private static final Logger LOG = LoggerFactory.getLogger(AlluxioEtcdClient.class);
   private static final Lock INSTANCE_LOCK = new ReentrantLock();
   public static final String BASE_PATH = "/ServiceDiscovery";
-  public static final long DEFAULT_LEASE_TTL_IN_SEC = 2L;
-  public static final long DEFAULT_TIMEOUT_IN_SEC = 2L;
-  public static final int RETRY_TIMES = 3;
-  private static final int RETRY_SLEEP_IN_MS = 100;
-  private static final int MAX_RETRY_SLEEP_IN_MS = 500;
+  public static final long DEFAULT_LEASE_TTL_IN_SEC = 5L;
+  public static final long DEFAULT_TIMEOUT_IN_SEC = 5L;
+  public static final int RETRY_TIMES = 5;
+  private static final int RETRY_SLEEP_IN_MS = 500;
+  private static final int MAX_RETRY_SLEEP_IN_MS = 5000;
   @GuardedBy("INSTANCE_LOCK")
   @Nullable
   private static volatile AlluxioEtcdClient sAlluxioEtcdClient;

--- a/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/EtcdMembershipManager.java
@@ -99,6 +99,8 @@ public class EtcdMembershipManager implements MembershipManager {
     LOG.info("Try joining on etcd for worker:{} ", workerInfo);
     WorkerServiceEntity entity =
         new WorkerServiceEntity(workerInfo.getIdentity(), workerInfo.getAddress());
+    entity.setLeaseTTLInSec(
+        mConf.getDuration(PropertyKey.WORKER_FAILURE_DETECTION_TIMEOUT).getSeconds());
     String pathOnRing = new StringBuffer()
         .append(getRingPathPrefix())
         .append(entity.getServiceEntityName()).toString();

--- a/dora/core/common/src/main/java/alluxio/membership/ServiceDiscoveryRecipe.java
+++ b/dora/core/common/src/main/java/alluxio/membership/ServiceDiscoveryRecipe.java
@@ -123,16 +123,6 @@ public class ServiceDiscoveryRecipe implements AutoCloseable {
         if (!txnResponse.isSucceeded()) {
           throw new IOException("Failed to new a lease for service:" + service.toString());
         }
-        // revoke old lease if there's any
-        if (oldLease != null) {
-          try {
-            LOG.info("Try revoking previous lease:{} to ServiceRegistry key:{}",
-                      service.getLease(), keyToPut);
-            mAlluxioEtcdClient.revokeLease(oldLease);
-          } catch (Throwable th) {
-            // best-of-effort to revoke, silence all exceptions.
-          }
-        }
         Preconditions.checkState(!kvs.isEmpty(), "No such service entry found.");
         long latestRevision = kvs.stream().mapToLong(kv -> kv.getModRevision())
             .max().getAsLong();

--- a/dora/core/common/src/main/java/alluxio/membership/ServiceRegistryMembershipManager.java
+++ b/dora/core/common/src/main/java/alluxio/membership/ServiceRegistryMembershipManager.java
@@ -12,6 +12,7 @@
 package alluxio.membership;
 
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerState;
 
@@ -32,7 +33,7 @@ import java.util.stream.Stream;
  */
 public class ServiceRegistryMembershipManager implements MembershipManager {
   private static final Logger LOG = LoggerFactory.getLogger(ServiceRegistryMembershipManager.class);
-
+  private final AlluxioConfiguration mConf;
   private AlluxioEtcdClient mAlluxioEtcdClient;
 
   /**
@@ -60,6 +61,7 @@ public class ServiceRegistryMembershipManager implements MembershipManager {
    */
   public ServiceRegistryMembershipManager(AlluxioConfiguration conf,
       AlluxioEtcdClient alluxioEtcdClient) {
+    mConf = conf;
     mAlluxioEtcdClient = alluxioEtcdClient;
   }
 
@@ -68,6 +70,8 @@ public class ServiceRegistryMembershipManager implements MembershipManager {
     LOG.info("Try joining Service Registry for worker:{} ", workerInfo);
     WorkerServiceEntity entity =
         new WorkerServiceEntity(workerInfo.getIdentity(), workerInfo.getAddress());
+    entity.setLeaseTTLInSec(
+        mConf.getDuration(PropertyKey.WORKER_FAILURE_DETECTION_TIMEOUT).getSeconds());
     mAlluxioEtcdClient.mServiceDiscovery.registerAndStartSync(entity);
     LOG.info("register to service registry for worker:{} ", workerInfo);
   }

--- a/dora/tests/testcontainers/src/test/java/alluxio/membership/MembershipManagerTest.java
+++ b/dora/tests/testcontainers/src/test/java/alluxio/membership/MembershipManagerTest.java
@@ -74,7 +74,7 @@ public class MembershipManagerTest {
   /*
   @BeforeClass
   public static void init() {
-    PropertyConfigurator.configure("/Users/lucyge/Documents/github/alluxio/conf/log4j.properties");
+    PropertyConfigurator.configure("<path_to_alluxio>/conf/log4j.properties");
     Properties props = new Properties();
     props.setProperty(PropertyKey.LOGGER_TYPE.toString(), "Console");
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?
1. catch all exception thrown by fetch worker cluster view from etcd …when refresh the workers view instead of propagate throwing all the way to the caller
2. make worker failure detection timeout (the timeout to determine if a worker is in FAILED state) configurable thru setting the service discovery entity's lease ttl
3. make newLeaseInternal always overwrite the key with the newly created lease

### Why are the changes needed?

To resolve:
1) currently worker is considered down only 2sec after its disconnection with etcd, its too small, make the failure detection timeout configurable for registered service discovery services.
2) etcd unavaible runtime exception will be propagated to caller which is non-ideal, currently capture at FileSystemContext.getCachedWorkers layer to prevent propagating to IO layer, causing an unnecessary ufs fallback such as cold read.

### Does this PR introduce any user facing changes?

No
