### PR TITLE
Return 404 when head the file end with slash

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -1164,6 +1164,8 @@ public final class S3RestServiceHandler {
           URIStatus status = userFs.getStatus(objectUri);
           if (status.isFolder() && !object.endsWith(AlluxioURI.SEPARATOR)) {
             throw new FileDoesNotExistException(status.getPath() + " is a directory");
+          } else if (!status.isFolder() && object.endsWith(AlluxioURI.SEPARATOR)) {
+            throw new FileDoesNotExistException(status.getPath() + " is a file");
           }
           Response.ResponseBuilder res = Response.ok()
               .lastModified(new Date(status.getLastModificationTimeMs()))


### PR DESCRIPTION
### What changes are proposed in this pull request?
if the request ends with "/" and the object is a file, return 404

### Why are the changes needed?
if the user want to get the metadata of a file, it should not end with "/". if the user wants to get the metadata of a dir, then it should end with "/".

### Does this PR introduce any user facing changes?
no
