### PR TITLE
Add http getPage cache hit ratio

### DIFF
--- a/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/dora/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -2178,6 +2178,25 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("Total number of GetFileInfo read from external storage.")
           .setMetricType(MetricType.COUNTER)
           .build();
+  public static final MetricKey WORKER_HTTP_CACHE_HIT_RATE =
+      new Builder("Worker.HttpCacheHitRate")
+          .setDescription("Cache hit rate: (# bytes read from cache) / (# bytes requested) "
+              + "from worker http server.")
+          .setMetricType(MetricType.GAUGE)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey WORKER_HTTP_BYTES_READ_CACHE =
+      new Builder("Worker.HttpBytesReadCache")
+          .setDescription("Total number of bytes read from the worker cache from http server.")
+          .setMetricType(MetricType.METER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey WORKER_HTTP_BYTES_REQUESTED =
+      new Builder("Worker.HttpBytesReadRequested")
+          .setDescription("Total number of bytes read requested from http server.")
+          .setMetricType(MetricType.METER)
+          .setIsClusterAggregated(false)
+          .build();
 
   // Client metrics
   public static final MetricKey CLIENT_BLOCK_READ_CHUNK_REMOTE =

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/HttpServerHandler.java
@@ -28,6 +28,8 @@ import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.PageNotFoundException;
 import alluxio.grpc.ListStatusPOptions;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.util.FileSystemOptionsUtils;
 import alluxio.worker.http.vo.WritePageResponseVO;
 
@@ -217,18 +219,19 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
     FileRegion fileRegion;
     String offsetStr = httpRequestUri.getParameters().get("offset");
     String lengthStr = httpRequestUri.getParameters().get("length");
+    long offset = 0;
+    long length = mPagedService.getPageSize();
     if (offsetStr != null && !offsetStr.isEmpty()) {
-      long offset = Long.parseLong(offsetStr);
+      offset = Long.parseLong(offsetStr);
       if (lengthStr != null && !lengthStr.isEmpty()) {
-        long length = Long.parseLong(lengthStr);
-        fileRegion = mPagedService.getPageFileRegion(fileId, pageIndex, offset, length);
+        length = Long.parseLong(lengthStr);
       } else {
-        fileRegion = mPagedService.getPageFileRegion(fileId, pageIndex, offset);
+        length -= offset;
       }
-    } else {
-      fileRegion = mPagedService.getPageFileRegion(fileId, pageIndex);
     }
-
+    MetricsSystem.meter(MetricKey.WORKER_HTTP_BYTES_REQUESTED.getName()).mark(length);
+    fileRegion = mPagedService.getPageFileRegion(fileId, pageIndex, offset, length);
+    MetricsSystem.meter(MetricKey.WORKER_HTTP_BYTES_READ_CACHE.getName()).mark(length);
     HttpResponse response = new DefaultHttpResponse(httpRequest.protocolVersion(), OK);
     HttpResponseContext httpResponseContext = new HttpResponseContext(response, fileRegion);
     response.headers()
@@ -365,5 +368,24 @@ public class HttpServerHandler extends SimpleChannelInboundHandler<HttpObject> {
     super.handlerRemoved(ctx);
     mFileSystem.close();
     mFileSystemContext.close();
+  }
+
+  private static final class Metrics {
+    // Note that only counter/guage can be added here.
+    // Both meter and timer need to be used inline
+    // because new meter and timer will be created after {@link MetricsSystem.resetAllMetrics()}
+
+    private static void registerGauges() {
+      // Cache hit rate = Cache hits / (Cache hits + Cache misses).
+      MetricsSystem.registerGaugeIfAbsent(
+          MetricsSystem.getMetricName(MetricKey.WORKER_HTTP_CACHE_HIT_RATE.getName()),
+          () -> {
+            long cacheHits = MetricsSystem.meter(
+                MetricKey.WORKER_HTTP_BYTES_READ_CACHE.getName()).getCount();
+            long total = MetricsSystem.meter(
+                MetricKey.WORKER_HTTP_BYTES_REQUESTED.getName()).getCount();
+            return cacheHits / (1.0 * total);
+          });
+    }
   }
 }

--- a/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/http/PagedService.java
@@ -82,19 +82,6 @@ public class PagedService {
    *
    * @param fileId    the file ID
    * @param pageIndex the page index
-   * @return the ByteBuf object that wraps page bytes
-   * @throws PageNotFoundException
-   */
-  public FileRegion getPageFileRegion(String fileId, long pageIndex)
-      throws PageNotFoundException {
-    return getPageFileRegion(fileId, pageIndex, 0, (int) mPageSize);
-  }
-
-  /**
-   * Get {@link FileRegion} object given fileId, pageIndex, and channel.
-   *
-   * @param fileId    the file ID
-   * @param pageIndex the page index
    * @param offset offset into the page
    * @param length number of bytes to read in this page
    * @return the ByteBuf object that wraps page bytes
@@ -113,17 +100,9 @@ public class PagedService {
   }
 
   /**
-   * Get {@link FileRegion} object given fileId, pageIndex, and channel.
-   *
-   * @param fileId    the file ID
-   * @param pageIndex the page index
-   * @param offset offset into the page
-   * @return the ByteBuf object that wraps page bytes
-   * @throws PageNotFoundException
+   * @return page size
    */
-  public FileRegion getPageFileRegion(String fileId, long pageIndex, long offset)
-      throws PageNotFoundException {
-    return getPageFileRegion(fileId, pageIndex, offset, (int) (mPageSize - offset));
+  public long getPageSize() {
+    return mPageSize;
   }
-  // TODO(JiamingMai): do we need to implement a method for reading file directly?
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add HTTP getPage cache hit ratio. This is used for mimicing how much data read from alluxio cache and how much data possibly fallback to UFS given that no that much user get metrics from alluxiofs client.

### Why are the changes needed?

To get cache hit ratio of worker http server get page

### Does this PR introduce any user facing changes?

Yes, add some metrics
