### PR TITLE
Make S3 proxy reject unverified signatures by default

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -7415,15 +7415,20 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey S3_REST_AUTHENTICATION_ENABLED =
       booleanBuilder(Name.S3_REST_AUTHENTICATION_ENABLED)
-          .setDefaultValue(false)
-          .setDescription("Whether to enable check s3 rest request header.")
+          .setDefaultValue(true)
+          .setDescription("Whether to verify the AWS signature of incoming S3 REST requests. "
+              + "When disabled, the proxy trusts the user name declared in the Authorization "
+              + "header without checking the signature, allowing any client to impersonate any "
+              + "user. Keep this enabled unless the proxy runs on a trusted, isolated network.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey S3_REST_AUTHENTICATOR_CLASSNAME =
        classBuilder(Name.S3_REST_AUTHENTICATOR_CLASSNAME)
-           .setDescription("The class's name is instantiated as an S3 authenticator.")
-           .setDefaultValue("alluxio.proxy.s3.auth.PassAllAuthenticator")
+           .setDescription("The class's name is instantiated as an S3 authenticator. "
+               + "The default fail-closed authenticator rejects every request; configure a "
+               + "signature-verifying implementation to serve authenticated S3 traffic.")
+           .setDefaultValue("alluxio.proxy.s3.auth.DenyAllAuthenticator")
            .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
            .setScope(Scope.ALL)
            .build();

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/auth/DenyAllAuthenticator.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/auth/DenyAllAuthenticator.java
@@ -1,0 +1,27 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3.auth;
+
+import alluxio.proxy.s3.S3Exception;
+
+/**
+ * Fail-closed implementation of {@link Authenticator}. The method {@link #isAuthenticated} always
+ * returns false, rejecting every request. This is the secure default so that the S3 proxy never
+ * trusts an unverified client identity until a real signature-verifying {@link Authenticator} is
+ * configured.
+ */
+public class DenyAllAuthenticator implements Authenticator {
+  @Override
+  public boolean isAuthenticated(AwsAuthInfo authInfo) throws S3Exception {
+    return false;
+  }
+}

--- a/core/server/proxy/src/test/java/alluxio/proxy/s3/auth/DenyAllAuthenticatorTest.java
+++ b/core/server/proxy/src/test/java/alluxio/proxy/s3/auth/DenyAllAuthenticatorTest.java
@@ -1,0 +1,46 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3.auth;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+
+import org.junit.Test;
+
+/**
+ * Regression test for the S3 proxy authentication-bypass: a forged AWS signature must not
+ * authenticate under the shipped default configuration.
+ */
+public class DenyAllAuthenticatorTest {
+  /** A completely fabricated signature, as used by the reported exploit. */
+  private static final AwsAuthInfo FORGED_AUTH_INFO =
+      new AwsAuthInfo("alluxio", "any-string-to-sign", "FAKESIGNATURE0000000000000000000000000000");
+
+  @Test
+  public void denyAllRejectsForgedSignature() throws Exception {
+    assertFalse(new DenyAllAuthenticator().isAuthenticated(FORGED_AUTH_INFO));
+  }
+
+  @Test
+  public void defaultConfigRejectsForgedSignature() throws Exception {
+    AlluxioConfiguration conf = Configuration.global();
+    // Signature verification must be on by default so the authenticator is consulted.
+    assertTrue(conf.getBoolean(PropertyKey.S3_REST_AUTHENTICATION_ENABLED));
+    // The default authenticator must be fail-closed, rejecting the forged signature.
+    Authenticator authenticator = Authenticator.Factory.create(conf);
+    assertFalse(authenticator.isAuthenticated(FORGED_AUTH_INFO));
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes the S3 REST proxy authentication-bypass reported in #18755.

`S3RestUtils.getUser()` resolves the request identity from the `Credential`
field of the AWS `Authorization` header. With the shipped defaults the signature
is never cryptographically verified, so any client that can reach the proxy port
(default `39999`) can impersonate any user — including the `alluxio` service
account — and enumerate, read, overwrite, or delete all data. Two defaults cause
this:

- `alluxio.s3.rest.authentication.enabled=false` routes requests to
  `getUserFromAuthorization()`, which only parses the user name and ignores the
  signature entirely.
- Even with authentication enabled, the default
  `alluxio.s3.rest.authenticator.classname` is `PassAllAuthenticator`, whose
  `isAuthenticated()` returns `true` for every request.

This PR makes the proxy secure by default:

- Default `alluxio.s3.rest.authentication.enabled` to `true` so requests go
  through the signature-verification path.
- Add a fail-closed `DenyAllAuthenticator` (mirror of `PassAllAuthenticator`)
  and make it the default `authenticator.classname`. It rejects every request
  until a real signature-verifying authenticator is configured.

The verification primitive already exists in the tree
(`AuthorizationV4Validator.validateRequest`); this change only fixes the unsafe
defaults so an unconfigured proxy denies instead of trusts.

### Why are the changes needed?

Fail-open defaults turn "the operator forgot to configure authentication" into
full unauthenticated data access. Fail-closed is the correct posture for a data
gateway.

### Does this PR introduce any user facing changes?

Yes — behavioral/config change. An S3 proxy that relied on the previous
open-by-default behavior will start rejecting requests until an authenticator is
configured. Operators who intentionally run an unauthenticated proxy on a
trusted, isolated network can restore the old behavior by setting
`alluxio.s3.rest.authentication.enabled=false`, or by pointing
`alluxio.s3.rest.authenticator.classname` back at
`alluxio.proxy.s3.auth.PassAllAuthenticator`.

Follow-up (not in this PR, to keep the change minimal): the
`getUserFromAuthorization()` trust path could be removed so signature
verification is unconditional and the footgun disappears from the code entirely.