### PR TITLE
Supporting building with JDK21

### DIFF
--- a/core/transport/pom.xml
+++ b/core/transport/pom.xml
@@ -93,12 +93,13 @@
     <profile>
       <id>java11</id>
       <activation>
-        <jdk>11</jdk>
+        <jdk>[11,]</jdk>
       </activation>
       <dependencies>
         <dependency>
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
+          <version>1.3.2</version>
         </dependency>
       </dependencies>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1449,20 +1449,18 @@
     <profile>
       <id>java11</id>
       <activation>
-        <jdk>11</jdk>
+        <jdk>[11,]</jdk>
       </activation>
       <properties>
         <java.version>1.8</java.version>
       </properties>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+          <version>1.3.2</version>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/table/server/underdb/glue/pom.xml
+++ b/table/server/underdb/glue/pom.xml
@@ -89,7 +89,7 @@
     <profile>
       <id>java11</id>
       <activation>
-        <jdk>11</jdk>
+        <jdk>[11,]</jdk>
       </activation>
       <dependencies>
         <dependency>

--- a/table/server/underdb/hive/pom.xml
+++ b/table/server/underdb/hive/pom.xml
@@ -159,7 +159,7 @@
     <profile>
       <id>java11</id>
       <activation>
-        <jdk>11</jdk>
+        <jdk>[11,]</jdk>
       </activation>
       <dependencies>
         <dependency>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Currently building with jdk21 is not supported, this PR is to support building Alluxio with JDK11+, including JDK21.

### Why are the changes needed?

The profile of "java11" only supports JDK11, we are changing it to support newer JDKs since JDK11.

### Does this PR introduce any user facing changes?

Building locally works.
