### PR TITLE
Add Failed to read from page store cache bytes

### DIFF
--- a/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -232,6 +232,10 @@ public class LocalCacheManager implements CacheManager {
             pageId, pageOffset);
         Metrics.GET_ERRORS.inc();
         Metrics.GET_STORE_READ_ERRORS.inc();
+        MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE_ERROR.getName())
+            .mark(bytesToRead);
+        cacheContext.incrementCounter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE_ERROR.getMetricName(),
+            BYTE, bytesToRead);
         // something is wrong to read this page, let's remove it from meta store
         try (LockResource r2 = new LockResource(mPageMetaStore.getLock().writeLock())) {
           mPageMetaStore.removePage(pageId);

--- a/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -2230,6 +2230,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_BYTES_READ_CACHE_ERROR =
+      new Builder("Client.CacheBytesReadCacheError")
+          .setDescription("Total number of bytes failed to read from the client cache.")
+          .setMetricType(MetricType.METER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_BYTES_READ_IN_STREAM_BUFFER =
       new Builder("Client.CacheBytesReadInStreamBuffer")
           .setDescription("Total number of bytes read from the client cache's in stream buffer.")


### PR DESCRIPTION
### What changes are proposed in this pull request?

RESTful API directly read data from Page Store, we already record the read successful bytes, add the read bytes failure.

### Why are the changes needed?

This is helpful for inducting the cache hit bytes ratio for requests coming from RESTful API.

### Does this PR introduce any user facing changes?

Yes, add a metric