### PR TITLE
Fix worker remote alluxio read metric in FileReadHandler

### DIFF
--- a/dora/core/server/worker/src/main/java/alluxio/worker/grpc/FileReadHandler.java
+++ b/dora/core/server/worker/src/main/java/alluxio/worker/grpc/FileReadHandler.java
@@ -349,6 +349,7 @@ public class FileReadHandler implements StreamObserver<ReadRequest> {
             DataBuffer finalChunk = chunk;
             mSerializingExecutor.execute(() -> {
               try {
+                long length = finalChunk.getLength();
                 ReadResponse response = ReadResponse.newBuilder().setChunk(Chunk.newBuilder()
                     .setData(UnsafeByteOperations.unsafeWrap(finalChunk.getReadOnlyByteBuffer()))
                 ).build();
@@ -358,7 +359,7 @@ public class FileReadHandler implements StreamObserver<ReadRequest> {
                 } else {
                   mResponse.onNext(response);
                 }
-                incrementMetrics(finalChunk.getLength());
+                incrementMetrics(length);
               } catch (Exception e) {
                 LogUtils.warnWithException(LOG,
                     "Exception occurred while sending data for read request {}.",


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix worker remote alluxio read metric in FileReadHandler

### Why are the changes needed?

In worker, after reading chunk from alluxio or ufs, the chunk will be send to client and then increase remote alluxio read metric. However, the type of chunk is NettyDataBuffer. Its readIndex may be increased when sending chunk so that the chunk getLength method which actually get readableBytes is not equal to the entire chunk length. The metric is not correct.

Therefore, In this PR, to make metric correct, getLength before sending and increase metric by using length from getLength.

### Does this PR introduce any user facing changes?

No
