### PR TITLE
Add position read supports for s3 proxy

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5570,6 +5570,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.SERVER)
 
           .build();
+  public static final PropertyKey PROXY_S3_USE_POSITION_READ_RANGE_SIZE =
+      dataSizeBuilder(Name.PROXY_S3_USE_POSITION_READ_RANGE_SIZE)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setDescription("When the requested range length is less than this value, "
+              + "the S3 proxy will use 'positionRead' to read data from the worker. "
+              + "Setting a value less than or equal to 0 indicates disabling this feature.")
+          .setDefaultValue("1MB")
+          .setScope(Scope.SERVER)
+          .build();
 
   //
   // Locality related properties
@@ -8814,6 +8823,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.proxy.s3.global.read.rate.limit.mb";
     public static final String PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB =
         "alluxio.proxy.s3.single.connection.read.rate.limit.mb";
+    public static final String PROXY_S3_USE_POSITION_READ_RANGE_SIZE =
+        "alluxio.proxy.s3.use.position.read.range.size";
 
     //
     // Locality related properties

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5576,7 +5576,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("When the requested range length is less than this value, "
               + "the S3 proxy will use 'positionRead' to read data from the worker. "
               + "Setting a value less than or equal to 0 indicates disabling this feature.")
-          .setDefaultValue("1MB")
+          .setDefaultValue(0)
           .setScope(Scope.SERVER)
           .build();
 

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5575,7 +5575,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setDescription("When the requested range length is less than this value, "
               + "the S3 proxy will use 'positionRead' to read data from the worker. "
-              + "Setting a value less than or equal to 0 indicates disabling this feature.")
+              + "Setting a value less than or equal to 0 indicates disabling this feature. "
+              + "In the current implementation, each request for a position read uses "
+              + "a byte array of the same size as the range to temporarily store data, "
+              + "which consumes additional memory. "
+              + "Therefore, in practical use, we limit this value to 4MB. "
+              + "This means that if a value exceeding 4MB is configured, "
+              + "it will be modified to 4MB.")
           .setDefaultValue(0)
           .setScope(Scope.SERVER)
           .build();

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Handler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Handler.java
@@ -90,6 +90,7 @@ public class S3Handler {
   private static final Logger LOG = LoggerFactory.getLogger(S3Handler.class);
   private static final ThreadLocal<byte[]> TLS_BYTES =
           ThreadLocal.withInitial(() -> new byte[8 * 1024]);
+  // Position read will consume additional memory, so here we limit the maximum memory usage.
   private static final int MAX_POSITION_READ_LENGTH = 4 * Constants.MB;
   public static final int USE_POSITION_READ_SIZE = (int) Math.min(MAX_POSITION_READ_LENGTH,
       Configuration.getBytes(PropertyKey.PROXY_S3_USE_POSITION_READ_RANGE_SIZE));

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Handler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Handler.java
@@ -12,6 +12,7 @@
 package alluxio.proxy.s3;
 
 import alluxio.AlluxioURI;
+import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
@@ -89,6 +90,9 @@ public class S3Handler {
   private static final Logger LOG = LoggerFactory.getLogger(S3Handler.class);
   private static final ThreadLocal<byte[]> TLS_BYTES =
           ThreadLocal.withInitial(() -> new byte[8 * 1024]);
+  private static final int MAX_POSITION_READ_LENGTH = 4 * Constants.MB;
+  public static final int USE_POSITION_READ_SIZE = (int) Math.min(MAX_POSITION_READ_LENGTH,
+      Configuration.getBytes(PropertyKey.PROXY_S3_USE_POSITION_READ_RANGE_SIZE));
   private final String mBucket;
   private final String mObject;
   private final HttpServletRequest mServletRequest;

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ObjectTask.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ObjectTask.java
@@ -56,6 +56,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -316,19 +317,25 @@ public class S3ObjectTask extends S3BaseTask {
             URIStatus status = userFs.getStatus(objectUri);
             FileInStream is = userFs.openFile(status, OpenFilePOptions.getDefaultInstance());
             S3RangeSpec s3Range = S3RangeSpec.Factory.create(range);
-            RangeFileInStream ris = RangeFileInStream.Factory.create(
-                is, status.getLength(), s3Range);
-
-            InputStream inputStream;
+            InputStream inputStream = null;
+            long read = s3Range.getLength(status.getLength());
+            if (read < S3Handler.USE_POSITION_READ_SIZE) {
+              byte[] bytes = new byte[(int) read];
+              is.positionedRead(s3Range.getOffset(status.getLength()), bytes, 0, bytes.length);
+              is.close();
+              inputStream = new ByteArrayInputStream(bytes);
+            }
+            if (inputStream == null) {
+              inputStream = RangeFileInStream.Factory.create(is, status.getLength(), s3Range);
+            }
             RateLimiter globalRateLimiter = (RateLimiter) mHandler.getServletContext()
                 .getAttribute(ProxyWebServer.GLOBAL_RATE_LIMITER_SERVLET_RESOURCE_KEY);
             long rate = (long) mHandler.getMetaFS().getConf()
                 .getInt(PropertyKey.PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB) * Constants.MB;
             RateLimiter currentRateLimiter = S3RestUtils.createRateLimiter(rate).orElse(null);
-            if (currentRateLimiter == null && globalRateLimiter == null) {
-              inputStream = ris;
-            } else {
-              inputStream = new RateLimitInputStream(ris, globalRateLimiter, currentRateLimiter);
+            if (currentRateLimiter != null || globalRateLimiter != null) {
+              inputStream =
+                  new RateLimitInputStream(inputStream, globalRateLimiter, currentRateLimiter);
             }
 
             Response.ResponseBuilder res = Response.ok(inputStream,


### PR DESCRIPTION
### What changes are proposed in this pull request?

When requesting a smaller range from the S3 proxy, support the S3 proxy in using the position read API to request data from the worker.
add a new property:
```
alluxio.proxy.s3.use.position.read.range.size
```


### Why are the changes needed?

Using position read can effectively solve the issue of reading amplification.

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API. no
  2. If you fix a bug, describe the bug. no

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs no
  2. addition or removal of property keys yes
  3. webui no
