### PR TITLE
Remove noisy logging in InstanceMetadataServiceResourceFetcher

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -198,6 +198,7 @@ log4j.appender.FUSE_LOGGER.layout=org.apache.log4j.PatternLayout
 log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Disable noisy DEBUG logs
+log4j.logger.com.amazonaws.internal.InstanceMetadataServiceResourceFetcher=OFF
 log4j.logger.com.amazonaws.util.EC2MetadataUtils=OFF
 log4j.logger.io.grpc.netty.NettyServerHandler=OFF
 


### PR DESCRIPTION
Removes log entries such as `2024-02-13 17:07:02,337 WARN  InstanceMetadataServiceResourceFetcher - Fail to retrieve token` in a similar fashion as https://github.com/Alluxio/alluxio/pull/13736