### PR TITLE
Allow MetricAccountingBlockReader to accept any BlockReader

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/io/MetricAccountingBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/io/MetricAccountingBlockReader.java
@@ -24,13 +24,13 @@ import java.nio.channels.ReadableByteChannel;
  * An reader class with metrics.
  */
 public class MetricAccountingBlockReader extends BlockReader {
-  private final LocalFileBlockReader mBlockReader;
+  private final BlockReader mBlockReader;
 
   /**
    * A decorator of BlockReader.
    * @param mblockReader block reader
    */
-  public MetricAccountingBlockReader(LocalFileBlockReader mblockReader) {
+  public MetricAccountingBlockReader(BlockReader mblockReader) {
     mBlockReader = mblockReader;
   }
 


### PR DESCRIPTION
generalize the constructor input of MetricAccountingBlockReader to count metrics for any implementation of BlockReader