### PR TITLE
Fix error code of ENOTSUP

### DIFF
--- a/dora/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/ErrorCodes.java
+++ b/dora/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/ErrorCodes.java
@@ -942,7 +942,7 @@ public class ErrorCodes {
    * The file system does not support extended attributes or has the feature disabled
    */
   public static int ENOTSUP() {
-    return 45;
+    return Errno.EOPNOTSUPP.intValue();
   }
 
   private ErrorCodes() {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix error code of ENOTSUP.

### Why are the changes needed?
The value `45` is for `EL2NSYNC`. `Errno.EOPNOTSUPP` can also be used for `ENOTSUP`([doc](https://chromium.googlesource.com/chromiumos/docs/+/master/constants/errnos.md)).

