### PR TITLE
Support MultiPartUpload in Tos

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1718,7 +1718,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       booleanBuilder(Name.UNDERFS_TOS_STREAMING_UPLOAD_ENABLED)
           .setAlias("alluxio.underfs.tos.streaming.upload.enabled")
           .setDefaultValue(false)
-          .setDescription("(Experimental) If true, using streaming upload to write to S3.")
+          .setDescription("(Experimental) If true, using streaming upload to write to TOS.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
@@ -2061,7 +2061,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey UNDERFS_TOS_STREAMING_UPLOAD_THREADS =
       intBuilder(Name.UNDERFS_TOS_STREAMING_UPLOAD_THREADS)
           .setDefaultValue(20)
-          .setDescription("the number of threads to use for streaming upload data to OSS.")
+          .setDescription("the number of threads to use for streaming upload data to TOS.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1707,6 +1707,25 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_TOS_STREAMING_UPLOAD_ENABLED =
+      booleanBuilder(Name.UNDERFS_TOS_STREAMING_UPLOAD_ENABLED)
+          .setAlias("alluxio.underfs.tos.streaming.upload.enabled")
+          .setDefaultValue(false)
+          .setDescription("(Experimental) If true, using streaming upload to write to S3.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_TOS_STREAMING_UPLOAD_PARTITION_SIZE =
+      dataSizeBuilder(Name.UNDERFS_TOS_STREAMING_UPLOAD_PARTITION_SIZE)
+          .setAlias("alluxio.underfs.tos.streaming.upload.partition.size")
+          .setDefaultValue("64MB")
+          .setDescription("Maximum allowable size of a single buffer file when using "
+              + "TOS streaming upload. When the buffer file reaches the partition size, "
+              + "it will be uploaded and the upcoming data will write to other buffer files."
+              + "If the partition size is too small, TOS upload speed might be affected. ")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
 
   // UFS access control related properties
   //
@@ -2032,6 +2051,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
       .setScope(Scope.SERVER)
       .build();
+  public static final PropertyKey UNDERFS_TOS_STREAMING_UPLOAD_THREADS =
+      intBuilder(Name.UNDERFS_TOS_STREAMING_UPLOAD_THREADS)
+          .setDefaultValue(20)
+          .setDescription("the number of threads to use for streaming upload data to OSS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   //
   // Mount table related properties
   //
@@ -8045,6 +8071,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.obs.streaming.upload.partition.size";
     public static final String UNDERFS_OBS_STREAMING_UPLOAD_THREADS =
         "alluxio.underfs.obs.streaming.upload.threads";
+    public static final String UNDERFS_TOS_STREAMING_UPLOAD_ENABLED =
+        "alluxio.underfs.tos.streaming.upload.enabled";
+    public static final String UNDERFS_TOS_STREAMING_UPLOAD_PARTITION_SIZE =
+        "alluxio.underfs.tos.streaming.upload.partition.size";
+    public static final String UNDERFS_TOS_STREAMING_UPLOAD_THREADS =
+        "alluxio.underfs.tos.streaming.upload.threads";
 
     //
     // UFS access control related properties

--- a/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
@@ -330,7 +330,7 @@ public abstract class ObjectLowLevelOutputStream extends OutputStream
     };
     ListenableFuture<?> futureTag = mExecutor.submit(callable);
     mFutures.add(futureTag);
-    LOG.debug(
+    LOG.info(
         "Submit upload part request. key={}, partNum={}, file={}, fileSize={}, lastPart={}.",
         mKey, partNumber, file.getPath(), file.length(), lastPart);
   }

--- a/underfs/tos/src/main/java/alluxio/underfs/tos/TOSLowLevelOutputStream.java
+++ b/underfs/tos/src/main/java/alluxio/underfs/tos/TOSLowLevelOutputStream.java
@@ -1,0 +1,203 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.tos;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.underfs.ObjectLowLevelOutputStream;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.volcengine.tos.TOSV2;
+import com.volcengine.tos.TosClientException;
+import com.volcengine.tos.comm.io.TosRepeatableBoundedFileInputStream;
+import com.volcengine.tos.model.object.AbortMultipartUploadInput;
+import com.volcengine.tos.model.object.CompleteMultipartUploadV2Input;
+import com.volcengine.tos.model.object.CompleteMultipartUploadV2Output;
+import com.volcengine.tos.model.object.CreateMultipartUploadInput;
+import com.volcengine.tos.model.object.CreateMultipartUploadOutput;
+import com.volcengine.tos.model.object.PutObjectInput;
+import com.volcengine.tos.model.object.UploadPartV2Input;
+import com.volcengine.tos.model.object.UploadPartV2Output;
+import com.volcengine.tos.model.object.UploadedPartV2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Object storage low output stream for TOS.
+ */
+@NotThreadSafe
+public class TOSLowLevelOutputStream extends ObjectLowLevelOutputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(TOSLowLevelOutputStream.class);
+
+  /**
+   * The TOS client to interact with TOS.
+   */
+  protected TOSV2 mClient;
+  /**
+   * Tags for the uploaded part, provided by TOS after uploading.
+   */
+  private final List<UploadedPartV2> mTags = Collections.synchronizedList(new ArrayList<>());
+
+  /**
+   * The upload id of this multipart upload.
+   */
+  protected volatile String mUploadId;
+
+  private String mContentHash;
+
+  /**
+   * Constructs a new stream for writing a file.
+   *
+   * @param bucketName the name of the bucket
+   * @param key        the key of the file
+   * @param tosClient  the TOS client to upload the file with
+   * @param executor   a thread pool executor
+   * @param ufsConf    the object store under file system configuration
+   */
+  public TOSLowLevelOutputStream(String bucketName, String key, TOSV2 tosClient,
+                                 ListeningExecutorService executor,
+                                 AlluxioConfiguration ufsConf) {
+    super(bucketName, key, executor,
+        ufsConf.getBytes(PropertyKey.UNDERFS_TOS_STREAMING_UPLOAD_PARTITION_SIZE), ufsConf);
+    mClient = Preconditions.checkNotNull(tosClient);
+  }
+
+  @Override
+  protected void abortMultiPartUploadInternal() throws IOException {
+    try {
+      AbortMultipartUploadInput input = new AbortMultipartUploadInput().setBucket(mBucketName)
+          .setKey(mKey).setUploadID(mUploadId);
+      getClient().abortMultipartUpload(input);
+    } catch (TosClientException e) {
+      LOG.debug("failed to abort multi part upload. upload id: {}", mUploadId, e);
+      throw new IOException(String.format(
+          "failed to upload part. key: %s uploadId: %s",
+          mKey, mUploadId), e);
+    }
+  }
+
+  @Override
+  protected void uploadPartInternal(
+      File file,
+      int partNumber,
+      boolean isLastPart,
+      @Nullable String md5)
+      throws IOException {
+    long fileSize = file.length();
+    long offset = partNumber * (mPartitionSize - 1);
+    long partSize = mPartitionSize;
+    try (FileInputStream content = new FileInputStream(file)) {
+      content.skip(offset);
+      InputStream wrappedContent = new TosRepeatableBoundedFileInputStream(content, mPartitionSize);
+      if (fileSize - offset < mPartitionSize) {
+        partSize = fileSize - offset;
+      }
+      final UploadPartV2Input input = new UploadPartV2Input()
+          .setBucket(mBucketName)
+          .setKey(mKey)
+          .setUploadID(mUploadId)
+          .setPartNumber(partNumber)
+          .setContentLength(partSize)
+          .setContent(wrappedContent);
+      UploadPartV2Output output = getClient().uploadPart(input);
+      mTags.add(new UploadedPartV2().setPartNumber(partNumber).setEtag(output.getEtag()));
+    } catch (IOException e) {
+      LOG.debug("failed to upload part.", e);
+      throw new IOException(String.format(
+          "failed to upload part. key: %s part number: %s uploadId: %s",
+          mKey, partNumber, mUploadId), e);
+    }
+  }
+
+  @Override
+  protected void initMultiPartUploadInternal() throws IOException {
+    try {
+      CreateMultipartUploadInput create =
+          new CreateMultipartUploadInput().setBucket(mBucketName).setKey(mKey);
+      CreateMultipartUploadOutput output = getClient().createMultipartUpload(create);
+      mUploadId = output.getUploadID();
+    } catch (TosClientException e) {
+      LOG.debug("failed to init multi part upload", e);
+      throw new IOException("failed to init multi part upload", e);
+    }
+  }
+
+  @Override
+  protected void completeMultiPartUploadInternal() throws IOException {
+    try {
+      LOG.debug("complete multi part {}", mUploadId);
+      CompleteMultipartUploadV2Input complete = new CompleteMultipartUploadV2Input()
+          .setBucket(mBucketName)
+          .setKey(mKey)
+          .setUploadID(mUploadId);
+      complete.setUploadedParts(mTags);
+      CompleteMultipartUploadV2Output completedOutput =
+          getClient().completeMultipartUpload(complete);
+      mContentHash = completedOutput.getEtag();
+    } catch (TosClientException e) {
+      LOG.debug("failed to complete multi part upload", e);
+      throw new IOException(
+          String.format("failed to complete multi part upload, key: %s, upload id: %s",
+              mKey, mUploadId) + e);
+    }
+  }
+
+  @Override
+  protected void createEmptyObject(String key) throws IOException {
+    try {
+      PutObjectInput putObjectInput = new PutObjectInput()
+          .setBucket(mBucketName)
+          .setKey(key)
+          .setContent(new ByteArrayInputStream(new byte[0]))
+          .setContentLength(0);
+      mContentHash = getClient().putObject(putObjectInput).getEtag();
+    } catch (TosClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected void putObject(String key, File file, @Nullable String md5) throws IOException {
+    try {
+      PutObjectInput putObjectInput = new PutObjectInput()
+          .setBucket(mBucketName)
+          .setKey(key)
+          .setContent(new FileInputStream(file))
+          .setContentLength(0);
+      mContentHash = getClient().putObject(putObjectInput).getEtag();
+    } catch (TosClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public Optional<String> getContentHash() {
+    return Optional.ofNullable(mContentHash);
+  }
+
+  protected TOSV2 getClient() {
+    return mClient;
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

I have completed the task of implementing multipart upload in TOS (Tachyon Object Storage). Users can now choose whether to enable multipart upload through the configuration file.

### Why are the changes needed?

1、Users need to choose multipart upload for large files exceeding 5GB.
2、Users can customize whether to use multipart upload for smaller files and also define the size of each part for multipart upload.

### Does this PR introduce any user facing changes?

Several new property keys have been added, which require users to specify the TOS configuration.
