### PR TITLE
Fix logging statement

### DIFF
--- a/dora/core/server/master/src/main/java/alluxio/master/job/CopyJob.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/job/CopyJob.java
@@ -216,7 +216,7 @@ public class CopyJob extends AbstractJob<CopyJob.CopyTask> {
     setJobState(JobState.FAILED, true);
     mFailedReason = Optional.of(reason);
     JOB_COPY_FAIL.inc();
-    LOG.info("Copy Job {} fails with status: {}", mJobId, this);
+    LOG.info("Copy Job {} failed with status: {}", mJobId, this);
   }
 
   @Override


### PR DESCRIPTION
## Description

This pull request addresses a minor improvement in the logging statement of the `failJob` method within the job handling logic. Specifically, it changes the word "fails" to "failed" to improve grammatical consistency.

### Changes Made

- Updated the logging statement from "Copy Job {} fails with status: {}" to "Copy Job {} failed with status: {}".

### Rationale

The previous logging statement used "fails," which is present tense, while the method name `failJob` and the context imply a past action. The change to "failed" aligns the tense with the past action, making the log message clearer and more grammatically correct.

### Code Diff

```diff
@Override
public void failJob(AlluxioRuntimeException reason) {
    setJobState(JobState.FAILED, true);
    mFailedReason = Optional.of(reason);
    JOB_COPY_FAIL.inc();
-    LOG.info("Copy Job {} fails with status: {}", mJobId, this);
+    LOG.info("Copy Job {} failed with status: {}", mJobId, this);
}