### PR TITLE
Add back shaded netty within grpc

### DIFF
--- a/dora/tests/testcontainers/src/test/java/alluxio/membership/MembershipManagerTest.java
+++ b/dora/tests/testcontainers/src/test/java/alluxio/membership/MembershipManagerTest.java
@@ -82,7 +82,7 @@ public class MembershipManagerTest {
 
   @ClassRule
   public static final GenericContainer<?> ETCD_CONTAINER =
-      new GenericContainer<>("quay.io/coreos/etcd:latest")
+      new GenericContainer<>("quay.io/coreos/etcd:v3.5.13")
           .withCommand("etcd",
               "--listen-client-urls", "http://0.0.0.0:" + ETCD_PORT,
               "--advertise-client-urls", "http://0.0.0.0:" + ETCD_PORT)

--- a/pom.xml
+++ b/pom.xml
@@ -416,12 +416,6 @@
         <groupId>io.grpc</groupId>
         <artifactId>grpc-netty</artifactId>
         <version>${grpc.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.grpc</groupId>


### PR DESCRIPTION
### What changes are proposed in this pull request?
add back netty dependency within grpc


### Why are the changes needed?
previously we exclude netty dependency since we already have netty-all outside https://github.com/Alluxio/alluxio/pull/9942

But due to https://github.com/grpc/grpc-java/issues/11284, we sometimes have incompatibility between grpc and netty, and it's better to use shaded netty within grpc so we can be sure that they are compatible.

### Does this PR introduce any user facing changes?

na
