### PR TITLE
Add a sleep during every scan round to avoid dead loop.

### DIFF
--- a/dora/core/common/src/main/java/alluxio/collections/LockPool.java
+++ b/dora/core/common/src/main/java/alluxio/collections/LockPool.java
@@ -158,6 +158,7 @@ public class LockPool<K> implements Closeable {
           if (!mIterator.hasNext()) {
             mIterator = mPool.entrySet().iterator();
             roundToScan--;
+            mOverHighWatermark.await(EVICTION_MAX_AWAIT_TIME, TimeUnit.MILLISECONDS);
           }
           Map.Entry<K, Resource> candidateMapEntry = mIterator.next();
           Resource candidate = candidateMapEntry.getValue();


### PR DESCRIPTION
### What changes are proposed in this pull request?
For big data tasks (eg, spark), might write a lot of files in the final stage. In that case, there will be a lot of write edge locks, which would trigger lockpool evict. All the locks have refcounts greater than 0, which means the locks cannot be evicted during that scan, and the lock pool size will keep what it is. There is no pause during each scan, and a dead loop accour. The server load grows up, and Alluxio master cannot offer service. So we add a wait during each scan to avoid this.

* The following pic shows where dead loop occurs.
![image](https://github.com/Alluxio/alluxio/assets/11374717/fc2c341a-3442-486d-b48c-941730d78b19)
* The following pic shows server load grows very high.
![image](https://github.com/Alluxio/alluxio/assets/11374717/2ea2b13b-531a-49b6-aeb9-4f8331dd7cc6)
* The jstack for Alluxio Master. (The nid matches java thread id.)
![image](https://github.com/Alluxio/alluxio/assets/11374717/4805e52d-057d-45e2-944d-127c4abec85d)


