### PR TITLE
Downgrade AWS SDK to 2.15.79

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <apache.curator.version>4.2.0</apache.curator.version>
     <aws.amazonaws.version>1.11.815</aws.amazonaws.version>
     <!-- Pin this version to make the library compatible with netty 4.1.52.Final version -->
-    <awssdk.version>2.16.104</awssdk.version>
+    <awssdk.version>2.15.79</awssdk.version>
     <build.path>build</build.path>
     <catalyst.version>1.2.1</catalyst.version>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Downgrade the version of AWS SDK to 2.15.79

### Why are the changes needed?

The current AWS SDK version 2.16.104 depends on Netty 4.1.63-Final, and Alluxio depends on Netty 4.1.52-Final. There is a conflict between the two versions that causes Netty's native epoll library to fail to be loaded. Consequently, the data server on a worker cannot be started on a domain socket which requires epoll, and thus short circuit read cannot be enabled in a Kubernetes deployment.

### Does this PR introduce any user facing changes?

No.
