### PR TITLE
Fix read exception when the range size is smaller than Block size

### DIFF
--- a/core/common/src/main/java/alluxio/retry/CountingRetry.java
+++ b/core/common/src/main/java/alluxio/retry/CountingRetry.java
@@ -54,4 +54,9 @@ public class CountingRetry implements RetryPolicy {
   public void reset() {
     mAttemptCount = 0;
   }
+
+  @Override
+  public RetryPolicy copy() {
+    return new CountingRetry(mMaxRetries);
+  }
 }

--- a/core/common/src/main/java/alluxio/retry/ExponentialBackoffRetry.java
+++ b/core/common/src/main/java/alluxio/retry/ExponentialBackoffRetry.java
@@ -56,4 +56,9 @@ public class ExponentialBackoffRetry extends SleepingRetry {
       return Math.min(Math.abs(sleepMs), mMaxSleepMs);
     }
   }
+
+  @Override
+  public ExponentialBackoffRetry copy() {
+    return new ExponentialBackoffRetry(mBaseSleepTimeMs, mMaxSleepMs, mMaxRetries);
+  }
 }

--- a/core/common/src/main/java/alluxio/retry/ExponentialTimeBoundedRetry.java
+++ b/core/common/src/main/java/alluxio/retry/ExponentialTimeBoundedRetry.java
@@ -133,4 +133,16 @@ public final class ExponentialTimeBoundedRetry extends TimeBoundedRetry {
           mTimeCtx, mMaxDuration, mInitialSleep, mMaxSleep, mSkipInitialSleep);
     }
   }
+
+  @Override
+  public RetryPolicy copy() {
+    Builder builder = ExponentialTimeBoundedRetry.builder()
+        .withMaxDuration(mMaxDuration)
+        .withInitialSleep(mNextSleep)
+        .withMaxSleep(mMaxSleep);
+    if (mSkipInitialSleep) {
+      builder.withSkipInitialSleep();
+    }
+    return builder.build();
+  }
 }

--- a/core/common/src/main/java/alluxio/retry/RetryPolicy.java
+++ b/core/common/src/main/java/alluxio/retry/RetryPolicy.java
@@ -36,4 +36,10 @@ public interface RetryPolicy {
    * @return whether another retry should be performed
    */
   boolean attempt();
+
+  /**
+   * Copy a new RetryPolicy based on the current RetryPolicy configuration.
+   * @return a copy of RetryPolicy
+   */
+  RetryPolicy copy();
 }

--- a/core/common/src/main/java/alluxio/retry/SleepingRetry.java
+++ b/core/common/src/main/java/alluxio/retry/SleepingRetry.java
@@ -21,7 +21,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public abstract class SleepingRetry implements RetryPolicy {
-  private final int mMaxRetries;
+  protected final int mMaxRetries;
   private int mAttemptCount = 0;
 
   protected SleepingRetry(int maxRetries) {

--- a/core/common/src/main/java/alluxio/retry/TimeBoundedRetry.java
+++ b/core/common/src/main/java/alluxio/retry/TimeBoundedRetry.java
@@ -25,7 +25,7 @@ import java.time.Instant;
 public abstract class TimeBoundedRetry implements RetryPolicy {
   private final Clock mClock;
   private final Sleeper mSleeper;
-  private final Duration mMaxDuration;
+  protected final Duration mMaxDuration;
   private final Instant mStartTime;
   private final Instant mEndTime;
 

--- a/core/common/src/main/java/alluxio/retry/TimeoutRetry.java
+++ b/core/common/src/main/java/alluxio/retry/TimeoutRetry.java
@@ -34,7 +34,7 @@ public class TimeoutRetry implements RetryPolicy {
    * @param retryTimeoutMs maximum period of time to retry for, in milliseconds
    * @param sleepMs time in milliseconds to sleep before retrying
    */
-  public TimeoutRetry(long retryTimeoutMs, int sleepMs) {
+  public TimeoutRetry(long retryTimeoutMs, long sleepMs) {
     Preconditions.checkArgument(retryTimeoutMs > 0, "Retry timeout must be a positive number");
     Preconditions.checkArgument(sleepMs >= 0, "sleepMs cannot be negative");
     mRetryTimeoutMs = retryTimeoutMs;
@@ -62,5 +62,10 @@ public class TimeoutRetry implements RetryPolicy {
       return true;
     }
     return false;
+  }
+
+  @Override
+  public RetryPolicy copy() {
+    return new TimeoutRetry(mRetryTimeoutMs, mSleepMs);
   }
 }

--- a/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoInputStream.java
+++ b/underfs/kodo/src/main/java/alluxio/underfs/kodo/KodoInputStream.java
@@ -74,13 +74,14 @@ public class KodoInputStream extends MultiRangeObjectInputStream {
       throws IOException {
     IOException lastException = null;
     String errorMessage = String.format("Failed to open key: %s", mKey);
-    while (mRetryPolicy.attempt()) {
+    RetryPolicy retryPolicy = mRetryPolicy.copy();
+    while (retryPolicy.attempt()) {
       try {
         return mKodoclent.getObject(mKey, startPos, endPos, mContentLength);
       } catch (NotFoundException e) {
         errorMessage = String
             .format("Failed to open key: %s attempts: %s error: %s", mKey,
-                mRetryPolicy.getAttemptCount(), e.getMessage());
+                retryPolicy.getAttemptCount(), e.getMessage());
         // Key does not exist
         lastException = e;
       }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftInputStream.java
@@ -84,7 +84,8 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
   protected InputStream createStream(long startPos, long endPos)
       throws IOException {
     NotFoundException lastException = null;
-    while (mRetryPolicy.attempt()) {
+    RetryPolicy retryPolicy = mRetryPolicy.copy();
+    while (retryPolicy.attempt()) {
       try {
         StoredObject storedObject = mAccount.getContainer(mContainerName).getObject(mObjectPath);
         DownloadInstructions downloadInstructions  = new DownloadInstructions();
@@ -92,7 +93,7 @@ public class SwiftInputStream extends MultiRangeObjectInputStream {
         return storedObject.downloadObjectAsInputStream(downloadInstructions);
       } catch (NotFoundException e) {
         LOG.warn("Attempt {} to get object {} from container {} failed with exception : {}",
-            mRetryPolicy.getAttemptCount(), mObjectPath, mContainerName, e.toString());
+            retryPolicy.getAttemptCount(), mObjectPath, mContainerName, e.toString());
         // Object does not exist
         lastException = e;
       }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add the copy() for RetryPolicy, so it can be used in some situations where the RetryPolicy needs to be reused.

### Why are the changes needed?
For OSSInputStream or other stream, it needs to call createStream() more than once in some cases, it should not use the same RetryPolicy instance in multiple different calls of createStream().

### Does this PR introduce any user facing changes?
None
