### PR TITLE
Add null check in DelegatingBlockReader#toString() and unit tests

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
@@ -76,6 +76,9 @@ public class DelegatingBlockReader extends BlockReader {
 
   @Override
   public String toString() {
+    if (mBlockReader == null) {
+      return "DelegatingBlockReader not fully initialized.";
+    }
     return mBlockReader.toString();
   }
 

--- a/core/common/src/test/java/alluxio/worker/block/io/DelegatingBlockReaderTest.java
+++ b/core/common/src/test/java/alluxio/worker/block/io/DelegatingBlockReaderTest.java
@@ -1,0 +1,67 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.io;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Tests for the {@link DelegatingBlockReader} class.
+ */
+public class DelegatingBlockReaderTest {
+
+    private DelegatingBlockReader mReader;
+
+    /** Rule to create a new temporary folder during each test. */
+    @Rule
+    public TemporaryFolder mFolder = new TemporaryFolder();
+
+    /**
+     * Test the {@link DelegatingBlockReader#toString()} method when the underlying BlockReader is null.
+     */
+    @Test
+    public void toStringWithNullBlockReader() throws Exception {
+        mReader = new DelegatingBlockReader(null, new Closeable() {
+            @Override
+            public void close() throws IOException {
+                // Empty close implementation for testing
+            }
+        });
+
+        String result = mReader.toString();
+        Assert.assertEquals("DelegatingBlockReader not fully initialized.", result);
+    }
+
+    /**
+     * Test the {@link DelegatingBlockReader#toString()} method when the underlying BlockReader is valid.
+     */
+    @Test
+    public void toStringWithValidBlockReader() throws Exception {
+        byte[] data = "test data".getBytes();
+        MockBlockReader mockBlockReader = new MockBlockReader(data);
+
+        mReader = new DelegatingBlockReader(mockBlockReader, new Closeable() {
+            @Override
+            public void close() throws IOException {
+                // Empty close implementation for testing
+            }
+        });
+
+        String result = mReader.toString();
+        Assert.assertEquals(mockBlockReader.toString(), result);
+    }
+}


### PR DESCRIPTION
### What changes are proposed in this PR?

This PR adds a null check in the `DelegatingBlockReader#toString()` method to handle cases where the underlying `BlockReader` is null. This prevents potential NullPointerException during the `toString()` call.

Additionally, unit tests were added to verify this new behavior.

### Why are the changes needed?

The change ensures that the `DelegatingBlockReader` can gracefully handle cases where the underlying `BlockReader` is null, which improves robustness.

### Does this PR introduce any user-facing changes?

No.

### How was this patch tested?

Unit tests have been added and verified with the current testing framework.