### PR TITLE
Allow running on early access and beta JDKs

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -76,6 +76,9 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class CommonUtils {
   private static final Logger LOG = LoggerFactory.getLogger(CommonUtils.class);
 
+  private static final String EARLY_ACCESS_SUFFIX = "-ea";
+  private static final String BETA_SUFFIX = "-beta";
+
   private static final String ALPHANUM =
       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
   private static final Random RANDOM = new Random();
@@ -882,6 +885,12 @@ public final class CommonUtils {
    * see https://www.oracle.com/java/technologies/javase/versioning-naming.html for reference
    */
   public static int parseMajorVersion(String version) {
+    if (version.endsWith(EARLY_ACCESS_SUFFIX)) {
+      version = version.substring(0, version.length() - EARLY_ACCESS_SUFFIX.length());
+    }
+    if (version.endsWith(BETA_SUFFIX)) {
+      version = version.substring(0, version.length() - BETA_SUFFIX.length());
+    }
     if (version.startsWith("1.")) {
       version = version.substring(2, 3);
     } else {

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -692,6 +692,10 @@ public class CommonUtilsTest {
     assertEquals(8, CommonUtils.parseMajorVersion("1.8.0"));
     assertEquals(11, CommonUtils.parseMajorVersion("11.0.1"));
     assertEquals(9, CommonUtils.parseMajorVersion("9.0.1"));
+    assertEquals(24, CommonUtils.parseMajorVersion("24-ea"));
+    assertEquals(23, CommonUtils.parseMajorVersion("23-beta"));
+    assertEquals(21, CommonUtils.parseMajorVersion("21.0.99-ea"));
+    assertEquals(22, CommonUtils.parseMajorVersion("22.0.2-beta"));
   }
 
   private void createFileOrDir(File dir, int index, Random rand, Set<File> files)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Right now Alluxio 2.x is not starting correctly on early access/beta JDKs. It's required to do a proper forward testing of new JDK releases.

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
