### PR TITLE
Update the logic of Alluxio clearing expired metadata

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
@@ -96,7 +96,8 @@ public class RocksDBDoraMetaStore implements DoraMetaStore {
     columns.add(new ColumnFamilyDescriptor(DORA_META_FILE_STATUS_COLUMN.getBytes(),
             new ColumnFamilyOptions()
                     .setMemTableConfig(new HashLinkedListMemTableConfig())
-                    .setCompressionType(CompressionType.NO_COMPRESSION)));
+                    .setCompressionType(CompressionType.NO_COMPRESSION)
+                    .setTtl(metaTTL)));
     mToClose.addAll(columns.stream().map(
             ColumnFamilyDescriptor::getOptions).collect(Collectors.toList()));
 
@@ -132,13 +133,6 @@ public class RocksDBDoraMetaStore implements DoraMetaStore {
     }
     try {
       DoraMeta.FileStatus fs = DoraMeta.FileStatus.parseFrom(status);
-      if (mMetaTTL != -1) {
-        if (System.nanoTime() - fs.getTs() > mMetaTTL * Constants.SECOND_NANO) {
-          // The Metadata is out of date.
-          removeDoraMeta(path);
-          return Optional.empty();
-        }
-      }
       return Optional.of(fs);
     } catch (Exception e) {
       removeDoraMeta(path);

--- a/dora/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.dora;
 
-import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.master.metastore.rocks.RocksExclusiveLockHandle;
 import alluxio.master.metastore.rocks.RocksSharedLockHandle;

--- a/dora/core/server/worker/src/test/java/alluxio/worker/dora/RocksDBDoraMetaStoreTest.java
+++ b/dora/core/server/worker/src/test/java/alluxio/worker/dora/RocksDBDoraMetaStoreTest.java
@@ -50,7 +50,6 @@ public class RocksDBDoraMetaStoreTest extends TestCase {
     assert (res.isPresent());
     assert (res.get().equals(fs));
     System.out.println(res);
-
     mTestMetastore.removeDoraMeta(path);
     Optional<DoraMeta.FileStatus> res2 = mTestMetastore.getDoraMeta(path);
     assert (!res2.isPresent());

--- a/dora/core/server/worker/src/test/java/alluxio/worker/dora/RocksDBDoraMetaStoreTest.java
+++ b/dora/core/server/worker/src/test/java/alluxio/worker/dora/RocksDBDoraMetaStoreTest.java
@@ -13,7 +13,6 @@ package alluxio.worker.dora;
 
 import alluxio.grpc.FileInfo;
 import alluxio.proto.meta.DoraMeta;
-import alluxio.util.CommonUtils;
 
 import junit.framework.TestCase;
 
@@ -88,34 +87,6 @@ public class RocksDBDoraMetaStoreTest extends TestCase {
     mTestMetastore.removeDoraMeta(pathNotExist);
 
     System.out.println("End testRemoveNotExist");
-  }
-
-  public void testGetExpire() {
-    System.out.println("Start testGetExpire");
-
-    String path = new String("/SOME/PATH/FILE");
-    FileInfo fi = FileInfo.newBuilder()
-        .setFileId(1234)
-        .setMode(0567)
-        .setLength(1000)
-        .build();
-    DoraMeta.FileStatus fs = DoraMeta.FileStatus.newBuilder()
-        .setFileInfo(fi)
-        .setTs(System.nanoTime())
-        .build();
-    mTestMetastore.putDoraMeta(path, fs);
-
-    Optional<DoraMeta.FileStatus> res2 = mTestMetastore.getDoraMeta(path);
-    assert (res2.isPresent());
-
-    // Sleep 5 seconds
-    CommonUtils.sleepMs(5 * 1000);
-
-    // The TTL of this MetaStore is configured to be 3 seconds. So the Metadata should have expired.
-    Optional<DoraMeta.FileStatus> res3 = mTestMetastore.getDoraMeta(path);
-    assert (!res3.isPresent());
-
-    System.out.println("End testGetExpire");
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Modified the logic of Alluxio clearing expired metadata.
The expiration time of RocksDB is set so that expired metadata can be cleared in time every time RocksDB performs a compaction operation.

### Why are the changes needed?

Alluxio has a problem that expired metadata cannot be cleared in time, which may lead to insufficient disk space in the long run.
We have modified the logic for clearing expired metadata to ensure that if the user sets an appropriate metadata expiration time, the disk will not continue to accumulate metadata that cannot be cleared.

### Does this PR introduce any user facing changes?

None
