### PR TITLE
Replace hardcoded TTL behavior with configurable options when TTL checker resets state

### DIFF
--- a/dora/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
+++ b/dora/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
@@ -13,6 +13,8 @@ package alluxio.master.file;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.FreePOptions;
@@ -116,7 +118,8 @@ final class InodeTtlChecker implements HeartbeatExecutor {
                   mInodeTree.updateInode(journalContext, UpdateInodeEntry.newBuilder()
                       .setId(inode.getId())
                       .setTtl(Constants.NO_TTL)
-                      .setTtlAction(ProtobufUtils.toProtobuf(TtlAction.DELETE))
+                      .setTtlAction(ProtobufUtils.toProtobuf(Configuration
+                          .getEnum(PropertyKey.USER_FILE_CREATE_TTL_ACTION, TtlAction.class)))
                       .build());
                 }
                 break;


### PR DESCRIPTION


### What changes are proposed in this pull request?

Replace hardcoded TTL behavior with configurable options when TTL checker resets state.

### Why are the changes needed?

It would be confusing if the TTL checker directly resets state using DELETE

### Does this PR introduce any user facing changes?

No.
